### PR TITLE
Add support for the ADC preripheral

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,6 +1,7 @@
 //! Makes an analog reading on channel 0 and prints it to itm
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 #![no_main]
 #![no_std]
 
@@ -24,7 +25,6 @@ use stm32f1xx_hal::prelude::*;
 use rt::ExceptionFrame;
 use stm32f1xx_hal::adc::{self};
 use embedded_hal::adc::OneShot;
-use cortex_m::asm;
 
 #[entry]
 fn main() -> ! {

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,64 @@
+//! Makes an analog reading on channel 0 and prints it to itm
+
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+extern crate cortex_m_rt as rt;
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal;
+extern crate embedded_hal;
+extern crate nb;
+
+use nb::block;
+
+use core::fmt::Write;
+
+use cortex_m_semihosting::hio;
+
+use stm32f1xx_hal::prelude::*;
+
+use rt::ExceptionFrame;
+use stm32f1xx_hal::adc::{self};
+use embedded_hal::adc::OneShot;
+use cortex_m::asm;
+
+#[entry]
+fn main() -> ! {
+    // Aquire the peripherals
+    let p = stm32f1xx_hal::stm32::Peripherals::take().unwrap();
+
+    let mut rcc = p.RCC.constrain();
+
+    // Set up the ADC
+    let mut adc = adc::Adc::adc2(p.ADC2, &mut rcc.apb2);
+
+    // Configure gpioa 0 as an analog input
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+    let mut pb1 = gpiob.pb1.into_analog(&mut gpiob.crl);
+
+
+    loop {
+        // Make a reading
+        let reading = block!(adc.read(&mut pb1)).unwrap();
+
+        // Aquire stdout and print the result of an analog reading
+        // NOTE: This will probably freeze when running without a debugger connected.
+        hio::hstdout().map(|mut hio| {
+            writeln!(hio, "reading: {}", reading).unwrap()
+        }).unwrap();
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,0 +1,176 @@
+use stm32::{ADC1, ADC2, ADC3};
+
+use hal::adc::{OneShot, Channel};
+
+use nb;
+use void::Void;
+
+use crate::gpio::Analog;
+use crate::gpio::gpioa::*;
+use crate::gpio::gpiob::*;
+
+use crate::rcc::APB2;
+
+pub struct Adc<ADC> {
+    adc: ADC,
+    current_channel: Option<u8>,
+}
+
+#[derive(Debug)]
+pub enum AdcReadError {
+    /// Another conversion is already being performed
+    Busy
+}
+
+macro_rules! hal {
+    ($(
+        $ADC:ident: (
+            $init:ident,
+            $adcxen:ident,
+            $adcxrst:ident
+        ),
+    )+) => {
+        $(
+            impl Adc<$ADC> {
+                /**
+                  Powers up $ADC and blocks until it's ready
+                */
+                pub fn $init(adc: $ADC, apb2: &mut APB2) -> Self {
+                    // Reset and enable the ADC peripheral
+                    apb2.rstr().modify(|_, w| w.$adcxrst().set_bit());
+                    apb2.rstr().modify(|_, w| w.$adcxrst().clear_bit());
+                    apb2.enr().modify(|_, w| w.$adcxen().set_bit());
+
+
+                    adc.cr2.modify(|_, w| { w.cont().clear_bit()});
+
+                    adc.cr2.modify(|_, w| { w.adon().set_bit()});
+
+                    // Wait for the ADC to be ready
+                    while adc.cr2.read().adon().bit_is_set() == false
+                        {}
+
+                    // Set the sequence length to 1
+                    // Amount of conversions n-1
+
+                    unsafe{adc.sqr1.modify(|_, w| w.l().bits(0))}
+                    Self {
+                        adc,
+                        current_channel: None,
+                    }
+                }
+
+                /**
+                  Make a single reading of the specified channel
+                */
+                fn read_raw(&mut self, channel: u8) -> nb::Result<u16, AdcReadError> {
+                    // Prevent starting another read before the previous one is done
+                    if let Some(previous_channel) = self.current_channel {
+                        if channel != previous_channel {
+                            return Err(nb::Error::Other(AdcReadError::Busy))
+                        }
+                    }
+
+                    // Select the channel to be converted
+                    if self.adc.sr.read().strt().bit() == false {
+                        unsafe{self.adc.sqr3.modify(|_, w| w.sq1().bits(channel))};
+                        // Set ADON
+                        // self.adc.cr2.modify(|_, w| w.swstart().set_bit());
+                        self.adc.cr2.modify(|_, w| { w.adon().set_bit()});
+                    }
+
+                    // Check if the data is ready for reading
+                    if self.adc.sr.read().eoc().bit() == false {
+                        self.current_channel = Some(channel);
+                        Err(nb::Error::WouldBlock)
+                    }
+                    else {
+                        self.current_channel = None;
+                        self.adc.sr.modify(|_, w| w.strt().clear_bit());
+                        Ok(self.adc.dr.read().data().bits())
+                    }
+                }
+            }
+
+
+            impl<PIN> OneShot<$ADC, u16, PIN> for Adc<$ADC>
+            where
+                PIN: Channel<$ADC, ID=u8>,
+            {
+                type Error = AdcReadError;
+
+                fn read(
+                    &mut self,
+                    _pin: &mut PIN
+                ) -> nb::Result<u16, Self::Error>
+                {
+                    self.read_raw(PIN::channel())
+                }
+            }
+        )+
+    }
+}
+
+
+macro_rules! analog_pin_impls {
+    ($($adc:ty: ($($pin:ident: $channel:expr),+)),+) =>
+    {
+        $(
+            $(
+                impl Channel<$adc> for $pin<Analog> {
+                    type ID = u8;
+
+                    fn channel() -> Self::ID {
+                        $channel
+                    }
+                }
+            )+
+        )+
+    }
+}
+
+
+hal! {
+    ADC1: (
+        adc1,
+        adc1en,
+        adc1rst
+    ),
+    ADC2: (
+        adc2,
+        adc2en,
+        adc2rst
+    ),
+    ADC3: (
+        adc3,
+        adc3en,
+        adc3rst
+    ),
+}
+
+analog_pin_impls!{
+    ADC1: (
+        PA0: 0,
+        PA1: 1,
+        PA2: 2,
+        PA3: 3,
+        PA4: 4,
+        PA5: 5,
+        PA6: 6,
+        PA7: 7,
+        PB0: 8,
+        PB1: 9
+    ),
+    ADC2: (
+        PA0: 0,
+        PA1: 1,
+        PA2: 2,
+        PA3: 3,
+        PA4: 4,
+        PA5: 5,
+        PA6: 6,
+        PA7: 7,
+        PB0: 8,
+        PB1: 9
+    )
+}

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,9 +1,10 @@
+//! Analog to digital converter
+
 use stm32::{ADC1, ADC2, ADC3};
 
 use hal::adc::{OneShot, Channel};
 
 use nb;
-use void::Void;
 
 use crate::gpio::Analog;
 use crate::gpio::gpioa::*;
@@ -32,9 +33,7 @@ macro_rules! hal {
     )+) => {
         $(
             impl Adc<$ADC> {
-                /**
-                  Powers up $ADC and blocks until it's ready
-                */
+                /// Powers up $ADC and blocks until it's ready
                 pub fn $init(adc: $ADC, apb2: &mut APB2) -> Self {
                     // Reset and enable the ADC peripheral
                     apb2.rstr().modify(|_, w| w.$adcxrst().set_bit());
@@ -60,9 +59,7 @@ macro_rules! hal {
                     }
                 }
 
-                /**
-                  Make a single reading of the specified channel
-                */
+                /// Make a single reading of the specified channel
                 fn read_raw(&mut self, channel: u8) -> nb::Result<u16, AdcReadError> {
                     // Prevent starting another read before the previous one is done
                     if let Some(previous_channel) = self.current_channel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,4 @@ pub mod serial;
 pub mod spi;
 pub mod time;
 pub mod timer;
+pub mod adc;


### PR DESCRIPTION
This is another port of a previous PR from the old repo https://github.com/japaric/stm32f103xx-hal/pull/114

The implementation is basically the same, with the only change being an added error type which is returned if a conversion on another channel is already happening when a read is started. As far as I know, this should fix all outstanding issues.

It would be nice to add static checks for this, but as mentioned in the previous PR, that would require changes to `embedded_hal`. I therefore propose that we merge this implementation and look into doing the check statically in the future.

CC: @tib888 This might be of interest to you, you had some very insightful comments in the previous PR