### PR TITLE
RFC: add support for ADC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Implement ADC example
 - Implement ADC embedded_hal traits
 - Implement ADC clock configuration
 - Add feature for using STM32F101 chip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Implement ADC embedded_hal traits
 - Implement ADC clock configuration
 - Add feature for using STM32F101 chip
 - Add gpio pins corresponding to LQFP-100 package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Implement ADC clock configuration
 - Add feature for using STM32F101 chip
 - Add gpio pins corresponding to LQFP-100 package
 - Implement `core::fmt::Write` for `serial::Tx`

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,76 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+extern crate cortex_m_rt as rt;
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate embedded_hal;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal;
+
+use core::fmt::Write;
+use cortex_m_semihosting::hio;
+use stm32f1xx_hal::prelude::*;
+
+use rt::ExceptionFrame;
+use stm32f1xx_hal::adc;
+
+#[entry]
+fn main() -> ! {
+    // Aquire peripherals
+    let p = stm32f1xx_hal::stm32::Peripherals::take().unwrap();
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    // Configure ADC clocks
+    // Default value is the slowest possible ADC clock: PCLK2 / 8. Meanwhile ADC
+    // clock is configurable. So its frequency may be tweaked to meet certain
+    // practical needs. User specified value is be approximated using supported
+    // prescaler values 2/4/6/8.
+    let clocks = rcc.cfgr.adcclk(2.mhz()).freeze(&mut flash.acr);
+    hio::hstdout()
+        .map(|mut hio| writeln!(hio, "adc freq: {}", clocks.adcclk().0).unwrap())
+        .unwrap();
+
+    // Setup ADC
+    let mut adc1 = adc::Adc::adc1(p.ADC1, &mut rcc.apb2);
+
+    #[cfg(feature = "stm32f103")]
+    let mut adc2 = adc::Adc::adc2(p.ADC2, &mut rcc.apb2);
+
+    // Setup GPIOB
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+
+    // Configure pb0, pb1 as an analog input
+    let mut ch0 = gpiob.pb0.into_analog(&mut gpiob.crl);
+
+    #[cfg(feature = "stm32f103")]
+    let mut ch1 = gpiob.pb1.into_analog(&mut gpiob.crl);
+
+    loop {
+        let data: u16 = adc1.read(&mut ch0).unwrap();
+        hio::hstdout()
+            .map(|mut hio| writeln!(hio, "adc1: {}", data).unwrap())
+            .unwrap();
+
+        #[cfg(feature = "stm32f103")]
+        {
+            let data1: u16 = adc2.read(&mut ch1).unwrap();
+            hio::hstdout()
+                .map(|mut hio| writeln!(hio, "adc2: {}", data1).unwrap())
+                .unwrap();
+        }
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -4,14 +4,17 @@ use embedded_hal::adc::{Channel, OneShot};
 
 use crate::gpio::Analog;
 use crate::gpio::{gpioa, gpiob, gpioc};
-
 use crate::rcc::APB2;
 
 use crate::stm32::ADC1;
+#[cfg(any(
+    feature = "stm32f103",
+))]
+use crate::stm32::ADC2;
 
