### PR TITLE
Add feature to support stm32f101 chip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 cache: cargo
 env:
 - MCU=stm32f103
+- MCU=stm32f101
 - MCU=stm32f100
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add feature for using STM32F101 chip
 - Add gpio pins corresponding to LQFP-100 package
 - Implement `core::fmt::Write` for `serial::Tx`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ version = "1.0.87"
 doc = []
 rt = ["stm32f1/rt"]
 stm32f100 = ["stm32f1/stm32f100"]
+stm32f101 = ["stm32f1/stm32f101"]
 stm32f103 = ["stm32f1/stm32f103"]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If no microcontroller is specified, the crate will not compile.
 ### Supported Microcontrollers
 
 * `stm32f100`
+* `stm32f101`
 * `stm32f103`
 
 

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -29,6 +29,9 @@ fn main() -> ! {
     #[cfg(feature = "stm32f100")]
     let mut led = gpioc.pc9.into_push_pull_output(&mut gpioc.crh);
 
+    #[cfg(feature = "stm32f101")]
+    let mut led = gpioc.pc9.into_push_pull_output(&mut gpioc.crh);
+
     #[cfg(feature = "stm32f103")]
     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
 

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -33,6 +33,9 @@ fn main() -> ! {
     #[cfg(feature = "stm32f100")]
     gpioc.pc9.into_push_pull_output(&mut gpioc.crh).set_high();
 
+    #[cfg(feature = "stm32f101")]
+    gpioc.pc9.into_push_pull_output(&mut gpioc.crh).set_high();
+
     #[cfg(feature = "stm32f103")]
     gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_low();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,9 @@ use embedded_hal as hal;
 #[cfg(feature = "stm32f100")]
 pub use stm32f1::stm32f100 as pac;
 
+#[cfg(feature = "stm32f101")]
+pub use stm32f1::stm32f101 as pac;
+
 #[cfg(feature = "stm32f103")]
 pub use stm32f1::stm32f103 as pac;
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -296,7 +296,10 @@ impl CFGR {
                 })
         });
 
-        #[cfg(feature = "stm32f100")]
+        #[cfg(any(
+                feature = "stm32f100",
+                feature = "stm32f101"
+        ))]
         rcc.cfgr.modify(|_, w| unsafe {
             w.ppre2()
                 .bits(ppre2_bits)

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -8,7 +8,13 @@ use cortex_m::peripheral::SYST;
 use nb;
 use void::Void;
 
-use crate::rcc::{Clocks, APB1, APB2};
+use crate::rcc::{Clocks, APB1};
+#[cfg(any(
+    feature = "stm32f100",
+    feature = "stm32f103",
+))]
+use crate::rcc::APB2;
+
 use crate::time::Hertz;
 
 /// Associated clocks with timers
@@ -176,8 +182,15 @@ macro_rules! hal {
     }
 }
 
+#[cfg(any(
+    feature = "stm32f100",
+    feature = "stm32f103",
+))]
 hal! {
     TIM1: (tim1, tim1en, tim1rst, APB2),
+}
+
+hal! {
     TIM2: (tim2, tim2en, tim2rst, APB1),
     TIM3: (tim3, tim3en, tim3rst, APB1),
     TIM4: (tim4, tim4en, tim4rst, APB1),


### PR DESCRIPTION
Add feature to enable support for stm32f101 chips.
Note that TIM1 is excluded since only stm32f100
and stm32f103 chips contain advanced timers.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>