### PR TITLE
Implement pwm input for TIM2, TIM3, TIM4

### DIFF
--- a/examples/pwm_input.rs
+++ b/examples/pwm_input.rs
@@ -1,0 +1,60 @@
+//! Testing PWM input
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal as hal;
+
+use hal::prelude::*;
+use hal::pwm_input::*;
+use hal::stm32;
+use rt::{entry, exception, ExceptionFrame};
+
+#[entry]
+fn main() -> ! {
+    let p = stm32::Peripherals::take().unwrap();
+
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut afio = p.AFIO.constrain(&mut rcc.apb2);
+    let mut dbg = p.DBG;
+
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+
+    let pb4 = gpiob.pb4.into_alternate_open_drain(&mut gpiob.crl);
+    let pb5 = gpiob.pb5.into_alternate_open_drain(&mut gpiob.crl);
+
+    let pwm_input = p.TIM3.pwm_input(
+        (pb4, pb5),
+        &mut rcc.apb1,
+        &mut afio.mapr,
+        &mut dbg,
+        &clocks,
+        Configuration::Frequency(10.khz()),
+    );
+
+    loop {
+        let _freq = pwm_input
+            .read_frequency(ReadMode::Instant, &clocks)
+            .unwrap();
+        let _duty_cycle = pwm_input.read_duty(ReadMode::Instant).unwrap();
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}

--- a/examples/pwm_input.rs
+++ b/examples/pwm_input.rs
@@ -7,7 +7,7 @@
 
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_abort;
 extern crate stm32f1xx_hal as hal;
 
 use hal::prelude::*;
@@ -47,14 +47,4 @@ fn main() -> ! {
             .unwrap();
         let _duty_cycle = pwm_input.read_duty(ReadMode::Instant).unwrap();
     }
-}
-
-#[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
-}
-
-#[exception]
-fn DefaultHandler(irqn: i16) {
-    panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub use crate::pac as device;
 pub use crate::pac as stm32;
 
 pub mod afio;
+pub mod backup_domain;
 pub mod bb;
 pub mod delay;
 pub mod dma;
@@ -58,11 +59,11 @@ pub mod i2c;
 pub mod prelude;
 #[cfg(not(feature = "stm32f100"))]
 pub mod pwm;
+pub mod pwm_input;
 pub mod qei;
 pub mod rcc;
+pub mod rtc;
 pub mod serial;
 pub mod spi;
 pub mod time;
 pub mod timer;
-pub mod rtc;
-pub mod backup_domain;

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -1,0 +1,368 @@
+//! This modules allows the Timer peripherals to be configured as pwm input.
+//! In this mode, the timer can sample a squared signal to find it's frequency and duty cycle.
+
+use core::marker::PhantomData;
+use core::mem;
+
+use crate::stm32::{DBG, TIM1, TIM2, TIM3, TIM4};
+
+use crate::afio::MAPR;
+use crate::gpio::gpioa::{PA0, PA1, PA15, PA6, PA7, PA8, PA9};
+use crate::gpio::gpiob::{PB3, PB4, PB5, PB6, PB7};
+use crate::gpio::{Alternate, OpenDrain};
+use crate::rcc::{Clocks, APB1};
+use crate::time::Hertz;
+
+pub trait Pins<TIM> {
+    const REMAP: u8;
+}
+
+impl Pins<TIM4> for (PB6<Alternate<OpenDrain>>, PB7<Alternate<OpenDrain>>) {
+    const REMAP: u8 = 0b0;
+}
+
+impl Pins<TIM3> for (PA6<Alternate<OpenDrain>>, PA7<Alternate<OpenDrain>>) {
+    const REMAP: u8 = 0b00;
+}
+
+impl Pins<TIM3> for (PB4<Alternate<OpenDrain>>, PB5<Alternate<OpenDrain>>) {
+    const REMAP: u8 = 0b10;
+}
+
+impl Pins<TIM2> for (PA0<Alternate<OpenDrain>>, PA1<Alternate<OpenDrain>>) {
+    const REMAP: u8 = 0b00;
+}
+
+impl Pins<TIM2> for (PA15<Alternate<OpenDrain>>, PB3<Alternate<OpenDrain>>) {
+    const REMAP: u8 = 0b11;
+}
+
+impl Pins<TIM1> for (PA8<Alternate<OpenDrain>>, PA9<Alternate<OpenDrain>>) {
+    const REMAP: u8 = 0b00;
+}
+
+/// PWM Input
+pub struct PwmInput<TIM, PINS> {
+    _timer: PhantomData<TIM>,
+    _pins: PhantomData<PINS>,
+}
+
+/// How the data is read from the timer
+pub enum ReadMode {
+    /// Return the latest captured data
+    Instant,
+    /// Wait for one period of the signal before computing the frequency and the duty cycle
+    /// The microcontroller will be halted for at most two period of the input signal.
+    WaitForNextCapture,
+}
+
+/// The error returned when reading a frequency from a timer
+#[derive(Debug)]
+pub enum Error {
+    /// The signal frequency is too low to be sampled by the current timer configuration
+    FrequencyTooLow,
+}
+
+/// The configuration for the timer : what frequency the timer will try to sample
+pub enum Configuration<T>
+where
+    T: Into<Hertz>,
+{
+    /// In this mode an algorithm calculates the optimal value for the autoreload register and the
+    /// prescaler register in order to be able to sample a wide range of frequency, at the expense
+    /// of resolution.
+    ///
+    /// The minimum frequency that can be sampled is 20% the provided frequency.
+    Frequency(T),
+
+    /// In this mode an algorithm calculates the optimal value for the autoreload register and the
+    /// prescaler register in order to sample the duty cycle with a high resolution.
+    /// This will limit the frequency range where the timer can operate.
+    ///
+    /// The minimum frequency that can be sampled is 90% the provided frequency
+    DutyCycle(T),
+
+    /// In this mode an algorithm calculates the optimal value for the autoreload register and the
+    /// prescaler register in order to be able to sample signal with a frequency higher than the
+    /// provided value : there is no margin.
+    RawFrequency(T),
+
+    /// In this mode, the user gives the desired arr and presc value that are then directly
+    /// programmed in the register.
+    RawValues { arr: u16, presc: u16 },
+}
+
+pub trait PwmInputExt: Sized {
+    fn pwm_input<PINS, T>(
+        self,
+        PINS,
+        apb: &mut APB1,
+        mapr: &mut MAPR,
+        dbg: &mut DBG,
+        clocks: &Clocks,
+        mode: Configuration<T>,
+    ) -> PwmInput<Self, PINS>
+    where
+        PINS: Pins<Self>,
+        T: Into<Hertz>;
+}
+
+impl PwmInputExt for TIM2 {
+    fn pwm_input<PINS, T>(
+        self,
+        pins: PINS,
+        apb: &mut APB1,
+        mapr: &mut MAPR,
+        dbg: &mut DBG,
+        clocks: &Clocks,
+        mode: Configuration<T>,
+    ) -> PwmInput<Self, PINS>
+    where
+        PINS: Pins<Self>,
+        T: Into<Hertz>,
+    {
+        mapr.mapr()
+            .modify(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
+        tim2(self, pins, clocks, apb, mode, dbg)
+    }
+}
+
+impl PwmInputExt for TIM3 {
+    fn pwm_input<PINS, T>(
+        self,
+        pins: PINS,
+        apb: &mut APB1,
+        mapr: &mut MAPR,
+        dbg: &mut DBG,
+        clocks: &Clocks,
+        mode: Configuration<T>,
+    ) -> PwmInput<Self, PINS>
+    where
+        PINS: Pins<Self>,
+        T: Into<Hertz>,
+    {
+        mapr.mapr()
+            .modify(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
+        tim3(self, pins, clocks, apb, mode, dbg)
+    }
+}
+
+impl PwmInputExt for TIM4 {
+    fn pwm_input<PINS, T>(
+        self,
+        pins: PINS,
+        apb: &mut APB1,
+        mapr: &mut MAPR,
+        dbg: &mut DBG,
+        clocks: &Clocks,
+        mode: Configuration<T>,
+    ) -> PwmInput<Self, PINS>
+    where
+        PINS: Pins<Self>,
+        T: Into<Hertz>,
+    {
+        mapr.mapr()
+            .modify(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
+        tim4(self, pins, clocks, apb, mode, dbg)
+    }
+}
+
+fn get_score(x: u32, y: u32) -> u32 {
+    if x > y {
+        x - y
+    } else {
+        y - x
+    }
+}
+/// F_timer = PCLK / [ (ARR+1) * (PRESC+1) ]
+/// We want maximum resolution, so ARR = u16::MAX;
+/// <=> PRESC = PCLK / [ u16::MAX * F_timer ] -1
+fn compute_arr_presc(freq: u32, clock: u32) -> (u16, u16) {
+    let mut arr: u32 = (core::u16::MAX - 1) as u32;
+    let mut presc: u32;
+
+    let mut curr_best_presc: u32 = 0;
+    let mut curr_best_arr: u32 = 0;
+    let mut curr_best_distance: u32 = core::u32::MAX;
+
+    for _ in 0..65530 {
+        presc = clock / ((arr + 1) * freq);
+        let computed_freq = clock / ((arr + 1) * (presc + 1));
+        if presc > core::u16::MAX as u32 {
+            break;
+        } else {
+            let score = get_score(computed_freq, freq);
+            if score < curr_best_distance {
+                curr_best_distance = score;
+                curr_best_arr = arr;
+                curr_best_presc = presc;
+            }
+        }
+        arr -= 1;
+    }
+    assert!(curr_best_arr <= core::u16::MAX as u32);
+    assert!(curr_best_presc < core::u16::MAX as u32);
+    (curr_best_arr as u16, curr_best_presc as u16)
+}
+macro_rules! hal {
+   ($($TIMX:ident: ($timX:ident, $timXen:ident, $timXrst:ident, $pclk:ident, $dbg_timX_stop:ident ),)+) => {
+      $(
+         fn $timX<PINS,T>(
+            tim: $TIMX,
+            _pins: PINS,
+            clocks: &Clocks,
+            apb: &mut APB1,
+            mode : Configuration<T>,
+            dbg : &mut DBG
+            ) -> PwmInput<$TIMX,PINS>
+         where
+         PINS: Pins<$TIMX>,
+         T : Into<Hertz>
+         {
+            use pwm_input::Configuration::*;
+            apb.enr().modify(|_, w| w.$timXen().set_bit());
+            apb.rstr().modify(|_, w| w.$timXrst().set_bit());
+            apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
+
+            // Do not stop the timer in debug mode, because it cause troubles when sampling the
+            // signal.
+            // Removing this line will break your code if you have breakpoints
+            dbg.cr.write(|w| w.$dbg_timX_stop().clear_bit());
+
+
+            // Disable capture on both channels during setting
+            // (for Channel X bit is CCXE)
+            tim.ccer.modify(|_,w| w.cc1e().clear_bit().cc2e().clear_bit()
+                            .cc1p().clear_bit().cc2p().set_bit());
+
+
+            // Define the direction of the channel (input/output)
+            // and the used input
+            // 01: CC1 channel is configured as input, IC1 is mapped on TI1.
+            // 10: CC1 channel is configured as input, IC1 is mapped on TI2.
+            tim.ccmr1_output.modify( |_,w| unsafe {w.cc1s().bits(0b01)});
+
+            // 01: CC2 channel is configured as input, IC2 is mapped on TI2
+            // 10: CC2 channel is configured as input, IC2 is mapped on TI1
+            tim.ccmr1_output.modify( |_,w| unsafe {w.cc2s().bits(0b10)});
+
+            tim.dier.write(|w| w.cc1ie().set_bit());
+
+            // Configure slave mode control register
+            // Selects the trigger input to be used to synchronize the counter
+            // 101: Filtered Timer Input 1 (TI1FP1)
+            // ---------------------------------------
+            // Slave Mode Selection :
+            //  100: Reset Mode - Rising edge of the selected trigger input (TRGI)
+            //  reinitializes the counter and generates an update of the registers.
+            tim.smcr.modify( |_,w| unsafe {w.ts().bits(0b101).sms().bits(0b100)});
+
+            match mode {
+               Frequency(f)  => {
+                  let freq = f.into().0;
+                  let max_freq = if freq > 5 {freq/5} else {1};
+                  let (arr,presc) = compute_arr_presc(max_freq, clocks.$pclk().0);
+                  tim.arr.write(|w| w.arr().bits(arr));
+                  tim.psc.write(|w| unsafe {w.psc().bits(presc)});
+
+               },
+               DutyCycle(f) => {
+                  let freq = f.into().0;
+                  let max_freq = if freq > 2 {freq/2 + freq/4 + freq/8} else {1};
+                  let (arr,presc) = compute_arr_presc(max_freq, clocks.$pclk().0);
+                  tim.arr.write(|w| w.arr().bits(arr));
+                  tim.psc.write(|w| unsafe {w.psc().bits(presc)});
+               },
+               RawFrequency(f) => {
+                  let freq = f.into().0;
+                  let (arr,presc) = compute_arr_presc(freq, clocks.$pclk().0);
+                  tim.arr.write(|w| w.arr().bits(arr));
+                  tim.psc.write(|w| unsafe {w.psc().bits(presc)});
+               }
+               RawValues{arr, presc} => {
+                  tim.arr.write(|w| w.arr().bits(arr));
+                  tim.psc.write(|w| unsafe {w.psc().bits(presc)});
+
+               }
+            }
+
+            // Enable Capture on both channels
+            tim.ccer.modify(|_,w| w.cc1e().set_bit().cc2e().set_bit());
+
+
+            tim.cr1.modify(|_,w| w.cen().set_bit());
+
+
+            unsafe { mem::uninitialized() }
+         }
+
+      impl<PINS> PwmInput<$TIMX,PINS> where PINS : Pins<$TIMX> {
+         /// Return the frequency sampled by the timer
+         pub fn read_frequency(&self, mode : ReadMode, clocks : &Clocks) -> Result<Hertz,Error> {
+
+            match mode {
+               ReadMode::WaitForNextCapture => self.wait_for_capture(),
+                  _ => (),
+            }
+            let presc = unsafe { (*$TIMX::ptr()).psc.read().bits() as u16};
+            let ccr1 = unsafe { (*$TIMX::ptr()).ccr1.read().bits() as u16};
+
+            // Formulas :
+            //
+            // F_timer = F_pclk / (PSC+1)*(ARR+1)
+            // Frac_arr = (CCR1+1)/(ARR+1)
+            // F_signal = F_timer/Frac_arr
+            // <=> F_signal = [(F_plck)/((PSC+1)*(ARR+1))] * [(ARR+1)/(CCR1+1)]
+            // <=> F_signal = F_pclk / ((PSC+1)*(CCR1+1))
+            //
+            // Where :
+            // * PSC is the prescaler register
+            // * ARR is the auto-reload register
+            // * F_timer is the number of time per second where the timer overflow under normal
+            // condition
+            //
+            if ccr1 == 0 {
+               Err(Error::FrequencyTooLow)
+            }
+            else {
+               let clk : u32 = clocks.$pclk().0;
+               Ok(Hertz(clk/((presc+1) as u32*(ccr1)as u32)))
+            }
+         }
+
+
+         /// Return the duty in the form of a fraction duty_cycle/period)
+         pub fn read_duty(&self, mode : ReadMode) -> Result<(u16,u16),Error> {
+
+            match mode {
+               ReadMode::WaitForNextCapture => self.wait_for_capture(),
+               _ => (),
+            }
+
+            // Formulas :
+            // Duty_cycle = (CCR2+1)/(CCR1+1)
+            let ccr1 = unsafe { (*$TIMX::ptr()).ccr1.read().bits() as u16};
+            let ccr2 = unsafe { (*$TIMX::ptr()).ccr2.read().bits() as u16};
+            if ccr1 == 0 {
+               Err(Error::FrequencyTooLow)
+            } else {
+               Ok((ccr2,ccr1))
+            }
+         }
+
+         /// Wait until the timer has captured a period
+         fn wait_for_capture(&self) {
+            unsafe { (*$TIMX::ptr()).sr.write(|w| w.uif().clear_bit().cc1if().clear_bit().cc1of().clear_bit())};
+            while unsafe { (*$TIMX::ptr()).sr.read().cc1if().bit_is_clear()} {}
+         }
+      }
+
+      )+
+   }
+}
+
+hal! {
+   TIM2: (tim2, tim2en, tim2rst, pclk2, dbg_tim2_stop),
+   TIM3: (tim3, tim3en, tim3rst, pclk2, dbg_tim3_stop),
+   TIM4: (tim4, tim4en, tim4rst, pclk2, dbg_tim4_stop),
+}

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -92,11 +92,10 @@ where
     /// In this mode, the provided arr and presc are directly programmed in the register.
     RawValues { arr: u16, presc: u16 },
 }
-
 pub trait PwmInputExt: Sized {
     fn pwm_input<PINS, T>(
         self,
-        PINS,
+        pins: PINS,
         apb: &mut APB1,
         mapr: &mut MAPR,
         dbg: &mut DBG,

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -191,7 +191,7 @@ macro_rules! hal {
          PINS: Pins<$TIMX>,
          T : Into<Hertz>
          {
-            use pwm_input::Configuration::*;
+            use crate::pwm_input::Configuration::*;
             apb.enr().modify(|_, w| w.$timXen().set_bit());
             apb.rstr().modify(|_, w| w.$timXrst().set_bit());
             apb.rstr().modify(|_, w| w.$timXrst().clear_bit());

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -1,5 +1,5 @@
-//! This modules allows the Timer peripherals to be configured as pwm input.
-//! In this mode, the timer can sample a squared signal to find it's frequency and duty cycle.
+//! This module allows Timer peripherals to be configured as pwm input.
+//! In this mode, the timer sample a squared signal to find it's frequency and duty cycle.
 
 use core::marker::PhantomData;
 use core::mem;
@@ -63,7 +63,7 @@ pub enum Error {
     FrequencyTooLow,
 }
 
-/// The configuration for the timer : what frequency the timer will try to sample
+/// Which frequency the timer will try to sample
 pub enum Configuration<T>
 where
     T: Into<Hertz>,
@@ -73,6 +73,8 @@ where
     /// of resolution.
     ///
     /// The minimum frequency that can be sampled is 20% the provided frequency.
+    ///
+    /// Use this mode if you do not know what to choose.
     Frequency(T),
 
     /// In this mode an algorithm calculates the optimal value for the autoreload register and the
@@ -84,11 +86,10 @@ where
 
     /// In this mode an algorithm calculates the optimal value for the autoreload register and the
     /// prescaler register in order to be able to sample signal with a frequency higher than the
-    /// provided value : there is no margin.
+    /// provided value : there is no margin for lower frequencies.
     RawFrequency(T),
 
-    /// In this mode, the user gives the desired arr and presc value that are then directly
-    /// programmed in the register.
+    /// In this mode, the provided arr and presc are directly programmed in the register.
     RawValues { arr: u16, presc: u16 },
 }
 
@@ -298,12 +299,12 @@ macro_rules! hal {
             }
             else {
                let clk : u32 = clocks.$pclk().0;
-               Ok(Hertz(clk/((presc+1) as u32*(ccr1)as u32)))
+               Ok(Hertz(clk/((presc+1) as u32*(ccr1 + 1)as u32)))
             }
          }
 
 
-         /// Return the duty in the form of a fraction duty_cycle/period)
+         /// Return the duty in the form of a fraction : (duty_cycle/period)
          pub fn read_duty(&self, mode : ReadMode) -> Result<(u16,u16),Error> {
 
             match mode {


### PR DESCRIPTION
Hello !
I gave a try at implementing pwm input for the stm32f103, it was not tested (yet!) but the implementation is well documented.
Could you take a first look at it and tell me if you spot something wrong ?

Current features :
* Define which pins can be used for PwmInput
* Configure a timer in PwmInput mode
* Automate PRESC and ARR calculation
* Read a frequency or a duty cycle from a timer in PwmInput mode
* Implement PwmInput for TIM2, TIM3, TIM4

Thank you ! :smile: