### PR TITLE
Fix broken LED example (#26)

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,4 +1,9 @@
 //! Blinks an LED
+//!
+//! This assumes that a LED is connected to pc13 as is the case on the blue pill board.
+//!
+//! Note: Without additional hardware, PC13 should not be used to drive an LED, see page 5.1.2 of
+//! the reference manaual for an explanation. This is not an issue on the blue pill.
 
 #![deny(unsafe_code)]
 #![deny(warnings)]

--- a/examples/blinky_rtc.rs
+++ b/examples/blinky_rtc.rs
@@ -1,4 +1,10 @@
-//! Blinks an LED using the real time clock to time the blinks
+//! Blinks an LED
+//!
+//! This assumes that a LED is connected to pc13 as is the case on the blue pill board.
+//!
+//! Note: Without additional hardware, PC13 should not be used to drive a LED, see
+//! section 5.1.2 of the reference manaual for an explanation.
+//! This is not an issue on the blue pill.
 
 #![deny(unsafe_code)]
 #![deny(warnings)]

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
     gpioc.pc9.into_push_pull_output(&mut gpioc.crh).set_high();
 
     #[cfg(feature = "stm32f103")]
-    gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_high();
+    gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_low();
 
     loop {}
 }

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -1,4 +1,13 @@
 //! Turns the user LED on
+//!
+//! If compiled for the stm32f103, this assumes that an active low LED is connected to pc13 as
+//! is the case on the blue pill board.
+//!
+//! If compiled for the stm32f100, this assumes that an active high LED is connected to pc9
+//!
+//! Note: Without additional hardware, PC13 should not be used to drive a LED, see
+//! section 5.1.2 of the reference manaual for an explanation.
+//! This is not an issue on the blue pill.
 
 #![deny(unsafe_code)]
 #![deny(warnings)]


### PR DESCRIPTION
Fix for #26 

This seems to have been broken in #20 where the affected line was changed from `gpioc.pc13.into_push_pull_output(&mut gpioc.crh);` to `gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_high();`

I think explicitly calling `set_low` is better than the previous case since it's more explicit and as far as I know, we don't specify wether or not pins will be high or low after `into_push_pull_output`. Or was there a reason `set_low` wasn't explicitly called?