### PR TITLE
Update to stm32f1 0.6.0 and bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ features = ["stm32f103", "rt"]
 cortex-m = "0.5.8"
 nb = "0.1.1"
 cortex-m-rt = "0.6.7"
-stm32f1 = "0.5.0"
+stm32f1 = "0.6.0"
 
 [dependencies.void]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "stm32f1xx-hal"
 repository = "https://github.com/stm32-rs/stm32f1xx-hal"
 documentation = "https://docs.rs/stm32f1xx-hal"
-version = "0.1.1"
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 features = ["stm32f103", "rt"]


### PR DESCRIPTION
As discussed in #8 

@therealprof How does publishing this to crates.io work, do I have the permissions to do so?

How does cargo package work when feature flags are required to build the crate? I tried adding --features as you would when building but that did not work.

Also, I assume that 0.2.0 is correct since our exported dependency had a minor version bump, is that correct?