-/// Analog to Digital converter interface
-pub struct Adc {
-    rb: ADC1,
+/// ADC configuration
+pub struct Adc<ADC> {
+    rb: ADC,
     sample_time: AdcSampleTime,
     align: AdcAlign,
 }
@@ -41,7 +44,7 @@ pub enum AdcSampleTime {
 }
 
 impl AdcSampleTime {
-    /// Get the default sample time (currently 239.5 cycles)
+    /// Get the default sample time (currently 28.5 cycles)
     pub fn default() -> Self {
         AdcSampleTime::T_28
     }
@@ -63,16 +66,16 @@ impl From<AdcSampleTime> for u8 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-/// ADC Result Alignment
+/// ADC data register alignment
 pub enum AdcAlign {
-    /// Left aligned results (most significant bits)
-    Left,
-    /// Right aligned results (least significant bits)
+    /// Right alignment of output data
     Right,
+    /// Left alignment of output data
+    Left,
 }
 
 impl AdcAlign {
-    /// Get the default alignment (currently right aligned)
+    /// Default: right alignment
     pub fn default() -> Self {
         AdcAlign::Right
     }
@@ -81,8 +84,8 @@ impl AdcAlign {
 impl From<AdcAlign> for u8 {
     fn from(val: AdcAlign) -> Self {
         match val {
-            AdcAlign::Left => 1,
             AdcAlign::Right => 0,
+            AdcAlign::Left => 1,
         }
     }
 }
@@ -90,16 +93,16 @@ impl From<AdcAlign> for u8 {
 impl From<AdcAlign> for bool {
     fn from(val: AdcAlign) -> Self {
         match val {
-            AdcAlign::Left => true,
             AdcAlign::Right => false,
+            AdcAlign::Left => true,
         }
     }
 }
 
 macro_rules! adc_pins {
-    ($($pin:ty => $chan:expr),+ $(,)*) => {
+    ($ADC:ident, $($pin:ty => $chan:expr),+ $(,)*) => {
         $(
-            impl Channel<Adc> for $pin {
+            impl Channel<$ADC> for $pin {
                 type ID = u8;
 
                 fn channel() -> u8 { $chan }
@@ -108,7 +111,7 @@ macro_rules! adc_pins {
     };
 }
 
-adc_pins!(
+adc_pins!(ADC1,
     gpioa::PA0<Analog> => 0_u8,
     gpioa::PA1<Analog> => 1_u8,
     gpioa::PA2<Analog> => 2_u8,
@@ -127,211 +130,274 @@ adc_pins!(
     gpioc::PC5<Analog> => 15_u8,
 );
 
-/// A stored ADC config, can be restored by using the `Adc::restore_cfg` method
+#[cfg(any(
+    feature = "stm32f103",
+))]
+adc_pins!(ADC2,
+    gpioa::PA0<Analog> => 0_u8,
+    gpioa::PA1<Analog> => 1_u8,
+    gpioa::PA2<Analog> => 2_u8,
+    gpioa::PA3<Analog> => 3_u8,
+    gpioa::PA4<Analog> => 4_u8,
+    gpioa::PA5<Analog> => 5_u8,
+    gpioa::PA6<Analog> => 6_u8,
+    gpioa::PA7<Analog> => 7_u8,
+    gpiob::PB0<Analog> => 8_u8,
+    gpiob::PB1<Analog> => 9_u8,
+    gpioc::PC0<Analog> => 10_u8,
+    gpioc::PC1<Analog> => 11_u8,
+    gpioc::PC2<Analog> => 12_u8,
+    gpioc::PC3<Analog> => 13_u8,
+    gpioc::PC4<Analog> => 14_u8,
+    gpioc::PC5<Analog> => 15_u8,
+);
+
+/// Stored ADC config can be restored using the `Adc::restore_cfg` method
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StoredConfig(AdcSampleTime, AdcAlign);
 
-impl Adc {
-    /// Init a new Adc
-    ///
-    /// Sets all configurable parameters to defaults and performs a boot time
-    /// calibration. As such this method may take an appreciable time to run.
-    pub fn new(adc: ADC1, apb2: &mut APB2) -> Self {
-        let mut s = Self {
-            rb: adc,
-            sample_time: AdcSampleTime::default(),
-            align: AdcAlign::default(),
-        };
-        s.enable_clock(apb2);
-        s.power_down();
-        s.reset(apb2);
-        s.setup_oneshot();
-        s.power_up();
-        s.calibrate();
-        s
-    }
+macro_rules! adc_hal {
+    ($(
+        $ADC:ident: (
+            $init:ident,
+            $adcxen:ident,
+            $adcxrst:ident
+        ),
+    )+) => {
+        $(
 
-    /// Saves a copy of the current ADC config
-    pub fn save_cfg(&mut self) -> StoredConfig {
-        StoredConfig(self.sample_time, self.align)
-    }
+            impl Adc<$ADC> {
+                /// Init a new Adc
+                ///
+                /// Sets all configurable parameters to one-shot defaults,
+                /// performs a boot-time calibration.
+                pub fn $init(adc: $ADC, apb2: &mut APB2) -> Self {
+                    let mut s = Self {
+                        rb: adc,
+                        sample_time: AdcSampleTime::default(),
+                        align: AdcAlign::default(),
+                    };
+                    s.enable_clock(apb2);
+                    s.power_down();
+                    s.reset(apb2);
+                    s.setup_oneshot();
+                    s.power_up();
+                    s.calibrate();
+                    s
+                }
 
-    /// Restores a stored config
-    pub fn restore_cfg(&mut self, cfg: StoredConfig) {
-        self.sample_time = cfg.0;
-        self.align = cfg.1;
-    }
+                /// Save current ADC config
+                pub fn save_cfg(&mut self) -> StoredConfig {
+                    StoredConfig(self.sample_time, self.align)
+                }
 
-    /// Resets the ADC config to default, returning the existing config as
-    /// a stored config.
-    pub fn default_cfg(&mut self) -> StoredConfig {
-        let cfg = self.save_cfg();
-        self.sample_time = AdcSampleTime::default();
-        self.align = AdcAlign::default();
-        cfg
-    }
+                /// Restore saved ADC config
+                pub fn restore_cfg(&mut self, cfg: StoredConfig) {
+                    self.sample_time = cfg.0;
+                    self.align = cfg.1;
+                }
 
-    /// Set the Adc sampling time
-    ///
-    /// Options can be found in [AdcSampleTime](crate::adc::AdcSampleTime).
-    pub fn set_sample_time(&mut self, t_samp: AdcSampleTime) {
-        self.sample_time = t_samp;
-    }
+                /// Reset the ADC config to default, return existing config
+                pub fn default_cfg(&mut self) -> StoredConfig {
+                    let cfg = self.save_cfg();
+                    self.sample_time = AdcSampleTime::default();
+                    self.align = AdcAlign::default();
+                    cfg
+                }
 
-    /// Set the Adc result alignment
-    ///
-    /// Options can be found in [AdcAlign](crate::adc::AdcAlign).
-    pub fn set_align(&mut self, align: AdcAlign) {
-        self.align = align;
-    }
+                /// Set ADC sampling time
+                ///
+                /// Options can be found in [AdcSampleTime](crate::adc::AdcSampleTime).
+                pub fn set_sample_time(&mut self, t_samp: AdcSampleTime) {
+                    self.sample_time = t_samp;
+                }
 
-    /// Returns the largest possible sample value for the current settings
-    pub fn max_sample(&self) -> u16 {
-        match self.align {
-            AdcAlign::Left => u16::max_value(),
-            AdcAlign::Right => (1 << 12) - 1,
-        }
-    }
+                /// Set the Adc result alignment
+                ///
+                /// Options can be found in [AdcAlign](crate::adc::AdcAlign).
+                pub fn set_align(&mut self, align: AdcAlign) {
+                    self.align = align;
+                }
 
-    fn power_up(&mut self) {
-        self.rb.cr2.modify(|_, w| w.adon().set_bit());
-    }
+                /// Returns the largest possible sample value for the current settings
+                pub fn max_sample(&self) -> u16 {
+                    match self.align {
+                        AdcAlign::Left => u16::max_value(),
+                        AdcAlign::Right => (1 << 12) - 1,
+                    }
+                }
 
-    fn power_down(&mut self) {
-        self.rb.cr2.modify(|_, w| w.adon().clear_bit());
-    }
+                fn power_up(&mut self) {
+                    self.rb.cr2.modify(|_, w| w.adon().set_bit());
+                }
 
-    fn reset(&mut self, apb2: &mut APB2) {
-        apb2.rstr().modify(|_, w| w.adc1rst().set_bit());
-        apb2.rstr().modify(|_, w| w.adc1rst().clear_bit());
-    }
+                fn power_down(&mut self) {
+                    self.rb.cr2.modify(|_, w| w.adon().clear_bit());
+                }
 
-    fn enable_clock(&mut self, apb2: &mut APB2) {
-        apb2.enr().modify(|_, w| w.adc1en().set_bit());
-    }
+                fn reset(&mut self, apb2: &mut APB2) {
+                    apb2.rstr().modify(|_, w| w.$adcxrst().set_bit());
+                    apb2.rstr().modify(|_, w| w.$adcxrst().clear_bit());
+                }
 
-    fn calibrate(&mut self) {
-        /* reset calibration */
-        self.rb.cr2.modify(|_, w| w.rstcal().set_bit());
-        while self.rb.cr2.read().rstcal().bit_is_set() {}
+                fn enable_clock(&mut self, apb2: &mut APB2) {
+                    apb2.enr().modify(|_, w| w.$adcxen().set_bit());
+                }
 
-        /* calibrate */
-        self.rb.cr2.modify(|_, w| w.cal().set_bit());
-        while self.rb.cr2.read().cal().bit_is_set() {}
-    }
+                fn calibrate(&mut self) {
+                    /* reset calibration */
+                    self.rb.cr2.modify(|_, w| w.rstcal().set_bit());
+                    while self.rb.cr2.read().rstcal().bit_is_set() {}
 
-    fn setup_oneshot(&mut self) {
-        self.rb.cr2.modify(|_, w| w.cont().clear_bit());
-        self.rb.cr2.modify(|_, w| w.exttrig().set_bit());
-        self.rb.cr2.modify(|_, w| unsafe { w.extsel().bits(0b111) });
+                    /* calibrate */
+                    self.rb.cr2.modify(|_, w| w.cal().set_bit());
+                    while self.rb.cr2.read().cal().bit_is_set() {}
+                }
 
-        self.rb.cr1.modify(|_, w| w.scan().clear_bit());
-        self.rb.cr1.modify(|_, w| w.discen().set_bit());
+                fn setup_oneshot(&mut self) {
+                    self.rb.cr2.modify(|_, w| w.cont().clear_bit());
+                    self.rb.cr2.modify(|_, w| w.exttrig().set_bit());
+                    self.rb.cr2.modify(|_, w| unsafe { w.extsel().bits(0b111) });
 
-        self.rb.sqr1.modify(|_, w| unsafe { w.l().bits(0b0) });
-    }
+                    self.rb.cr1.modify(|_, w| w.scan().clear_bit());
+                    self.rb.cr1.modify(|_, w| w.discen().set_bit());
 
-    fn set_chan_smps(&mut self, chan: u8) {
-        match chan {
-            0 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp0().bits(self.sample_time.into()) }),
-            1 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp1().bits(self.sample_time.into()) }),
-            2 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp2().bits(self.sample_time.into()) }),
-            3 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp3().bits(self.sample_time.into()) }),
-            4 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp4().bits(self.sample_time.into()) }),
-            5 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp5().bits(self.sample_time.into()) }),
-            6 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp6().bits(self.sample_time.into()) }),
-            7 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp7().bits(self.sample_time.into()) }),
-            8 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp8().bits(self.sample_time.into()) }),
-            9 => self
-                .rb
-                .smpr2
-                .modify(|_, w| unsafe { w.smp9().bits(self.sample_time.into()) }),
+                    self.rb.sqr1.modify(|_, w| unsafe { w.l().bits(0b0) });
+                }
 
