### PR TITLE
Adds some simple methods to Timer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add feature for using STM32F101 chip
 - Add gpio pins corresponding to LQFP-100 package
 - Implement `core::fmt::Write` for `serial::Tx`
-- Add methods `stop`, `release` and `clear_uif` to `Timer` (`clear_uif` only on `Timer<TIMX>`)
+- Add methods `stop`, `release` and `clear_update_interrupt_flag` to `Timer` (`clear_update_interrupt_flag` does not apply to `Timer<SYST>`)
+- Add timer interrupt example using RTFM
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add feature for using STM32F101 chip
 - Add gpio pins corresponding to LQFP-100 package
 - Implement `core::fmt::Write` for `serial::Tx`
+- Add methods `stop`, `release` and `clear_uif` to `Timer` (`clear_uif` only on `Timer<TIMX>`)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ version = "0.2.1"
 [package.metadata.docs.rs]
 features = ["stm32f103", "rt"]
 
+[[example]]
+name = "timer-interrupt-rtfm"
+required-features = ["rt"]
+
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
@@ -36,7 +40,7 @@ version = "0.2.2"
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.1"
 panic-itm = "0.4.0"
-# cortex-m-rtfm = "0.3.1"
+cortex-m-rtfm = "0.4.2"
 cortex-m-semihosting = "0.3.2"
 enc28j60 = "0.2.1"
 heapless = "0.4.1"

--- a/examples/timer-interrupt-rtfm.rs
+++ b/examples/timer-interrupt-rtfm.rs
@@ -1,0 +1,99 @@
+//! Uses the timer interrupt to blink a led with different frequencies.
+//!
+//! This assumes that a LED is connected to pc13 as is the case on the blue pill board.
+//!
+//! Note: Without additional hardware, PC13 should not be used to drive an LED, see page 5.1.2 of
+//! the reference manaual for an explanation. This is not an issue on the blue pill.
+
+#![no_std]
+#![no_main]
+
+// you can put a breakpoint on `rust_begin_unwind` to catch panics
+extern crate panic_halt;
+
+use cortex_m::asm::wfi;
+use rtfm::app;
+
+use stm32f1xx_hal::{
+    prelude::*,
+    pac,
+    timer::{ Timer, Event },
+    gpio::{ gpioc::PC13, State, Output, PushPull },
+};
+
+#[app(device = stm32f1xx_hal::pac)]
+const APP: () = {
+
+    static mut LED: PC13<Output<PushPull>> = ();
+    static mut TIMER_HANDLER: Timer<pac::TIM1> = ();
+    static mut LED_STATE: bool = false;
+    
+    #[init]
+    fn init() -> init::LateResources {
+
+        // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+        // HAL structs
+        let mut flash = device.FLASH.constrain();
+        let mut rcc = device.RCC.constrain();
+
+        // Freeze the configuration of all the clocks in the system and store the frozen frequencies
+        // in `clocks`
+        let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+        // Acquire the GPIOC peripheral
+        let mut gpioc = device.GPIOC.split(&mut rcc.apb2);
+
+        // Configure gpio C pin 13 as a push-pull output. The `crh` register is passed to the
+        // function in order to configure the port. For pins 0-7, crl should be passed instead
+        let led = gpioc.pc13.into_push_pull_output_with_state(&mut gpioc.crh, State::High);
+        // Configure the syst timer to trigger an update every second and enables interrupt
+        let mut timer = Timer::tim1(device.TIM1, 1.hz(), clocks, &mut rcc.apb2);
+        timer.listen(Event::Update);
+
+        // Init the static resources to use them later through RTFM
+        init::LateResources {
+            LED: led,
+            TIMER_HANDLER: timer,
+        }
+    }
+
+    #[idle]
+    fn idle() -> ! {
+
+        loop {
+            // Waits for interrupt
+            wfi();
+        }
+    }
+
+    #[interrupt(priority = 1, resources = [LED, TIMER_HANDLER, LED_STATE])]
+    fn TIM1_UP() {
+        // Depending on the application, you could want to delegate some of the work done here to
+        // the idle task if you want to minimize the latency of interrupts with same priority (if
+        // you have any). That could be done with some kind of machine state, etc.
+
+        // Count used to change the timer update frequency
+        static mut COUNT: u8 = 0;
+
+        if *resources.LED_STATE {
+            // Uses resourcers managed by rtfm to turn led off (on bluepill)
+            resources.LED.set_high();
+            *resources.LED_STATE = false;
+        } else {
+            resources.LED.set_low();
+            *resources.LED_STATE = true;
+        }
+        *COUNT += 1;
+
+        if *COUNT == 4 {
+            // Changes timer update frequency
+            resources.TIMER_HANDLER.start(2.hz());
+        } else if *COUNT == 12 {
+            resources.TIMER_HANDLER.start(1.hz());
+            *COUNT = 0;
+        }
+
+        // Clears the update flag
+        resources.TIMER_HANDLER.clear_update_interrupt_flag();
+    }
+};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -133,6 +133,22 @@ macro_rules! hal {
                         Event::Update => self.tim.dier.write(|w| w.uie().clear_bit()),
                     }
                 }
