### PR TITLE
Add support for real time clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add basic backup domain support
+- Add support for real time clock
+
 ## [v0.2.0] - 2019-02-10
 
 ### Added

--- a/examples/blinky_rtc.rs
+++ b/examples/blinky_rtc.rs
@@ -1,0 +1,65 @@
+//! Blinks an LED using the real time clock to time the blinks
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal as hal;
+#[macro_use(block)]
+extern crate nb;
+
+use hal::prelude::*;
+use hal::stm32;
+use rt::{entry, exception, ExceptionFrame};
+use hal::rtc::Rtc;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let mut pwr = dp.PWR;
+    let mut rcc = dp.RCC.constrain();
+
+    // Set up the GPIO pin
+    let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
+    let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+
+    // Set up the RTC
+    // Enable writes to the backup domain
+    let backup_domain = rcc.bkp.constrain(dp.BKP, &mut rcc.apb1, &mut pwr);
+    // Start the LSE which is used as the clock for the RTC
+    let lse = rcc.lse.freeze(&backup_domain);
+    // Aquire the RTC
+    let mut rtc = Rtc::rtc(dp.RTC, lse, &backup_domain);
+
+    let mut led_on = false;
+    loop {
+        // Set the current time to 0
+        rtc.set_cnt(0);
+        // Trigger the alarm in 5 seconds
+        rtc.set_alarm(5);
+        block!(rtc.wait_alarm()).unwrap();
+        if led_on {
+            led.set_low();
+            led_on = false;
+        }
+        else {
+            led.set_high();
+            led_on = true;
+        }
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}