-            10 => self
-                .rb
-                .smpr1
-                .modify(|_, w| unsafe { w.smp10().bits(self.sample_time.into()) }),
-            11 => self
-                .rb
-                .smpr1
-                .modify(|_, w| unsafe { w.smp11().bits(self.sample_time.into()) }),
-            12 => self
-                .rb
-                .smpr1
-                .modify(|_, w| unsafe { w.smp12().bits(self.sample_time.into()) }),
-            13 => self
-                .rb
-                .smpr1
-                .modify(|_, w| unsafe { w.smp13().bits(self.sample_time.into()) }),
-            14 => self
-                .rb
-                .smpr1
-                .modify(|_, w| unsafe { w.smp14().bits(self.sample_time.into()) }),
-            15 => self
-                .rb
-                .smpr1
-                .modify(|_, w| unsafe { w.smp15().bits(self.sample_time.into()) }),
+                fn set_chan_smps(&mut self, chan: u8) {
+                    match chan {
+                        0 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp0().bits(self.sample_time.into()) }),
+                        1 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp1().bits(self.sample_time.into()) }),
+                        2 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp2().bits(self.sample_time.into()) }),
+                        3 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp3().bits(self.sample_time.into()) }),
+                        4 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp4().bits(self.sample_time.into()) }),
+                        5 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp5().bits(self.sample_time.into()) }),
+                        6 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp6().bits(self.sample_time.into()) }),
+                        7 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp7().bits(self.sample_time.into()) }),
+                        8 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp8().bits(self.sample_time.into()) }),
+                        9 => self
+                            .rb
+                            .smpr2
+                            .modify(|_, w| unsafe { w.smp9().bits(self.sample_time.into()) }),
 
