### PR TITLE
Improve example documentation

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -5,6 +5,13 @@
 //! Note: Without additional hardware, PC13 should not be used to drive an LED, see page 5.1.2 of
 //! the reference manaual for an explanation. This is not an issue on the blue pill.
 
+//! This example assumes that a LED is connected to PC13 which is where an LED is connected on the
+//! [blue_pill] board. If you have different hardware, you need to change which gpio pin is used.
+//!
+//! Note: PC13 can not source much current and should not be used to drive an LED directly.
+//!
+//! [blue_pill]: http://wiki.stm32duino.com/index.php?title=Blue_Pill
+
 #![deny(unsafe_code)]
 #![deny(warnings)]
 #![no_std]

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -47,12 +47,14 @@ fn main() -> ! {
     // Acquire the GPIOC peripheral
     let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
 
-    // Configure gpio C pin 13 as a push-pull output
+    // Configure gpio C pin 13 as a push-pull output. The `crh` register is passed to the function
+    // in order to configure the port. For pins 0-7, crl should be passed instead.
     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
     // Configure the syst timer to trigger an update every second
     let mut timer = Timer::syst(cp.SYST, 1.hz(), clocks);
+
+    // Wait for the timer to trigger an update and change the state of the LED
     loop {
-        // Wait until the timer triggers an update
         block!(timer.wait()).unwrap();
         led.set_high();
         block!(timer.wait()).unwrap();

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -23,25 +23,29 @@ use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
+    // Get access to the core peripherals from the cortex-m crate
     let cp = cortex_m::Peripherals::take().unwrap();
+    // Get access to the device specific peripherals from the peripheral access crate
     let dp = pac::Peripherals::take().unwrap();
 
+    // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+    // HAL structs
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();
 
-    // Try a different clock configuration
+    // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
+    // `clocks`
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
-    // let clocks = rcc.cfgr
-    //     .sysclk(64.mhz())
-    //     .pclk1(32.mhz())
-    //     .freeze(&mut flash.acr);
 
+    // Acquire the GPIOC peripheral
     let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
 
+    // Configure gpio C pin 13 as a push-pull output
     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
-    // Try a different timer (even SYST)
+    // Configure the syst timer to trigger an update every second
     let mut timer = Timer::syst(cp.SYST, 1.hz(), clocks);
     loop {
+        // Wait until the timer triggers an update
         block!(timer.wait()).unwrap();
         led.set_high();
         block!(timer.wait()).unwrap();

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -5,13 +5,6 @@
 //! Note: Without additional hardware, PC13 should not be used to drive an LED, see page 5.1.2 of
 //! the reference manaual for an explanation. This is not an issue on the blue pill.
 
-//! This example assumes that a LED is connected to PC13 which is where an LED is connected on the
-//! [blue_pill] board. If you have different hardware, you need to change which gpio pin is used.
-//!
-//! Note: PC13 can not source much current and should not be used to drive an LED directly.
-//!
-//! [blue_pill]: http://wiki.stm32duino.com/index.php?title=Blue_Pill
-
 #![deny(unsafe_code)]
 #![deny(warnings)]
 #![no_std]

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -22,16 +22,22 @@ use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
+    // Get access to the device specific peripherals from the peripheral access crate
     let p = pac::Peripherals::take().unwrap();
 
+    // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+    // HAL structs
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
 
+    // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
+    // `clocks`
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
+    // Prepare the alternate function I/O registers
     let mut afio = p.AFIO.constrain(&mut rcc.apb2);
 
-    // let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
+    // Prepare the GPIOB peripheral
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
 
     // USART1
@@ -47,9 +53,13 @@ fn main() -> ! {
     // let rx = gpioa.pa3;
 
     // USART3
+    // Configure pb10 as a push_pull output, this will be the tx pin
     let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
+    // Take ownership over pb11
     let rx = gpiob.pb11;
 
+    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // the registers are used to enable and configure the device.
     let serial = Serial::usart3(
         p.USART3,
         (tx, rx),
@@ -59,16 +69,21 @@ fn main() -> ! {
         &mut rcc.apb1,
     );
 
+    // Split the serial struct into a receiving and a transmitting part
     let (mut tx, mut rx) = serial.split();
 
     let sent = b'X';
 
+    // Write `X` and wait until the write is successful
     block!(tx.write(sent)).ok();
 
+    // Read the byte that was just sent. Blocks until the read is complete
     let received = block!(rx.read()).unwrap();
 
+    // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
 
+    // Trigger a breakpoint to allow us to inspect the values
     asm::bkpt();
 
     loop {}


### PR DESCRIPTION
As a step towards closing #37 I want to start improving the documentation of this crate and I think the examples are a good place to start. I added a bunch of comments to the blinky and serial examples which try to explain what each line in the example does.

I also improved the main crate documentation page by adding the blinky example to it and clarifying how to specify the crate as a dependency. I also kind of think we should do that to the readme since that's where people will first encounter the crate, is that a good idea?

I intend to give the rest of the examples similar treatment, but I would like some feedback on the two examples that are already done so I don't make the same misstakes in *all* of them :). I'm not sure if we should make all of them this verbose, especially for the things that are the same between all of them. What do you think?

PS: Turns out pressing enter when creating a PR sends the PR without warning which is why it didn't have a description at first :sweat_smile: 