+
+                /// Stops the timer
+                pub fn stop(&mut self) {
+                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                }
+
+                /// Clears Update Interrupt Flag
+                pub fn clear_uif(&mut self) {
+                    self.tim.sr.modify(|_, w| w.uif().clear_bit());
+                }
+
+                /// Releases the TIM Peripheral
+                pub fn release(self) -> ($TIMX, Clocks) {
+                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                    (self.tim, self.clocks)
+                }
             }
 
             impl CountDown for Timer<$TIMX> {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -78,7 +78,7 @@ impl Timer<SYST> {
         self.tim.disable_counter();
     }
 
-    /// Releases the SYST and clocks
+    /// Releases the SYST
     pub fn release(mut self) -> SYST {
         self.tim.disable_counter();
         self.tim
@@ -155,9 +155,9 @@ macro_rules! hal {
                     self.tim.sr.modify(|_, w| w.uif().clear_bit());
                 }
 
-                /// Releases the TIM Peripheral and clocks
-                pub fn release(self) -> $TIMX {
-                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                /// Releases the TIM Peripheral
+                pub fn release(mut self) -> $TIMX {
+                    self.stop();
                     self.tim
                 }
             }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -72,6 +72,17 @@ impl Timer<SYST> {
             Event::Update => self.tim.disable_interrupt(),
         }
     }
+
+    /// Stops the timer
+    pub fn stop(&mut self) {
+        self.tim.disable_counter();
+    }
+
+    /// Releases the SYST and clocks
+    pub fn release(mut self) -> (SYST, Clocks) {
+        self.tim.disable_counter();
+        (self.tim, self.clocks)
+    }
 }
 
 impl CountDown for Timer<SYST> {
@@ -144,7 +155,7 @@ macro_rules! hal {
                     self.tim.sr.modify(|_, w| w.uif().clear_bit());
                 }
 
-                /// Releases the TIM Peripheral
+                /// Releases the TIM Peripheral and clocks
                 pub fn release(self) -> ($TIMX, Clocks) {
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
                     (self.tim, self.clocks)

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -151,7 +151,7 @@ macro_rules! hal {
                 }
 
                 /// Clears Update Interrupt Flag
-                pub fn clear_uif(&mut self) {
+                pub fn clear_update_interrupt_flag(&mut self) {
                     self.tim.sr.modify(|_, w| w.uif().clear_bit());
                 }
 
@@ -188,7 +188,7 @@ macro_rules! hal {
                     // The above line raises an update event which will indicate
                     // that the timer is already finished. Since this is not the case,
                     // it should be cleared
-                    self.tim.sr.modify(|_, w| w.uif().clear_bit());
+                    self.clear_update_interrupt_flag();
 
                     // start counter
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
@@ -198,7 +198,7 @@ macro_rules! hal {
                     if self.tim.sr.read().uif().bit_is_clear() {
                         Err(nb::Error::WouldBlock)
                     } else {
-                        self.tim.sr.modify(|_, w| w.uif().clear_bit());
+                        self.clear_update_interrupt_flag();
                         Ok(())
                     }
                 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -80,7 +80,7 @@ impl Timer<SYST> {
 
     /// Releases the SYST
     pub fn release(mut self) -> SYST {
-        self.tim.disable_counter();
+        self.stop();
         self.tim
     }
 }
@@ -170,7 +170,7 @@ macro_rules! hal {
                     T: Into<Hertz>,
                 {
                     // pause
-                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                    self.stop();
 
                     let frequency = timeout.into().0;
                     let timer_clock = $TIMX::get_clk(&self.clocks);

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -79,9 +79,9 @@ impl Timer<SYST> {
     }
 
     /// Releases the SYST and clocks
-    pub fn release(mut self) -> (SYST, Clocks) {
+    pub fn release(mut self) -> SYST {
         self.tim.disable_counter();
-        (self.tim, self.clocks)
+        self.tim
     }
 }
 
@@ -156,9 +156,9 @@ macro_rules! hal {
                 }
 
                 /// Releases the TIM Peripheral and clocks
-                pub fn release(self) -> ($TIMX, Clocks) {
+                pub fn release(self) -> $TIMX {
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
-                    (self.tim, self.clocks)
+                    self.tim
                 }
             }
 


### PR DESCRIPTION
Very simple methods but potentially useful, especially the one to clear the update interrupt flag.
I was having trouble using the timer with interrupts, because the Timer takes ownership of the registers and the `tim` field is private.
Sorry if I got something wrong, I am kinda new to rust.