-            _ => unreachable!(),
-        }
+                        10 => self
+                            .rb
+                            .smpr1
+                            .modify(|_, w| unsafe { w.smp10().bits(self.sample_time.into()) }),
+                        11 => self
+                            .rb
+                            .smpr1
+                            .modify(|_, w| unsafe { w.smp11().bits(self.sample_time.into()) }),
+                        12 => self
+                            .rb
+                            .smpr1
+                            .modify(|_, w| unsafe { w.smp12().bits(self.sample_time.into()) }),
+                        13 => self
+                            .rb
+                            .smpr1
+                            .modify(|_, w| unsafe { w.smp13().bits(self.sample_time.into()) }),
+                        14 => self
+                            .rb
+                            .smpr1
+                            .modify(|_, w| unsafe { w.smp14().bits(self.sample_time.into()) }),
+                        15 => self
+                            .rb
+                            .smpr1
+                            .modify(|_, w| unsafe { w.smp15().bits(self.sample_time.into()) }),
 
-        return;
-    }
+                        _ => unreachable!(),
+                    }
 
-    fn convert(&mut self, chan: u8) -> u16 {
-        self.rb.cr2.modify(|_, w| w.align().bit(self.align.into()));
-        self.set_chan_smps(chan);
-        self.rb.sqr3.modify(|_, w| unsafe { w.sq1().bits(chan) });
+                    return;
+                }
 
