### PR TITLE
Enable PWM for stm32f100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- enable PWM on stm32f100
+
 ## [v0.2.1] - 2019-03-08
 
 ### Added
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for real time clock
 - Add patches for using STM32F100 chip (PWM disabled)
 
-### Change
+### Changed
 
 - Improve documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,6 @@ pub mod flash;
 pub mod gpio;
 pub mod i2c;
 pub mod prelude;
-#[cfg(not(feature = "stm32f100"))]
 pub mod pwm;
 pub mod pwm_input;
 pub mod qei;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,7 +6,6 @@ pub use crate::gpio::GpioExt as _stm32_hal_gpio_GpioExt;
 pub use crate::hal::digital::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
 pub use crate::hal::digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use crate::hal::prelude::*;
-#[cfg(not(feature = "stm32f100"))]
 pub use crate::pwm::PwmExt as _stm32_hal_pwm_PwmExt;
 pub use crate::rcc::RccExt as _stm32_hal_rcc_RccExt;
 //pub use crate::serial::ReadDma as _stm32_hal_serial_ReadDma;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -245,7 +245,10 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> u16 {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr1().bits() }
                 }
 
                 fn get_max_duty(&self) -> u16 {
@@ -253,7 +256,10 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: u16) {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty)) }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1().bits(duty)) }
                 }
             }
 
@@ -269,7 +275,10 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> u16 {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr2().bits() }
                 }
 
                 fn get_max_duty(&self) -> u16 {
@@ -277,7 +286,10 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: u16) {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty)) }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr2().bits(duty)) }
                 }
             }
 
@@ -293,7 +305,10 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> u16 {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr3().bits() }
                 }
 
                 fn get_max_duty(&self) -> u16 {
@@ -301,7 +316,10 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: u16) {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty)) }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr3().bits(duty)) }
                 }
             }
 
@@ -317,7 +335,10 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> u16 {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr4().bits() }
                 }
 
                 fn get_max_duty(&self) -> u16 {
@@ -325,7 +346,10 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: u16) {
+                    #[cfg(feature = "stm32f103")]
                     unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty)) }
+                    #[cfg(not(feature = "stm32f103"))]
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr4().bits(duty)) }
                 }
             }
         )+


### PR DESCRIPTION
Crate stm32f1 handles CCRx registers differently for stm32f103
and for all the other supported MCU families. As a result,
naming conventions to access CCRx fields  are not the same.

Enable support for PWM on stm32f100 using 'feature' switch to
distinguish between stm32f103 and other MCUs at compile time
and use the correct CCRx field names.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>