### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ $ rustup target add thumbv7m-none-eabi
 # on another terminal
 $ openocd -f interface/$INTERFACE.cfg -f target/stm32f1x.cfg
 
-# flash and debug the "Hello, world" example
-$ cargo run --features $MICROCONTROLLER --example led
+# flash and debug the "Hello, world" example. Change stm32f103 to match your hardware
+$ cargo run --features stm32f103 --example hello
 ```
 
-`$INTERFACE` should be set based on your debugging hardware. If you are using an stlink V2, use
-`stlink-v2.cfg`. For more information, see the [embeddonomicon].
+`$INTERFACE` should be set based on your debugging hardware. If you are using
+an stlink V2, use `stlink-v2.cfg`. For more information, see the
+[embeddonomicon].
 
 [embeddonomicon]: https://rust-embedded.github.io/book/start/hardware.html
 
@@ -45,7 +46,7 @@ $ cargo run --features $MICROCONTROLLER --example led
 When using this crate as a dependency in your project, the microcontroller can 
 be specified as part of the `Cargo.toml` definition.
 
-```
+```toml
 [dependencies.stm32f1xx-hal]
 version = "0.2.0"
 features = ["stm32f100", "rt"]
@@ -53,7 +54,9 @@ features = ["stm32f100", "rt"]
 
 ## Blinky example
 
-The following example blinks an LED connected to pin PC13. For instructions on how set up a project and run the example, see the [documentation]
+The following example blinks an LED connected to pin PC13. For instructions on
+how set up a project and run the example, see the [documentation]. For more
+examples, see the [examples](examples) directory.
 
 [documentation]: https://docs.rs/stm32f1xx-hal/
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 
 [HAL]: https://crates.io/crates/embedded-hal
 
+[![crates.io](https://img.shields.io/crates/v/stm32f1xx-hal.svg)](https://crates.io/crates/stm32f1xx-hal)
+[![Released API docs](https://docs.rs/stm32f1xx-hal/badge.svg)](https://docs.rs/stm32f1xx-hal)
+
 ## Usage
 
-This crate will eventually contain support for multiple microcontrollers in the
+This crate supports multiple microcontrollers in the
 stm32f1 family. Which specific microcontroller you want to build for has to be
 specified with a feature, for example `stm32f103`.
 
@@ -14,7 +17,7 @@ If no microcontroller is specified, the crate will not compile.
 
 ### Building an Example
 
-If you are compiling the crate on its own for development or running examples, 
+If you are compiling the crate on its own for development or running examples,
 specify your microcontroller on the command line. For example:
 
 ```
@@ -36,6 +39,62 @@ features = ["stm32f100", "rt"]
 
 * STM32F100
 * STM32F103
+
+## Blinky example
+
+The following example blinks an LED connected to pin PC13. For instructions on how set up a project and run the example, see the [documentation]
+
+[documentation]: https://docs.rs/stm32f1xx-hal/
+
+```rust
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use nb::block;
+
+use stm32f1xx_hal::{
+    prelude::*,
+    pac,
+    timer::Timer,
+};
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    // Get access to the core peripherals from the cortex-m crate
+    let cp = cortex_m::Peripherals::take().unwrap();
+    // Get access to the device specific peripherals from the peripheral access crate
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+    // HAL structs
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    // Freeze the configuration of all the clocks in the system and store
+    // the frozen frequencies in `clocks`
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    // Acquire the GPIOC peripheral
+    let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
+
+    // Configure gpio C pin 13 as a push-pull output. The `crh` register is passed to the function
+    // in order to configure the port. For pins 0-7, crl should be passed instead.
+    let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+    // Configure the syst timer to trigger an update every second
+    let mut timer = Timer::syst(cp.SYST, 1.hz(), clocks);
+
+    // Wait for the timer to trigger an update and change the state of the LED
+    loop {
+        block!(timer.wait()).unwrap();
+        led.set_high();
+        block!(timer.wait()).unwrap();
+        led.set_low();
+    }
+}
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ fn main() -> ! {
 }
 ```
 