-        // ADC start conversion of regular sequence
-        self.rb.cr2.modify(|_, w| w.swstart().set_bit());
-        while self.rb.cr2.read().swstart().bit_is_set() {}
-        // ADC wait for conversion results
-        while self.rb.sr.read().eoc().bit_is_clear() {}
+                fn convert(&mut self, chan: u8) -> u16 {
+                    self.rb.cr2.modify(|_, w| w.align().bit(self.align.into()));
+                    self.set_chan_smps(chan);
+                    self.rb.sqr3.modify(|_, w| unsafe { w.sq1().bits(chan) });
 
-        let res = self.rb.dr.read().data().bits();
-        res
+                    // ADC start conversion of regular sequence
+                    self.rb.cr2.modify(|_, w| w.swstart().set_bit());
+                    while self.rb.cr2.read().swstart().bit_is_set() {}
+                    // ADC wait for conversion results
+                    while self.rb.sr.read().eoc().bit_is_clear() {}
+
+                    let res = self.rb.dr.read().data().bits();
+                    res
+                }
+            }
+
+            impl<WORD, PIN> OneShot<$ADC, WORD, PIN> for Adc<$ADC>
+            where
+                WORD: From<u16>,
+                PIN: Channel<$ADC, ID = u8>,
+                {
+                    type Error = ();
+
+                    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+                        self.power_up();
+                        let res = self.convert(PIN::channel());
+                        self.power_down();
+                        Ok(res.into())
+                    }
+                }
+
+        )+
     }
 }
 
-impl<WORD, PIN> OneShot<Adc, WORD, PIN> for Adc
-where
-    WORD: From<u16>,
-    PIN: Channel<Adc, ID = u8>,
-{
-    type Error = ();
+#[cfg(any(
+    feature = "stm32f100",
+    feature = "stm32f101",
+))]
+adc_hal! {
+    ADC1: (
+        adc1,
+        adc1en,
+        adc1rst
+    ),
+}
 
