### PR TITLE
stm32f100 - compiles, but PWM broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 cache: cargo
 env:
 - MCU=stm32f103
+- MCU=stm32f100
 matrix:
   allow_failures:
     - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added patches for using STM32F100 chip (PWM disabled)
+
 ## [v0.2.0] - 2019-02-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ version = "1.0.87"
 [features]
 doc = []
 rt = ["stm32f1/rt"]
+stm32f100 = ["stm32f1/stm32f100"]
 stm32f103 = ["stm32f1/stm32f103"]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ cargo build --features stm32f103
 
 If no device is specified, the crate does not compile.
 
+Alternatively, adding the following to your project's `Cargo.toml` will target
+your chip without needing the `--features` argument:
+
+```
+[features]
+default = ["stm32f100", "rt"]
+rt = ["stm32f1xx-hal/rt"]
+stm32f100 = ["stm32f1xx-hal/stm32f100"]
+```
+
+## Supported Microcontrollers
+
+* STM32F100
+* STM32F103
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -10,20 +10,26 @@ This crate will eventually contain support for multiple microcontrollers in the
 stm32f1 family. Which specific microcontroller you want to build for has to be
 specified with a feature, for example `stm32f103`.
 
-```
-cargo build --features stm32f103
-```
+If no microcontroller is specified, the crate will not compile.
 
-If no device is specified, the crate does not compile.
+### Building an Example
 
-Alternatively, adding the following to your project's `Cargo.toml` will target
-your chip without needing the `--features` argument:
+If you are compiling the crate on its own for development or running examples, 
+specify your microcontroller on the command line. For example:
 
 ```
-[features]
-default = ["stm32f100", "rt"]
-rt = ["stm32f1xx-hal/rt"]
-stm32f100 = ["stm32f1xx-hal/stm32f100"]
+cargo build --features stm32f103 --example led
+```
+
+### Using as a Dependency
+
+When using this crate as a dependency in your project, the microcontroller can 
+be specified as part of the `Cargo.toml` definition.
+
+```
+[dependencies.stm32f1xx-hal]
+version = "0.2.0"
+features = ["stm32f100", "rt"]
 ```
 
 ## Supported Microcontrollers

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -27,7 +27,12 @@ fn main() -> ! {
 
     let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
 
+    #[cfg(feature = "stm32f100")]
+    let mut led = gpioc.pc9.into_push_pull_output(&mut gpioc.crh);
+
+    #[cfg(feature = "stm32f103")]
     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+
     let mut delay = Delay::new(cp.SYST, clocks);
 
     loop {

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -20,7 +20,11 @@ fn main() -> ! {
     let mut rcc = p.RCC.constrain();
     let mut gpioc = p.GPIOC.split(&mut rcc.apb2);
 
-    gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+    #[cfg(feature = "stm32f100")]
+    gpioc.pc9.into_push_pull_output(&mut gpioc.crh).set_high();
+
+    #[cfg(feature = "stm32f103")]
+    gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_high();
 
     loop {}
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -530,8 +530,15 @@ gpio!(GPIOB, gpiob, gpioa, iopben, iopbrst, PBx, [
     PB15: (pb15, 15, Input<Floating>, CRH),
 ]);
 
+#[cfg(not(feature = "stm32f100"))]
 gpio!(GPIOC, gpioc, gpioa, iopcen, iopcrst, PCx, [
     PC13: (pc13, 13, Input<Floating>, CRH),
     PC14: (pc14, 14, Input<Floating>, CRH),
     PC15: (pc15, 15, Input<Floating>, CRH),
+]);
+
+#[cfg(feature = "stm32f100")]
+gpio!(GPIOC, gpioc, gpioa, iopcen, iopcrst, PCx, [
+    PC8: (pc8, 8, Input<Floating>, CRH),
+    PC9: (pc9, 9, Input<Floating>, CRH),
 ]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ extern crate void;
 
 pub extern crate stm32f1;
 
+#[cfg(feature = "stm32f100")]
+pub use stm32f1::stm32f100 as stm32;
+
 #[cfg(feature = "stm32f103")]
 pub use stm32f1::stm32f103 as stm32;
 
@@ -56,6 +59,7 @@ pub mod flash;
 pub mod gpio;
 pub mod i2c;
 pub mod prelude;
+#[cfg(not(feature = "stm32f100"))]
 pub mod pwm;
 pub mod qei;
 pub mod rcc;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,7 @@ pub use gpio::GpioExt as _stm32_hal_gpio_GpioExt;
 pub use hal::digital::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
 pub use hal::digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use hal::prelude::*;
+#[cfg(not(feature = "stm32f100"))]
 pub use pwm::PwmExt as _stm32_hal_pwm_PwmExt;
 pub use rcc::RccExt as _stm32_hal_rcc_RccExt;
 //pub use serial::ReadDma as _stm32_hal_serial_ReadDma;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -214,6 +214,7 @@ impl CFGR {
         assert!(pclk2 <= 72_000_000);
 
         // adjust flash wait states
+        #[cfg(not(feature = "stm32f100"))]
         unsafe {
             acr.acr().write(|w| {
                 w.latency().bits(if sysclk <= 24_000_000 {
@@ -261,6 +262,7 @@ impl CFGR {
         }
 
         // set prescalers and clock source
+        #[cfg(not(feature = "stm32f100"))]
         rcc.cfgr.modify(|_, w| unsafe {
             w.ppre2()
                 .bits(ppre2_bits)
@@ -270,6 +272,27 @@ impl CFGR {
                 .bits(hpre_bits)
                 .usbpre()
                 .bit(usbpre)
+                .sw()
+                .bits(if pllmul_bits.is_some() {
+                    // PLL
+                    0b10
+                } else if self.hse.is_some() {
+                    // HSE
+                    0b1
+                } else {
+                    // HSI
+                    0b0
+                })
+        });
+
+        #[cfg(feature = "stm32f100")]
+        rcc.cfgr.modify(|_, w| unsafe {
+            w.ppre2()
+                .bits(ppre2_bits)
+                .ppre1()
+                .bits(ppre1_bits)
+                .hpre()
+                .bits(hpre_bits)
                 .sw()
                 .bits(if pllmul_bits.is_some() {
                     // PLL

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -214,7 +214,7 @@ impl CFGR {
         assert!(pclk2 <= 72_000_000);
 
         // adjust flash wait states
-        #[cfg(not(feature = "stm32f100"))]
+        #[cfg(feature = "stm32f103")]
         unsafe {
             acr.acr().write(|w| {
                 w.latency().bits(if sysclk <= 24_000_000 {
@@ -262,7 +262,7 @@ impl CFGR {
         }
 
         // set prescalers and clock source
-        #[cfg(not(feature = "stm32f100"))]
+        #[cfg(feature = "stm32f103")]
         rcc.cfgr.modify(|_, w| unsafe {
             w.ppre2()
                 .bits(ppre2_bits)


### PR DESCRIPTION
Hi there!

This is a WIP pull request to support the STM32F100 which is on the valueline discovery board.

It looks like not all chips supported by `stm32f1` are supported by this HAL wrapper. Maybe they should be added to the `features` list in `Cargo.toml` as they become supported? 

I've added a `stm32f100` feature. PWM is disabled for the moment until I figure out how to fix the `.ccr()`-not-found problem.

A version of  `led.rs` on PC8 (with an `.set_high()` call that was missing) was tested and working. I'm going to have a look at timers and delays next. The ultimate goal is to be able to use this crate along with https://github.com/JohnDoneth/hd44780-driver