--- a/examples/blinky_rtc.rs
+++ b/examples/blinky_rtc.rs
@@ -32,9 +32,7 @@ fn main() -> ! {
     // Enable writes to the backup domain
     let mut backup_domain = rcc.bkp.constrain(dp.BKP, &mut rcc.apb1, &mut pwr);
     // Start the LSE which is used as the clock for the RTC
-    let lse = backup_domain.enable_lse(rcc.lse);
-    // Aquire the RTC
-    let mut rtc = Rtc::rtc(dp.RTC, lse, &mut backup_domain);
+    let mut rtc = Rtc::rtc(dp.RTC, rcc.lse, &mut backup_domain);
 
     let mut led_on = false;
     loop {

--- a/examples/blinky_rtc.rs
+++ b/examples/blinky_rtc.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     // Enable writes to the backup domain
     let mut backup_domain = rcc.bkp.constrain(dp.BKP, &mut rcc.apb1, &mut pwr);
     // Start the LSE which is used as the clock for the RTC
-    let lse = rcc.lse.freeze(&mut backup_domain);
+    let lse = backup_domain.enable_lse(rcc.lse);
     // Aquire the RTC
     let mut rtc = Rtc::rtc(dp.RTC, lse, &mut backup_domain);
 

--- a/examples/blinky_rtc.rs
+++ b/examples/blinky_rtc.rs
@@ -30,16 +30,16 @@ fn main() -> ! {
 
     // Set up the RTC
     // Enable writes to the backup domain
-    let backup_domain = rcc.bkp.constrain(dp.BKP, &mut rcc.apb1, &mut pwr);
+    let mut backup_domain = rcc.bkp.constrain(dp.BKP, &mut rcc.apb1, &mut pwr);
     // Start the LSE which is used as the clock for the RTC
-    let lse = rcc.lse.freeze(&backup_domain);
+    let lse = rcc.lse.freeze(&mut backup_domain);
     // Aquire the RTC
-    let mut rtc = Rtc::rtc(dp.RTC, lse, &backup_domain);
+    let mut rtc = Rtc::rtc(dp.RTC, lse, &mut backup_domain);
 
     let mut led_on = false;
     loop {
         // Set the current time to 0
-        rtc.set_cnt(0);
+        rtc.set_seconds(0);
         // Trigger the alarm in 5 seconds
         rtc.set_alarm(5);
         block!(rtc.wait_alarm()).unwrap();

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
     let backup_domain = rcc.cfgr.enable_backup_domain(&mut pwr);
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let rtc = backup_domain.rtc(p.RTC, clocks);
+    let rtc = backup_domain.rtc(p.RTC, &clocks);
 
     loop {
         writeln!(hstdout, "time: {}", rtc.read()).unwrap();

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -27,16 +27,14 @@ fn main() -> ! {
     let p = hal::stm32::Peripherals::take().unwrap();
 
     let mut pwr = p.PWR;
-    let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
     let backup_domain = rcc.bkp.constrain(p.BKP, &mut rcc.apb1, &mut pwr);
-    let _clocks = rcc.cfgr.freeze(&mut flash.acr);
     let lse = rcc.lse.freeze(&backup_domain);
 
     let rtc = Rtc::rtc(p.RTC, lse, &backup_domain);
 
     loop {
-        writeln!(hstdout, "time: {}", rtc.read_counts()).unwrap();
+        writeln!(hstdout, "time: {}", rtc.read_seconds()).unwrap();
     }
 }
 

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let mut pwr = p.PWR;
     let mut rcc = p.RCC.constrain();
     let mut backup_domain = rcc.bkp.constrain(p.BKP, &mut rcc.apb1, &mut pwr);
-    let lse = rcc.lse.freeze(&mut backup_domain);
+    let lse = backup_domain.enable_lse(rcc.lse);
 
     let rtc = Rtc::rtc(p.RTC, lse, &mut backup_domain);
 

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     let mut pwr = p.PWR;
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
-    let backup_domain = rcc.cfgr.enable_backup_domain(&mut pwr);
+    let backup_domain = rcc.cfgr.access_backup_domain(&mut pwr);
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
     let rtc = backup_domain.rtc(p.RTC, &clocks);

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -28,13 +28,13 @@ fn main() -> ! {
 
     let mut pwr = p.PWR;
     let mut rcc = p.RCC.constrain();
-    let backup_domain = rcc.bkp.constrain(p.BKP, &mut rcc.apb1, &mut pwr);
-    let lse = rcc.lse.freeze(&backup_domain);
+    let mut backup_domain = rcc.bkp.constrain(p.BKP, &mut rcc.apb1, &mut pwr);
+    let lse = rcc.lse.freeze(&mut backup_domain);
 
-    let rtc = Rtc::rtc(p.RTC, lse, &backup_domain);
+    let rtc = Rtc::rtc(p.RTC, lse, &mut backup_domain);
 
     loop {
-        writeln!(hstdout, "time: {}", rtc.read_seconds()).unwrap();
+        writeln!(hstdout, "time: {}", rtc.seconds()).unwrap();
     }
 }
 

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -18,6 +18,8 @@ use sh::hio;
 
 use core::fmt::Write;
 
+use hal::rtc::Rtc;
+
 #[entry]
 fn main() -> ! {
     let mut hstdout = hio::hstdout().unwrap();
@@ -27,10 +29,11 @@ fn main() -> ! {
     let mut pwr = p.PWR;
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
-    let backup_domain = rcc.backup_domain(&mut pwr);
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let backup_domain = rcc.backup_domain(p.BKP, &mut pwr);
+    let _clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let lse = rcc.lse.freeze(&backup_domain);
 
-    let rtc = backup_domain.rtc(p.RTC, &clocks);
+    let rtc = Rtc::rtc(p.RTC, lse, &backup_domain);
 
     loop {
         writeln!(hstdout, "time: {}", rtc.read_counts()).unwrap();

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let mut pwr = p.PWR;
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
-    let backup_domain = rcc.backup_domain(p.BKP, &mut pwr);
+    let backup_domain = rcc.bkp.constrain(p.BKP, &mut rcc.apb1, &mut pwr);
     let _clocks = rcc.cfgr.freeze(&mut flash.acr);
     let lse = rcc.lse.freeze(&backup_domain);
 

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -1,0 +1,50 @@
+//! Blinks an LED
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate cortex_m_semihosting as sh;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal as hal;
+
+use hal::prelude::*;
+use hal::rtc::Rtc;
+use rt::{entry, exception, ExceptionFrame};
+
+use sh::hio;
+
+use core::fmt::Write;
+
+#[entry]
+fn main() -> ! {
+    let mut hstdout = hio::hstdout().unwrap();
+
+    let mut p = hal::stm32::Peripherals::take().unwrap();
+
+    let mut pwr = p.PWR;
+    let mut flash = p.FLASH.constrain();
+    // Enable the clocks in the backup domain
+    let bd_token = p.RCC.enable_backup_domain(&mut pwr);
+    let rcc = p.RCC.constrain();
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let rtc = Rtc::rtc(p.RTC, &bd_token, clocks);
+
+    loop {
+        writeln!(hstdout, "time: {}", rtc.read()).unwrap();
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -27,13 +27,13 @@ fn main() -> ! {
     let mut pwr = p.PWR;
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
-    let backup_domain = rcc.cfgr.access_backup_domain(&mut pwr);
+    let backup_domain = rcc.backup_domain(&mut pwr);
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
     let rtc = backup_domain.rtc(p.RTC, &clocks);
 
     loop {
-        writeln!(hstdout, "time: {}", rtc.read()).unwrap();
+        writeln!(hstdout, "time: {}", rtc.read_counts()).unwrap();
     }
 }
 

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -1,4 +1,4 @@
-//! Blinks an LED
+//! Outputs the current time in seconds to hstdout using the real time clock
 
 #![deny(unsafe_code)]
 #![deny(warnings)]

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -29,9 +29,8 @@ fn main() -> ! {
     let mut pwr = p.PWR;
     let mut rcc = p.RCC.constrain();
     let mut backup_domain = rcc.bkp.constrain(p.BKP, &mut rcc.apb1, &mut pwr);
-    let lse = backup_domain.enable_lse(rcc.lse);
 
-    let rtc = Rtc::rtc(p.RTC, lse, &mut backup_domain);
+    let rtc = Rtc::rtc(p.RTC, rcc.lse, &mut backup_domain);
 
     loop {
         writeln!(hstdout, "time: {}", rtc.seconds()).unwrap();

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -1,10 +1,23 @@
-use stm32::{BKP};
+/*!
+  Registers that are not reset as long as Vbat or Vdd has power.
 
+  The registers retain their values during wakes from standby mode or system resets. They also
+  retain their value when Vdd is switched off as long as V_BAT is powered.
+
+  The backup domain also contains tamper protection and writes to it must be enabled in order
+  to use the real time clock (RTC).
+
+  Write access to the backup domain is enabled in RCC using the `rcc::Rcc::BKP::constrain()`
+  function.
+
+  Only the RTC functionality is currently implemented.
+*/
+
+use stm32::{BKP};
 
 /**
   The existence of this struct indicates that writing to the the backup
-  domain has been enabled. It is aquired by calling the `enable_backup_domain`
-  function on `rcc::CFGR`
+  domain has been enabled. It is aquired by calling `constrain` on `rcc::Rcc::BKP`
 */
 pub struct BackupDomain {
     pub(crate) _regs: BKP

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -1,0 +1,18 @@
+use crate::rtc::Rtc;
+use crate::rcc::Clocks;
+
+use stm32::RTC;
+
+
+pub struct BackupDomain {
+    pub(crate) _0: ()
+}
+
+impl BackupDomain {
+    pub fn rtc(&self, regs: RTC, _clocks: Clocks) -> Rtc {
+        Rtc::rtc(regs)
+    }
+}
+
+
+

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -4,13 +4,19 @@ use crate::rcc::Clocks;
 use stm32::RTC;
 
 
+/**
+  The existence of this struct indicates that writing to the the backup
+  domain has been enabled. It is aquired by calling the `enable_backup_domain`
+  function on `rcc::CFGR`
+*/
 pub struct BackupDomain {
     pub(crate) _0: ()
 }
 
 impl BackupDomain {
-    pub fn rtc(&self, regs: RTC, _clocks: Clocks) -> Rtc {
-        Rtc::rtc(regs)
+    /// Initialise the RTC
+    pub fn rtc(&self, regs: RTC, clocks: &Clocks) -> Rtc {
+        Rtc::rtc(regs, clocks)
     }
 }
 

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -15,7 +15,8 @@
 
 use stm32::{BKP, rcc, RCC};
 
-use crate::rcc::Lse;
+use crate::rcc::{LSE};
+use time::Hertz;
 
 /**
   The existence of this struct indicates that writing to the the backup
@@ -28,6 +29,7 @@ pub struct BackupDomain {
 impl BackupDomain {
     // Enables the RTC device with the lse as the clock
     pub(crate) fn enable_rtc(&mut self, lse: Lse) {
+        // NOTE: Safe RCC access because we are only accessing bdcr
         let rcc = unsafe { &*RCC::ptr() };
         rcc.bdcr.modify(|_, w| {
             w
@@ -39,8 +41,30 @@ impl BackupDomain {
     }
 
     /// Enables the low speed external oscilator
-    pub(crate) fn enable_lse(&mut self) {
+    pub fn enable_lse(&mut self, _lse: LSE) -> Lse {
+        // NOTE: Safe RCC access because we are only accessing bdcr
         let rcc = unsafe { &*RCC::ptr() };
         rcc.bdcr.modify(|_, w| w.lseon().set_bit());
+
+        // NOTE: Chosing another frequency requires an external oscilator as explained in section
+        // 8.2.4
+        Lse{freq: Hertz(32768)}
+    }
+}
+
+
+/// The existense of this struct means that the LSE is enabled and runs at `freq` hertz
+///
+/// The LSE can be started using `BackupDomain.enable_lse`
+#[derive(Clone, Copy)]
+pub struct Lse {
+    freq: Hertz
+}
+
+
+impl Lse {
+    /// Returns the frequency of the LSE
+    pub fn freq(&self) -> Hertz {
+        self.freq
     }
 }

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -19,6 +19,3 @@ impl BackupDomain {
         Rtc::rtc(regs, clocks)
     }
 }
-
-
-

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -1,7 +1,4 @@
-use crate::rtc::Rtc;
-use crate::rcc::Clocks;
-
-use stm32::{BKP, RTC};
+use stm32::{BKP};
 
 
 /**
@@ -10,7 +7,7 @@ use stm32::{BKP, RTC};
   function on `rcc::CFGR`
 */
 pub struct BackupDomain {
-    pub(crate) regs: BKP
+    pub(crate) _regs: BKP
 }
 
 impl BackupDomain {

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -13,15 +13,34 @@
   Only the RTC functionality is currently implemented.
 */
 
-use stm32::{BKP};
+use stm32::{BKP, rcc, RCC};
+
+use crate::rcc::Lse;
 
 /**
   The existence of this struct indicates that writing to the the backup
   domain has been enabled. It is aquired by calling `constrain` on `rcc::Rcc::BKP`
 */
 pub struct BackupDomain {
-    pub(crate) _regs: BKP
+    pub(crate) _regs: BKP,
 }
 
 impl BackupDomain {
+    // Enables the RTC device with the lse as the clock
+    pub(crate) fn enable_rtc(&mut self, lse: Lse) {
+        let rcc = unsafe { &*RCC::ptr() };
+        rcc.bdcr.modify(|_, w| {
+            w
+                // Enable the RTC
+                .rtcen().set_bit()
+                // Set the source of the RTC to LSE
+                .rtcsel().lse()
+        })
+    }
+
+    /// Enables the low speed external oscilator
+    pub(crate) fn enable_lse(&mut self) {
+        let rcc = unsafe { &*RCC::ptr() };
+        rcc.bdcr.modify(|_, w| w.lseon().set_bit());
+    }
 }

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -1,7 +1,7 @@
 use crate::rtc::Rtc;
 use crate::rcc::Clocks;
 
-use stm32::RTC;
+use stm32::{BKP, RTC};
 
 
 /**
@@ -10,12 +10,8 @@ use stm32::RTC;
   function on `rcc::CFGR`
 */
 pub struct BackupDomain {
-    pub(crate) _0: ()
+    pub(crate) regs: BKP
 }
 
 impl BackupDomain {
-    /// Initialise the RTC
-    pub fn rtc(&self, regs: RTC, clocks: &Clocks) -> Rtc {
-        Rtc::rtc(regs, clocks)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,4 @@ pub mod spi;
 pub mod time;
 pub mod timer;
 pub mod rtc;
+pub mod backup_domain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,4 @@ pub mod serial;
 pub mod spi;
 pub mod time;
 pub mod timer;
+pub mod rtc;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -151,6 +151,7 @@ impl CFGR {
         self
     }
 
+    /// Gives write access to the registers in the backup domain
     pub fn enable_backup_domain(&mut self, pwr: &mut PWR) -> BackupDomain {
         // NOTE: Access to apb1enr inside Rcc struct is means we have exclusive access
         let apb1_enr = unsafe { &(*RCC::ptr()).apb1enr };

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -65,7 +65,7 @@ impl Rcc {
         });
 
         BackupDomain {
-            regs: bkp
+            _regs: bkp
         }
     }
 }
@@ -333,7 +333,7 @@ pub struct LSE {
 
 impl LSE {
     /// Start the LSE clock with a frequency of 32.768 kHz
-    pub fn freeze(self, bkp: &BackupDomain) -> Lse {
+    pub fn freeze(self, _bkp: &BackupDomain) -> Lse {
         // NOTE: Safe because only the BDCR is written to and it is not
         // used anywhere else.
         let rcc = unsafe { &*RCC::ptr() };

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -334,22 +334,6 @@ pub struct LSE {
     _0: ()
 }
 
-impl LSE {
-    /**
-      Start the LSE clock with a frequency of 32.768 kHz
-
-      Returns an `Lse` which indicates that the Lse is on and its frequency is fixed
-    */
-    pub fn freeze(self, bkp: &mut BackupDomain) -> Lse {
-        // Enable the clock
-        bkp.enable_lse();
-
-        // NOTE: Chosing another frequency requires an external oscilator as explained in section
-        // 8.2.4
-        Lse{freq: Hertz(32768)}
-    }
-}
-
 
 pub struct BKP {
     _0: ()
@@ -430,16 +414,3 @@ impl Clocks {
     }
 }
 
-/// The existense of this struct means that the LSE is enabled and runs at `freq` hertz
-#[derive(Clone, Copy)]
-pub struct Lse {
-    freq: Hertz
-}
-
-
-impl Lse {
-    /// Returns the frequency of the LSE
-    pub fn freq(&self) -> Hertz {
-        self.freq
-    }
-}

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,7 +1,7 @@
 use core::cmp;
 
 use cast::u32;
-use stm32::{rcc, RCC, PWR};
+use stm32::{rcc, RCC, PWR, BKP};
 
 use flash::ACR;
 use time::Hertz;
@@ -30,8 +30,8 @@ impl RccExt for RCC {
                 pclk1: None,
                 pclk2: None,
                 sysclk: None,
-                backup_domain: None,
             },
+            lse: LSE { _0: () },
         }
     }
 }
@@ -45,13 +45,12 @@ pub struct Rcc {
     /// Advanced Peripheral Bus 2 (APB2) registers
     pub apb2: APB2,
     pub cfgr: CFGR,
+    pub lse: LSE,
 }
 
 impl Rcc {
     /// Enables write access to the registers in the backup domain
-    pub fn backup_domain(&mut self, pwr: &mut PWR) -> BackupDomain {
-        // NOTE: Exclusive access to RCC because this struct is a member of
-        // Rcc
+    pub fn backup_domain(&mut self, bkp: BKP, pwr: &mut PWR) -> BackupDomain {
         // Enable the backup interface by setting PWREN and BKPEN
         self.apb1.enr().modify(|_r, w| {
             w
@@ -65,12 +64,8 @@ impl Rcc {
                 dbp().set_bit()
         });
 
-
-        // Remember that the LSE needs to be initialised in clocks
-        self.cfgr.backup_domain = Some(());
-
         BackupDomain {
-            _0: ()
+            regs: bkp
         }
     }
 }
@@ -91,6 +86,7 @@ impl AHB {
 pub struct APB1 {
     _0: (),
 }
+
 
 impl APB1 {
     pub(crate) fn enr(&mut self) -> &rcc::APB1ENR {
@@ -129,7 +125,6 @@ pub struct CFGR {
     pclk1: Option<u32>,
     pclk2: Option<u32>,
     sysclk: Option<u32>,
-    backup_domain: Option<()>,
 }
 
 impl CFGR {
@@ -274,20 +269,6 @@ impl CFGR {
 
         let rcc = unsafe { &*RCC::ptr() };
 
-        if self.backup_domain.is_some() {
-            // Configure the perscaler to use the LSE clock as defined in the documentation
-            // in section 7.2.4. This gives a 32.768khz frequency for the RTC
-            rcc.bdcr.modify(|_, w| {
-                w
-                    // Enable external low speed oscilator
-                    .lseon().set_bit()
-                    // Enable the RTC
-                    .rtcen().set_bit()
-                    // Set the source of the RTC to LSE
-                    .rtcsel().lse()
-            });
-        }
-
         if self.hse.is_some() {
             // enable HSE and wait for it to be ready
 
@@ -346,6 +327,32 @@ impl CFGR {
     }
 }
 
+pub struct LSE {
+    _0: ()
+}
+
+impl LSE {
+    /// Start the LSE clock with a frequency of 32.768 kHz
+    pub fn freeze(self, bkp: &BackupDomain) -> Lse {
+        // NOTE: Safe because only the BDCR is written to and it is not
+        // used anywhere else.
+        let rcc = unsafe { &*RCC::ptr() };
+
+        rcc.bdcr.modify(|_, w| {
+            w
+                // Enable external low speed oscilator
+                .lseon().set_bit()
+                // Enable the RTC
+                .rtcen().set_bit()
+                // Set the source of the RTC to LSE
+                .rtcsel().lse()
+        });
+
+        // NOTE: Chosing another frequency requires an external oscilator
+        Lse{freq: Hertz(32768)}
+    }
+}
+
 /// Frozen clock frequencies
 ///
 /// The existence of this value indicates that the clock configuration can no longer be changed
@@ -394,5 +401,18 @@ impl Clocks {
     /// Returns whether the USBCLK clock frequency is valid for the USB peripheral
     pub fn usbclk_valid(&self) -> bool {
         self.usbclk_valid
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Lse {
+    freq: Hertz
+}
+
+
+impl Lse {
+    /// Returns the frequency of the AHB
+    pub fn freq(&self) -> Hertz {
+        self.freq
     }
 }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -151,9 +151,10 @@ impl CFGR {
         self
     }
 
-    /// Gives write access to the registers in the backup domain
-    pub fn enable_backup_domain(&mut self, pwr: &mut PWR) -> BackupDomain {
-        // NOTE: Access to apb1enr inside Rcc struct is means we have exclusive access
+    /// Enables write access to the registers in the backup domain
+    pub fn access_backup_domain(&mut self, pwr: &mut PWR) -> BackupDomain {
+        // NOTE: Exclusive access to RCC because this struct is a member of
+        // Rcc
         let apb1_enr = unsafe { &(*RCC::ptr()).apb1enr };
         // Enable the backup interface by setting PWREN and BKPEN
         apb1_enr.modify(|_r, w| {

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -8,6 +8,7 @@ use time::Hertz;
 
 use backup_domain::BackupDomain;
 
+
 /// Extension trait that constrains the `RCC` peripheral
 pub trait RccExt {
     /// Constrains the `RCC` peripheral so it plays nicely with the other abstractions

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -8,10 +8,6 @@ use time::Hertz;
 
 use backup_domain::BackupDomain;
 
-pub struct BackupDomainEnabledToken {
-    _0: ()
-}
-
 /// Extension trait that constrains the `RCC` peripheral
 pub trait RccExt {
     /// Constrains the `RCC` peripheral so it plays nicely with the other abstractions

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,6 +1,7 @@
 use stm32::{RTC};
 
-use crate::rcc::Clocks;
+use crate::rcc::Lse;
+use crate::backup_domain::BackupDomain;
 
 
 /*
@@ -23,7 +24,8 @@ use crate::rcc::Clocks;
   are writeable and that the clock has been configured correctly.
 */
 pub struct Rtc {
-    regs: RTC
+    regs: RTC,
+    lse: Lse,
 }
 
 
@@ -32,14 +34,15 @@ impl Rtc {
       Initialises the RTC, this should only be called if access to the backup
       domain has been enabled
     */
-    pub(crate) fn rtc(regs: RTC, _clocks: &Clocks) -> Self {
+    pub fn rtc(regs: RTC, lse: Lse, bkp: &BackupDomain) -> Self {
         // Set the prescaler to make it count up once every second
         // The manual on page 490 says that the prescaler value for this should be 7fffh
         let mut result = Rtc {
-            regs
+            regs,
+            lse,
         };
 
-        let freq = 32768;
+        let freq = lse.freq().0;
         let prl = freq - 1;
         assert!(prl < 1 << 20);
         result.perform_write(|s| {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,0 +1,126 @@
+use stm32::{RTC};
+
+use rcc::BackupDomainEnabledToken;
+
+
+/*
+    Configuring RTC registers requires the following process:
+    poll RTOFF, make sure it is 1
+    set CNF to enter config mode
+    write to the registers
+    clear CNF
+    poll RTOFF to make sure it's back to 1
+    The frequency of the rtc is calculated by
+    f_rtcclk / (PRL[19:0] + 1)
+    f_rtcclk can probably be configured to be the main clock. Then we can use
+    rcc to figure out what that frequency is
+    both vbat and vdd might have to be connected for the clock to keep counting
+*/
+
+pub struct Rtc {
+    regs: RTC
+}
+
+
+impl Rtc {
+    pub fn rtc(regs: RTC, _token: &BackupDomainEnabledToken) -> Self {
+        // Set the prescaler to make it count up once every second
+        // The manual on page 490 says that the prescaler value for this should be 7fffh
+        regs.prll.write(|w| unsafe{w.bits(0x7fff)});
+        regs.prlh.write(|w| unsafe{w.bits(0)});
+
+        Rtc {
+            regs
+        }
+    }
+
+    pub fn set_alarm(&mut self, time_seconds: u32) {
+        // Reset counter
+        self.perform_write(|s| {
+            s.regs.cnth.write(|w| unsafe{w.bits(0)});
+        });
+        self.perform_write(|s| {
+            s.regs.cntl.write(|w| unsafe{w.bits(0)});
+        });
+
+        // Set alarm time
+        // See section 18.3.5 for explanation
+        let alarm_value = time_seconds - 1;
+        self.perform_write(|s| {
+            s.regs.alrh.write(|w| unsafe{w.alrh().bits((alarm_value >> 16) as u16)});
+        });
+        self.perform_write(|s| {
+            s.regs.alrl.write(|w| unsafe{w.alrl().bits((alarm_value & 0x0000ffff) as u16)});
+        });
+
+        // Enable alarm interrupt
+        self.perform_write(|s| {
+            s.regs.crh.modify(|_, w| w.alrie().set_bit());
+        })
+    }
+
+    pub fn disable_alarm(&mut self) {
+        // Disable alarm interrupt
+        self.perform_write(|s| {
+            s.regs.crh.modify(|_, w| w.alrie().clear_bit());
+        })
+    }
+
+    pub fn read(&self) -> u32{
+        // Wait for the APB1 interface to be ready
+        while self.regs.crl.read().rsf().bit() == false {}
+
+        ((self.regs.cnth.read().bits() << 16) as u32) + (self.regs.cntl.read().bits() as u32)
+    }
+
+    /**
+      Enables the RTC second interrupt
+    */
+    pub fn listen_seconds(&mut self) {
+        self.perform_write(|s| {
+            s.regs.crh.modify(|_, w| w.secie().set_bit())
+        })
+    }
+    /**
+      Disables the RTC second interrupt
+    */
+    pub fn unlisten_seconds(&mut self) {
+        self.perform_write(|s| {
+            s.regs.crh.modify(|_, w| w.secie().clear_bit())
+        })
+    }
+    /**
+      Clears the RTC second interrupt flag
+    */
+    pub fn clear_second_flag(&mut self) {
+        self.perform_write(|s| {
+            s.regs.crl.modify(|_, w| w.secf().clear_bit())
+        })
+    }
+
+    /**
+      Clears the RTC alarm interrupt flag
+    */
+    pub fn clear_alarm_flag(&mut self) {
+        self.perform_write(|s| {
+            s.regs.crl.modify(|_, w| w.alrf().clear_bit())
+        })
+    }
+
+
+    fn perform_write(&mut self, func: impl Fn(&mut Self)) {
+        // This process is documented on page 485 of the stm32f103 manual
+        // Wait for the last write operation to be done
+        while self.regs.crl.read().rtoff().bit() == false {}
+        // Put the clock into config mode
+        self.regs.crl.modify(|_, w| w.cnf().set_bit());
+
+        // Perform the write opertaion
+        func(self);
+
+        // Take the device out of config mode
+        self.regs.crl.modify(|_, w| w.cnf().clear_bit());
+        // Wait for the write to be done
+        while self.regs.crl.read().rtoff().bit() == false {}
+    }
+}

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -63,7 +63,7 @@ impl Rtc {
         });
     }
 
-    /// Starts an alarm which will trigger the RTCALARM interrupt when the counter hits counts
+    /// Sets the time at which an alarm will be triggered
     pub fn set_alarm(&mut self, counts: u32) {
 
         // Set alarm time
@@ -75,15 +75,18 @@ impl Rtc {
         self.perform_write(|s| {
             s.regs.alrl.write(|w| unsafe{w.alrl().bits((counts & 0x0000ffff) as u16)});
         });
+    }
 
+    /// Enables the RTCALARM interrupt
+    pub fn listen_alarm(&mut self) {
         // Enable alarm interrupt
         self.perform_write(|s| {
             s.regs.crh.modify(|_, w| w.alrie().set_bit());
         })
     }
 
-    /// Disables a previously set alarm
-    pub fn disable_alarm(&mut self) {
+    /// Disables the RTCALARM interrupt
+    pub fn unlisten_alarm(&mut self) {
         // Disable alarm interrupt
         self.perform_write(|s| {
             s.regs.crh.modify(|_, w| w.alrie().clear_bit());

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -64,7 +64,11 @@ impl Rtc {
         });
     }
 
-    /// Sets the time at which an alarm will be triggered
+    /**
+      Sets the time at which an alarm will be triggered
+
+      This also clears the alarm flag if it is set
+    */
     pub fn set_alarm(&mut self, seconds: u32) {
         // Set alarm time
         // See section 18.3.5 for explanation
@@ -134,9 +138,8 @@ impl Rtc {
     /**
       Return `Ok(())` if the alarm flag is set, `Err(nb::WouldBlock)` otherwise.
 
-      Note: Does not clear the alarm flag
+      **Note**: Does not clear the alarm flag
 
-      Usage example: wait 
       ```rust
       use nb::block;
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,7 +1,5 @@
 use stm32::{RTC};
 
-use rcc::{Clocks, BackupDomainEnabledToken};
-
 
 /*
     Configuring RTC registers requires the following process:
@@ -23,7 +21,7 @@ pub struct Rtc {
 
 
 impl Rtc {
-    pub fn rtc(regs: RTC, _token: &BackupDomainEnabledToken, _clocks: Clocks) -> Self {
+    pub(crate) fn rtc(regs: RTC) -> Self {
         // Set the prescaler to make it count up once every second
         // The manual on page 490 says that the prescaler value for this should be 7fffh
         regs.prll.write(|w| unsafe{w.bits(0x7fff)});

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -14,7 +14,7 @@
 
 use stm32::{RTC};
 
-use crate::rcc::Lse;
+use crate::backup_domain::Lse;
 use crate::backup_domain::BackupDomain;
 
 use nb;

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -25,7 +25,7 @@ use crate::backup_domain::BackupDomain;
 */
 pub struct Rtc {
     regs: RTC,
-    lse: Lse,
+    _lse: Lse,
 }
 
 
@@ -34,12 +34,12 @@ impl Rtc {
       Initialises the RTC, this should only be called if access to the backup
       domain has been enabled
     */
-    pub fn rtc(regs: RTC, lse: Lse, bkp: &BackupDomain) -> Self {
+    pub fn rtc(regs: RTC, lse: Lse, _bkp: &BackupDomain) -> Self {
         // Set the prescaler to make it count up once every second
         // The manual on page 490 says that the prescaler value for this should be 7fffh
         let mut result = Rtc {
             regs,
-            lse,
+            _lse: lse,
         };
 
         let freq = lse.freq().0;
@@ -70,10 +70,10 @@ impl Rtc {
         // See section 18.3.5 for explanation
         let alarm_value = counts - 1;
         self.perform_write(|s| {
-            s.regs.alrh.write(|w| unsafe{w.alrh().bits((counts >> 16) as u16)});
+            s.regs.alrh.write(|w| unsafe{w.alrh().bits((alarm_value >> 16) as u16)});
         });
         self.perform_write(|s| {
-            s.regs.alrl.write(|w| unsafe{w.alrl().bits((counts & 0x0000ffff) as u16)});
+            s.regs.alrl.write(|w| unsafe{w.alrl().bits((alarm_value & 0x0000ffff) as u16)});
         });
     }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -35,32 +35,42 @@ impl Rtc {
     pub(crate) fn rtc(regs: RTC, _clocks: &Clocks) -> Self {
         // Set the prescaler to make it count up once every second
         // The manual on page 490 says that the prescaler value for this should be 7fffh
-        regs.prll.write(|w| unsafe{w.bits(0x7fff)});
-        regs.prlh.write(|w| unsafe{w.bits(0)});
-
-        Rtc {
+        let mut result = Rtc {
             regs
-        }
+        };
+
+        let freq = 32768;
+        let prl = freq - 1;
+        assert!(prl < 1 << 20);
+        result.perform_write(|s| {
+            s.regs.prlh.write(|w| unsafe { w.bits(prl >> 16) });
+            s.regs.prll.write(|w| unsafe { w.bits(prl as u16 as u32) });
+        });
+
+        result
     }
 
-    /// Starts an alarm which will trigger the RTCALARM interrupt in `time_seconds`
-    pub fn set_alarm(&mut self, time_seconds: u32) {
-        // Reset counter
+    /// Set the current rtc value to the specified amount of counts
+    pub fn set_cnt(&mut self, counts: u32) {
         self.perform_write(|s| {
-            s.regs.cnth.write(|w| unsafe{w.bits(0)});
+            s.regs.cnth.write(|w| unsafe{w.bits(counts >> 16)});
         });
         self.perform_write(|s| {
-            s.regs.cntl.write(|w| unsafe{w.bits(0)});
+            s.regs.cntl.write(|w| unsafe{w.bits(counts)});
         });
+    }
+
+    /// Starts an alarm which will trigger the RTCALARM interrupt when the counter hits counts
+    pub fn set_alarm(&mut self, counts: u32) {
 
         // Set alarm time
         // See section 18.3.5 for explanation
-        let alarm_value = time_seconds - 1;
+        let alarm_value = counts - 1;
         self.perform_write(|s| {
-            s.regs.alrh.write(|w| unsafe{w.alrh().bits((alarm_value >> 16) as u16)});
+            s.regs.alrh.write(|w| unsafe{w.alrh().bits((counts >> 16) as u16)});
         });
         self.perform_write(|s| {
-            s.regs.alrl.write(|w| unsafe{w.alrl().bits((alarm_value & 0x0000ffff) as u16)});
+            s.regs.alrl.write(|w| unsafe{w.alrl().bits((counts & 0x0000ffff) as u16)});
         });
 
         // Enable alarm interrupt
@@ -77,8 +87,8 @@ impl Rtc {
         })
     }
 
-    /// Reads the current second since the RTC device was initialised
-    pub fn read(&self) -> u32 {
+    /// Reads the current time
+    pub fn read_counts(&self) -> u32 {
         // Wait for the APB1 interface to be ready
         while self.regs.crl.read().rsf().bit() == false {}
 
@@ -131,6 +141,6 @@ impl Rtc {
         // Take the device out of config mode
         self.regs.crl.modify(|_, w| w.cnf().clear_bit());
         // Wait for the write to be done
-        while self.regs.crl.read().rtoff().bit() == false {}
+        while !self.regs.crl.read().rtoff().bit() {}
     }
 }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -65,7 +65,6 @@ impl Rtc {
 
     /// Sets the time at which an alarm will be triggered
     pub fn set_alarm(&mut self, counts: u32) {
-
         // Set alarm time
         // See section 18.3.5 for explanation
         let alarm_value = counts - 1;

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,6 +1,6 @@
 use stm32::{RTC};
 
-use rcc::BackupDomainEnabledToken;
+use rcc::{Clocks, BackupDomainEnabledToken};
 
 
 /*
@@ -23,7 +23,7 @@ pub struct Rtc {
 
 
 impl Rtc {
-    pub fn rtc(regs: RTC, _token: &BackupDomainEnabledToken) -> Self {
+    pub fn rtc(regs: RTC, _token: &BackupDomainEnabledToken, _clocks: Clocks) -> Self {
         // Set the prescaler to make it count up once every second
         // The manual on page 490 says that the prescaler value for this should be 7fffh
         regs.prll.write(|w| unsafe{w.bits(0x7fff)});


### PR DESCRIPTION
This is essentially the same code as the one in https://github.com/japaric/stm32f103xx-hal/pull/98 and it still has some issues.

# Where to initialise
The main problem is that LSE initialization and rtc clock selection has to happen before clock freeze. However, in order to do that, the backup domain has to be enabled in the pwr register. Since freeze, or any other function dealing with rcc does not modify pwr, adding that as a parameter would be a breaking change.

Additionally, we want to statically ensure (I think) that the required clocks are on when the real time clock is started. There are a couple of solutions to this

## Token type
My current solution to all this is to add a function to rcc that sets up things in the backup domain which gives a token that is required in order to run the rtc.

I'm not a huge fan of that solution, but I can't think of anything that is obviously better.

## Rtc "owned" by `RCC`
One option would be to, rather generate a token, generate an `UninitialisedRtc` struct which can then be used to actually initialise the `RTC` by passing the `Clock` struct.

## Dynamic initialisation check

We could add a function to cfgr which enables the backup domain and adds something to clocks to indicate that that has been done. Then, the `RTC` would check wether this value is set. I'd say this is a bad solution, we should avoid runtime errors wherever possible.

# Incomplete implementation
The current implementation does not support changing the prescaler or clock speed which I think can be added later.

Does anyone have any thoughts on this? which solution do you prefer for initialisation?