+
+## Trying out the examples
+
+```bash
+# on another terminal
+$ openocd -f interface/$INTERFACE.cfg -f target/stm32f1x.cfg
+
+# flash and debug the "Hello, world" example
+$ rustup target add thumbv7m-none-eabi
+$ cargo run --example hello
+```
+
+$INTERFACE should be set based on your debugging hardware. If you are using an stlink V2, use
+`stlink-v2.cfg`. For more information, see the [embeddonomicon].
+
+[embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
+
+
 ## Documentation
 
 The documentation can be found at [docs.rs](https://docs.rs/stm32f1xx-hal/).

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ If no microcontroller is specified, the crate will not compile.
 
 ### Supported Microcontrollers
 
-* stm32f100
-* stm32f103
+* `stm32f100`
+* `stm32f103`
 
 
 ### Trying out the examples

--- a/README.md
+++ b/README.md
@@ -15,14 +15,30 @@ specified with a feature, for example `stm32f103`.
 
 If no microcontroller is specified, the crate will not compile.
 
-### Building an Example
+### Supported Microcontrollers
 
-If you are compiling the crate on its own for development or running examples,
-specify your microcontroller on the command line. For example:
+* stm32f100
+* stm32f103
 
+
+### Trying out the examples
+
+```bash
+$ rustup target add thumbv7m-none-eabi
+
+# on another terminal
+$ openocd -f interface/$INTERFACE.cfg -f target/stm32f1x.cfg
+
+# flash and debug the "Hello, world" example
+$ cargo run --features $MICROCONTROLLER --example led
 ```
-cargo build --features stm32f103 --example led
-```
+
+`$INTERFACE` should be set based on your debugging hardware. If you are using an stlink V2, use
+`stlink-v2.cfg`. For more information, see the [embeddonomicon].
+
+[embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
+
+
 
 ### Using as a Dependency
 
@@ -34,11 +50,6 @@ be specified as part of the `Cargo.toml` definition.
 version = "0.2.0"
 features = ["stm32f100", "rt"]
 ```
-
-## Supported Microcontrollers
-
-* STM32F100
-* STM32F103
 
 ## Blinky example
 
@@ -95,24 +106,6 @@ fn main() -> ! {
     }
 }
 ```
-
-
-## Trying out the examples
-
-```bash
-# on another terminal
-$ openocd -f interface/$INTERFACE.cfg -f target/stm32f1x.cfg
-
-# flash and debug the "Hello, world" example
-$ rustup target add thumbv7m-none-eabi
-$ cargo run --example hello
-```
-
-$INTERFACE should be set based on your debugging hardware. If you are using an stlink V2, use
-`stlink-v2.cfg`. For more information, see the [embeddonomicon].
-
-[embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
-
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ cargo run --features $MICROCONTROLLER --example led
 `$INTERFACE` should be set based on your debugging hardware. If you are using an stlink V2, use
 `stlink-v2.cfg`. For more information, see the [embeddonomicon].
 
-[embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
+[embeddonomicon]: https://rust-embedded.github.io/book/start/hardware.html
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,11 @@
 //! $ cargo run --example hello
 //! ```
 //!
+//! $INTERFACE should be set based on your debugging hardware. If you are using an stlink V2, use
+//! `stlink-v2.cfg`. For more information, see the [embedonomicon].
+//!
+//! [embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
+//!
 //! ## Building an application (binary crate)
 //!
 //! Follow the [cortex-m-quickstart] instructions, add this crate as a dependency
@@ -48,8 +53,6 @@
 //!
 //!
 //! ```rust
-//! #![deny(unsafe_code)]
-//! #![deny(warnings)]
 //! #![no_std]
 //! #![no_main]
 //! 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@
 //!     // Get access to the device specific peripherals from the peripheral access crate
 //!     let dp = pac::Peripherals::take().unwrap();
 //! 
-//!     // Take ownership over the raw flash and rcc devices and convert them into the corresponding
-//!     // HAL structs
+//!     // Take ownership over the raw flash and rcc devices and convert them
+//!     // into the corresponding HAL structs
 //!     let mut flash = dp.FLASH.constrain();
 //!     let mut rcc = dp.RCC.constrain();
 //! 
@@ -82,8 +82,9 @@
 //!     // Acquire the GPIOC peripheral
 //!     let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
 //! 
-//!     // Configure gpio C pin 13 as a push-pull output. The `crh` register is passed to the function
-//!     // in order to configure the port. For pins 0-7, crl should be passed instead.
+//!     // Configure gpio C pin 13 as a push-pull output. The `crh` register is
+//!     // passed to the function in order to configure the port. For pins 0-7,
+//!     // crl should be passed instead.
 //!     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
 //!     // Configure the syst timer to trigger an update every second
 //!     let mut timer = Timer::syst(cp.SYST, 1.hz(), clocks);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,20 +10,16 @@
 //! ## Trying out the examples
 //!
 //! ```bash
-//! $ git clone https://github.com/stm32-rs/stm32f1xx-hal
-//!
 //! # on another terminal
 //! $ openocd -f interface/$INTERFACE.cfg -f target/stm32f1x.cfg
 //!
 //! # flash and debug the "Hello, world" example
-//! # NOTE examples assume 64KB of Flash and 20KB of RAM; you can tweak layout in memory.x
-//! $ cd stm32f1xx-hal
 //! $ rustup target add thumbv7m-none-eabi
 //! $ cargo run --example hello
 //! ```
 //!
 //! $INTERFACE should be set based on your debugging hardware. If you are using an stlink V2, use
-//! `stlink-v2.cfg`. For more information, see the [embedonomicon].
+//! `stlink-v2.cfg`. For more information, see the [embeddonomicon].
 //!
 //! [embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,22 +7,6 @@
 //!
 //! # Usage
 //!
-//! ## Trying out the examples
-//!
-//! ```bash
-//! # on another terminal
-//! $ openocd -f interface/$INTERFACE.cfg -f target/stm32f1x.cfg
-//!
-//! # flash and debug the "Hello, world" example
-//! $ rustup target add thumbv7m-none-eabi
-//! $ cargo run --example hello
-//! ```
-//!
-//! $INTERFACE should be set based on your debugging hardware. If you are using an stlink V2, use
-//! `stlink-v2.cfg`. For more information, see the [embeddonomicon].
-//!
-//! [embedonomicon]: https://rust-embedded.github.io/book/start/hardware.html
-//!
 //! ## Building an application (binary crate)
 //!
 //! Follow the [cortex-m-quickstart] instructions, add this crate as a dependency


### PR DESCRIPTION
Followup to #37 which improves the README.

- Add badges for docs.rs and crates.io
- Add example code
- Some wording and stylistic changes
- Prevent line wrap in docs code sample

I also moved the example usage instructions from lib.rs to README because I feel like they are more relevant here. I go to docs.rs when i've added the crate as a dependency and want to use it and to the repo when I first encounter the crate which is when i'd want to run the examples.

I kind of feel like the blinky example is a bit out of place, but I also like having some sort of code sample in the README...