### PR TITLE
Fix warnings

### DIFF
--- a/src/dma.rs
+++ b/src/dma.rs
@@ -108,6 +108,7 @@ pub struct R;
 /// Write transfer
 pub struct W;
 
+/*
 macro_rules! dma {
     ($($DMAX:ident: ($dmaX:ident, $dmaXen:ident, $dmaXrst:ident, {
         $($CX:ident: (
@@ -318,7 +319,6 @@ macro_rules! dma {
     }
 }
 
-/*
 dma! {
     DMA1: (dma1, dma1en, dma1rst, {
         C1: (

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -428,8 +428,8 @@ macro_rules! hal {
                             self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
                             self.send_addr_and_wait(addr, true)?;
 
-                            let (mut first_bytes, mut last_two_bytes) = buffer.split_at_mut(buffer_len - 3);
-                            for mut byte in first_bytes {
+                            let (first_bytes, last_two_bytes) = buffer.split_at_mut(buffer_len - 3);
+                            for byte in first_bytes {
                                 self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
                                 busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne), self.data_timeout)?;
                                 *byte = self.nb.i2c.dr.read().dr().bits();

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -53,6 +53,8 @@ pub struct AHB {
 }
 
 impl AHB {
+    // TODO remove `allow`
+    #[allow(dead_code)]
     pub(crate) fn enr(&mut self) -> &rcc::AHBENR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).ahbenr }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -38,17 +38,14 @@
 
 use core::marker::PhantomData;
 use core::ptr;
-use core::sync::atomic::{self, Ordering};
 
-use cast::u16;
-use crate::hal;
 use nb;
 use crate::pac::{USART1, USART2, USART3};
 use void::Void;
 
 use crate::afio::MAPR;
 //use crate::dma::{dma1, CircBuffer, Static, Transfer, R, W};
-use crate::dma::{CircBuffer, Static, Transfer, R, W};
+// use crate::dma::{CircBuffer, Static, Transfer, R, W};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::{Alternate, Floating, Input, PushPull};

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2,7 +2,6 @@
 
 use core::ptr;
 
-use crate::hal;
 pub use crate::hal::spi::{Mode, Phase, Polarity};
 use nb;
 use crate::pac::{SPI1, SPI2};


### PR DESCRIPTION
Another small PR before releasing to crates, hopefully you don't mind the spam but code review tends to be useful.

I commented out the things which are clearly DMA related and removed the rest of the unused code.

I'm a bit confused as to why the `mut` aren't required in `i2c.rs` but if the compiler is fine with it, I suppose it's not an issue.