-    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
-        self.power_up();
-        let res = self.convert(PIN::channel());
-        self.power_down();
-        Ok(res.into())
-    }
+#[cfg(any(
+    feature = "stm32f103",
+))]
+adc_hal! {
+    ADC1: (
+        adc1,
+        adc1en,
+        adc1rst
+    ),
+    ADC2: (
+        adc2,
+        adc2en,
+        adc2rst
+    ),
 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,0 +1,337 @@
+//! # API for the Analog to Digital converter
+
+use embedded_hal::adc::{Channel, OneShot};
+
+use crate::gpio::Analog;
+use crate::gpio::{gpioa, gpiob, gpioc};
+
+use crate::rcc::APB2;
+
+use crate::stm32::ADC1;
+
+/// Analog to Digital converter interface
+pub struct Adc {
+    rb: ADC1,
+    sample_time: AdcSampleTime,
+    align: AdcAlign,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(non_camel_case_types)]
+/// ADC sampling time
+///
+/// Options for the sampling time, each is T + 0.5 ADC clock cycles.
+pub enum AdcSampleTime {
+    /// 1.5 cycles sampling time
+    T_1,
+    /// 7.5 cycles sampling time
+    T_7,
+    /// 13.5 cycles sampling time
+    T_13,
+    /// 28.5 cycles sampling time
+    T_28,
+    /// 41.5 cycles sampling time
+    T_41,
+    /// 55.5 cycles sampling time
+    T_55,
+    /// 71.5 cycles sampling time
+    T_71,
+    /// 239.5 cycles sampling time
+    T_239,
+}
+
+impl AdcSampleTime {
+    /// Get the default sample time (currently 239.5 cycles)
+    pub fn default() -> Self {
+        AdcSampleTime::T_28
+    }
+}
+
+impl From<AdcSampleTime> for u8 {
+    fn from(val: AdcSampleTime) -> Self {
+        match val {
+            AdcSampleTime::T_1 => 0,
+            AdcSampleTime::T_7 => 1,
+            AdcSampleTime::T_13 => 2,
+            AdcSampleTime::T_28 => 3,
+            AdcSampleTime::T_41 => 4,
+            AdcSampleTime::T_55 => 5,
+            AdcSampleTime::T_71 => 6,
+            AdcSampleTime::T_239 => 7,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+/// ADC Result Alignment
+pub enum AdcAlign {
+    /// Left aligned results (most significant bits)
+    Left,
+    /// Right aligned results (least significant bits)
+    Right,
+}
+
+impl AdcAlign {
+    /// Get the default alignment (currently right aligned)
+    pub fn default() -> Self {
+        AdcAlign::Right
+    }
+}
+
+impl From<AdcAlign> for u8 {
+    fn from(val: AdcAlign) -> Self {
+        match val {
+            AdcAlign::Left => 1,
+            AdcAlign::Right => 0,
+        }
+    }
+}
+
+impl From<AdcAlign> for bool {
+    fn from(val: AdcAlign) -> Self {
+        match val {
+            AdcAlign::Left => true,
+            AdcAlign::Right => false,
+        }
+    }
+}
+
+macro_rules! adc_pins {
+    ($($pin:ty => $chan:expr),+ $(,)*) => {
+        $(
+            impl Channel<Adc> for $pin {
+                type ID = u8;
+
+                fn channel() -> u8 { $chan }
+            }
+        )+
+    };
+}
+
+adc_pins!(
+    gpioa::PA0<Analog> => 0_u8,
+    gpioa::PA1<Analog> => 1_u8,
+    gpioa::PA2<Analog> => 2_u8,
+    gpioa::PA3<Analog> => 3_u8,
+    gpioa::PA4<Analog> => 4_u8,
+    gpioa::PA5<Analog> => 5_u8,
+    gpioa::PA6<Analog> => 6_u8,
+    gpioa::PA7<Analog> => 7_u8,
+    gpiob::PB0<Analog> => 8_u8,
+    gpiob::PB1<Analog> => 9_u8,
+    gpioc::PC0<Analog> => 10_u8,
+    gpioc::PC1<Analog> => 11_u8,
+    gpioc::PC2<Analog> => 12_u8,
+    gpioc::PC3<Analog> => 13_u8,
+    gpioc::PC4<Analog> => 14_u8,
+    gpioc::PC5<Analog> => 15_u8,
+);
+
+/// A stored ADC config, can be restored by using the `Adc::restore_cfg` method
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct StoredConfig(AdcSampleTime, AdcAlign);
+
+impl Adc {
+    /// Init a new Adc
+    ///
+    /// Sets all configurable parameters to defaults and performs a boot time
+    /// calibration. As such this method may take an appreciable time to run.
+    pub fn new(adc: ADC1, apb2: &mut APB2) -> Self {
+        let mut s = Self {
+            rb: adc,
+            sample_time: AdcSampleTime::default(),
+            align: AdcAlign::default(),
+        };
+        s.enable_clock(apb2);
+        s.power_down();
+        s.reset(apb2);
+        s.setup_oneshot();
+        s.power_up();
+        s.calibrate();
+        s
+    }
+
+    /// Saves a copy of the current ADC config
+    pub fn save_cfg(&mut self) -> StoredConfig {
+        StoredConfig(self.sample_time, self.align)
+    }
+
+    /// Restores a stored config
+    pub fn restore_cfg(&mut self, cfg: StoredConfig) {
+        self.sample_time = cfg.0;
+        self.align = cfg.1;
+    }
+
+    /// Resets the ADC config to default, returning the existing config as
+    /// a stored config.
+    pub fn default_cfg(&mut self) -> StoredConfig {
+        let cfg = self.save_cfg();
+        self.sample_time = AdcSampleTime::default();
+        self.align = AdcAlign::default();
+        cfg
+    }
+
+    /// Set the Adc sampling time
+    ///
+    /// Options can be found in [AdcSampleTime](crate::adc::AdcSampleTime).
+    pub fn set_sample_time(&mut self, t_samp: AdcSampleTime) {
+        self.sample_time = t_samp;
+    }
+
+    /// Set the Adc result alignment
+    ///
+    /// Options can be found in [AdcAlign](crate::adc::AdcAlign).
+    pub fn set_align(&mut self, align: AdcAlign) {
+        self.align = align;
+    }
+
+    /// Returns the largest possible sample value for the current settings
+    pub fn max_sample(&self) -> u16 {
+        match self.align {
+            AdcAlign::Left => u16::max_value(),
+            AdcAlign::Right => (1 << 12) - 1,
+        }
+    }
+
+    fn power_up(&mut self) {
+        self.rb.cr2.modify(|_, w| w.adon().set_bit());
+    }
+
+    fn power_down(&mut self) {
+        self.rb.cr2.modify(|_, w| w.adon().clear_bit());
+    }
+
+    fn reset(&mut self, apb2: &mut APB2) {
+        apb2.rstr().modify(|_, w| w.adc1rst().set_bit());
+        apb2.rstr().modify(|_, w| w.adc1rst().clear_bit());
+    }
+
+    fn enable_clock(&mut self, apb2: &mut APB2) {
+        apb2.enr().modify(|_, w| w.adc1en().set_bit());
+    }
+
+    fn calibrate(&mut self) {
+        /* reset calibration */
+        self.rb.cr2.modify(|_, w| w.rstcal().set_bit());
+        while self.rb.cr2.read().rstcal().bit_is_set() {}
+
+        /* calibrate */
+        self.rb.cr2.modify(|_, w| w.cal().set_bit());
+        while self.rb.cr2.read().cal().bit_is_set() {}
+    }
+
+    fn setup_oneshot(&mut self) {
+        self.rb.cr2.modify(|_, w| w.cont().clear_bit());
+        self.rb.cr2.modify(|_, w| w.exttrig().set_bit());
+        self.rb.cr2.modify(|_, w| unsafe { w.extsel().bits(0b111) });
+
+        self.rb.cr1.modify(|_, w| w.scan().clear_bit());
+        self.rb.cr1.modify(|_, w| w.discen().set_bit());
+
+        self.rb.sqr1.modify(|_, w| unsafe { w.l().bits(0b0) });
+    }
+
+    fn set_chan_smps(&mut self, chan: u8) {
+        match chan {
+            0 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp0().bits(self.sample_time.into()) }),
+            1 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp1().bits(self.sample_time.into()) }),
+            2 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp2().bits(self.sample_time.into()) }),
+            3 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp3().bits(self.sample_time.into()) }),
+            4 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp4().bits(self.sample_time.into()) }),
+            5 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp5().bits(self.sample_time.into()) }),
+            6 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp6().bits(self.sample_time.into()) }),
+            7 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp7().bits(self.sample_time.into()) }),
+            8 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp8().bits(self.sample_time.into()) }),
+            9 => self
+                .rb
+                .smpr2
+                .modify(|_, w| unsafe { w.smp9().bits(self.sample_time.into()) }),
+
+            10 => self
+                .rb
+                .smpr1
+                .modify(|_, w| unsafe { w.smp10().bits(self.sample_time.into()) }),
+            11 => self
+                .rb
+                .smpr1
+                .modify(|_, w| unsafe { w.smp11().bits(self.sample_time.into()) }),
+            12 => self
+                .rb
+                .smpr1
+                .modify(|_, w| unsafe { w.smp12().bits(self.sample_time.into()) }),
+            13 => self
+                .rb
+                .smpr1
+                .modify(|_, w| unsafe { w.smp13().bits(self.sample_time.into()) }),
+            14 => self
+                .rb
+                .smpr1
+                .modify(|_, w| unsafe { w.smp14().bits(self.sample_time.into()) }),
+            15 => self
+                .rb
+                .smpr1
+                .modify(|_, w| unsafe { w.smp15().bits(self.sample_time.into()) }),
+
+            _ => unreachable!(),
+        }
+
+        return;
+    }
+
+    fn convert(&mut self, chan: u8) -> u16 {
+        self.rb.cr2.modify(|_, w| w.align().bit(self.align.into()));
+        self.set_chan_smps(chan);
+        self.rb.sqr3.modify(|_, w| unsafe { w.sq1().bits(chan) });
+
+        // ADC start conversion of regular sequence
+        self.rb.cr2.modify(|_, w| w.swstart().set_bit());
+        while self.rb.cr2.read().swstart().bit_is_set() {}
+        // ADC wait for conversion results
+        while self.rb.sr.read().eoc().bit_is_clear() {}
+
+        let res = self.rb.dr.read().data().bits();
+        res
+    }
+}
+
+impl<WORD, PIN> OneShot<Adc, WORD, PIN> for Adc
+where
+    WORD: From<u16>,
+    PIN: Channel<Adc, ID = u8>,
+{
+    type Error = ();
+
+    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        self.power_up();
+        let res = self.convert(PIN::channel());
+        self.power_down();
+        Ok(res.into())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub use stm32f1::stm32f103 as pac;
 pub use crate::pac as device;
 pub use crate::pac as stm32;
 
+pub mod adc;
 pub mod afio;
 pub mod backup_domain;
 pub mod bb;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,7 @@ pub use crate::dma::DmaChannel as _stm32_hal_dma_DmaChannel;
 pub use crate::dma::DmaExt as _stm32_hal_dma_DmaExt;
 pub use crate::flash::FlashExt as _stm32_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32_hal_gpio_GpioExt;
+pub use crate::hal::adc::OneShot as _embedded_hal_adc_OneShot;
 pub use crate::hal::digital::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
 pub use crate::hal::digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use crate::hal::prelude::*;


### PR DESCRIPTION
Summary
-------------

This PR adds the following bits:
- implement ADC clock configuration in rcc module
- implement ADC support, including multiple ADC blocks
- add ADC example

This PR is based on #19 by @TheZoq2 . As per request from @therealprof , it has been reworked following stm32f0x ADC implementation. Besides, some implementation details follow stm32f4x ADC implementation.

Limitations
-------------
1. Basic one-shot support only: similar to what we have in stm32f0x, but not in stm32f4xx
2. No dual ADC mode support when 2 ADC blocks are available
3. No fool proof against using the same channel in two ADC blocks.

Implementation notes
-------------
1. Split of ADC implementation to simplify review
To simplify review, ADC implementation is split into the following two parts: 
   - 2nd commit: implement one-shot support for ADC1 only
   - 3rd commit: use rust macros to support multiple ADC blocks (including gpio channel assignment) w/o functional changes to ADC handling code
2. Hardware support
Current implementation enables the following ADC blocks:
   - the only available ADC1 for both stm32f100 and stm32f101
   - both ADC1 and ADC2 available on medium-density stm32f103 chips
3. Support for a more capable stm32f10x chips
Note that XL-density stm32f103 chips support ADC3 as well. Besides, gpio-to-channel mapping is different on those chips. Meanwhile it can be also embraced by suggested implementation. For instance, something like the following should work: 
```
#[cfg(feature = "stm32f103XL")]
adc_pins!(ADC1,
    gpioa::PA0<Analog> => 0_u8,
    gpioa::PA1<Analog> => 1_u8,
    gpioa::PA2<Analog> => 2_u8,
    gpioa::PA3<Analog> => 3_u8,
    gpioa::PA4<Analog> => 4_u8,
    gpioa::PA5<Analog> => 5_u8,
    gpioa::PA6<Analog> => 6_u8,
    gpioa::PA7<Analog> => 7_u8,
    gpiob::PB0<Analog> => 8_u8,
    gpiob::PB1<Analog> => 9_u8,
    gpioc::PC0<Analog> => 10_u8,
    gpioc::PC1<Analog> => 11_u8,
    gpioc::PC2<Analog> => 12_u8,
    gpioc::PC3<Analog> => 13_u8,
    gpioc::PC4<Analog> => 14_u8,
    gpioc::PC5<Analog> => 15_u8,
);

#[cfg(feature = "stm32f103XL")]
adc_pins!(ADC3,
    gpioa::PA0<Analog> => 0_u8,
    gpioa::PA1<Analog> => 1_u8,
    gpioa::PA2<Analog> => 2_u8,
    gpioa::PA3<Analog> => 3_u8,
    gpioa::PA4<Analog> => 4_u8,
    gpioa::PA5<Analog> => 5_u8,
    gpioa::PA6<Analog> => 6_u8,
    gpioa::PA7<Analog> => 7_u8,
    gpiob::PB0<Analog> => 8_u8,
    gpiob::PB1<Analog> => 9_u8,
    gpioc::PC0<Analog> => 10_u8,
    gpioc::PC1<Analog> => 11_u8,
    gpioc::PC2<Analog> => 12_u8,
    gpioc::PC3<Analog> => 13_u8,
    gpioc::PC4<Analog> => 14_u8,
    gpioc::PC5<Analog> => 15_u8,
);

#[cfg(feature = "stm32f103XL")]
adc_pins!(ADC3,
    gpioa::PA0<Analog> => 0_u8,
    gpioa::PA1<Analog> => 1_u8,
    gpioa::PA2<Analog> => 2_u8,
    gpioa::PA3<Analog> => 3_u8,
    gpiof::PF6<Analog> => 4_u8,
    gpiof::PF7<Analog> => 5_u8,
    gpiof::PF8<Analog> => 6_u8,
    gpiof::PF9<Analog> => 7_u8,
    gpiof::PF10<Analog> => 8_u8,
    gpioc::PC0<Analog> => 10_u8,
    gpioc::PC1<Analog> => 11_u8,
    gpioc::PC2<Analog> => 12_u8,
    gpioc::PC3<Analog> => 13_u8,
);

#[cfg(feature = "stm32f103XL")]
adc_hal! {
    ADC1: (
        adc1,
        adc1en,
        adc1rst
    ),
    ADC2: (
        adc2,
        adc2en,
        adc2rst
    ),
    ADC3: (
        adc3,
        adc3en,
        adc3rst
    ),
}
```