### PR TITLE
RFC: docs and examples for custom selection of PWM channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add methods `stop`, `release` and `clear_update_interrupt_flag` to `Timer` (`clear_update_interrupt_flag` does not apply to `Timer<SYST>`)
 - Add timer interrupt example using RTFM
 - Implement IndependentWatchdog for the IWDG peripheral
+- Remove all PWM channel configurations except 'all the channels for default remapping' configuratons
+- Update PWM documentation: clarify custom selection of channels
+- Add PWM example for custom selection of channels
 
 ### Changed
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,4 +1,4 @@
-//! Testing PWM output
+//! Testing PWM output for pre-defined pin combination: all pins for default mapping
 
 #![deny(unsafe_code)]
 #![no_main]

--- a/examples/pwm_custom.rs
+++ b/examples/pwm_custom.rs
@@ -1,4 +1,4 @@
-//! Testing PWM output
+//! Testing PWM output for custom pin combinations
 
 #![deny(unsafe_code)]
 #![no_main]
@@ -18,8 +18,19 @@ use stm32f1xx_hal::{
 
 use cortex_m_rt::entry;
 
-struct MyChannels(PB4<Alternate<PushPull>>, PB5<Alternate<PushPull>>);
+// Using PB5 channel for TIM3 PWM output 
+// struct MyChannels(PB5<Alternate<PushPull>>);
+// impl Pins<TIM3>  for MyChannels {
+//     const REMAP: u8 = 0b10;
+//     const C1: bool = false;
+//     const C2: bool = true;
+//     const C3: bool = false;
+//     const C4: bool = false;
+//     type Channels = Pwm<TIM3, C2>;
+// }
 
+// Using PB4 and PB5 channels for TIM3 PWM output
+struct MyChannels(PB4<Alternate<PushPull>>, PB5<Alternate<PushPull>>);
 impl Pins<TIM3> for MyChannels {
     const REMAP: u8 = 0b10;
     const C1: bool = true;

--- a/examples/pwm_custom.rs
+++ b/examples/pwm_custom.rs
@@ -1,0 +1,80 @@
+//! Testing PWM output
+
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use cortex_m::asm;
+use stm32f1xx_hal::{
+    gpio::gpiob::{PB4, PB5},
+    gpio::{Alternate, PushPull},
+    pac,
+    prelude::*,
+    pwm::{Pins, Pwm, C1, C2},
+    stm32::TIM3,
+};
+
+use cortex_m_rt::entry;
+
+struct MyChannels(PB4<Alternate<PushPull>>, PB5<Alternate<PushPull>>);
+
+impl Pins<TIM3> for MyChannels {
+    const REMAP: u8 = 0b10;
+    const C1: bool = true;
+    const C2: bool = true;
+    const C3: bool = false;
+    const C4: bool = false;
+    type Channels = (Pwm<TIM3, C1>, Pwm<TIM3, C2>);
+}
+
+#[entry]
+fn main() -> ! {
+    let p = pac::Peripherals::take().unwrap();
+
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut afio = p.AFIO.constrain(&mut rcc.apb2);
+
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+
+    // TIM3
+    let p0 = gpiob.pb4.into_alternate_push_pull(&mut gpiob.crl);
+    let p1 = gpiob.pb5.into_alternate_push_pull(&mut gpiob.crl);
+
+    let mut pwm = p.TIM3.pwm(
+        MyChannels(p0, p1),
+        &mut afio.mapr,
+        1.khz(),
+        clocks,
+        &mut rcc.apb1,
+    );
+
+    let max = pwm.0.get_max_duty();
+
+    pwm.0.enable();
+    pwm.1.enable();
+
+    // full
+    pwm.0.set_duty(max);
+    pwm.1.set_duty(max);
+
+    asm::bkpt();
+
+    // dim
+    pwm.1.set_duty(max / 4);
+
+    asm::bkpt();
+
+    // zero
+    pwm.0.set_duty(0);
+    pwm.1.set_duty(0);
+
+    asm::bkpt();
+
+    loop {}
+}

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -7,7 +7,7 @@
 
   ## Usage for pre-defined channel combinations
 
-  Crate defines only basic channel combinations for default AFIO remappings,
+  This crate only defines basic channel combinations for default AFIO remappings,
   where all the channels are enabled. Start by setting all the pins for the
   timer you want to use to alternate push pull pins:
 
@@ -81,8 +81,8 @@
   }
   ```
 
-  REMAP value and channel pins should specified according to the stm32f1xx specification,
-  namely according to the chapter about AFIO and timer alternate function remappings.
+  REMAP value and channel pins should be specified according to the stm32f1xx specification,
+  e.g. the section 9.3.7 "Timer alternate function remapping" in RM0008 Rev 20.
 
   Finally, here is a complete example for two channels:
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -196,7 +196,7 @@ impl Pins<TIM4>
         PB9<Alternate<PushPull>>,
     )
 {
-    const REMAP: u8 = 0b00;
+    const REMAP: u8 = 0b0;
     const C1: bool = true;
     const C2: bool = true;
     const C3: bool = true;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -5,7 +5,7 @@
   pulse width modulated signals on some pins. The timers support up to 4 simultaneous
   pwm outputs in separate `Channels`
 
-  ## Usage
+  ## Usage for pre-defined channel combinations
 
   Start by setting all the pins for the timer you want to use to alternate
   push pull pins. The `Pins` trait shows the mapping between timers, output pins
@@ -31,15 +31,68 @@
     let (c0, c1, c2, c3) = device.TIM2.pwm(
         pins,
         &mut afio.mapr,
-        100.hz()
+        100.hz(),
         clocks,
-        &mut rcc.apb
+        &mut rcc.apb1
     );
 
     // Set the duty cycle of channel 0 to 50%
     c0.set_duty(c0.get_max_duty() / 2);
     // PWM outputs are disabled by default
     c0.enable()
+  ```
+
+  ## Usage for custom channel combinations
+
+  Note that crate itself defines only basic channel combinations for default AFIO remapppings,
+  where all the channels are enabled. Meanwhile it is possible to configure PWM for any custom
+  selection of channels. For this purpose the 'Pins' trait should be implemented for the chosen
+  combination of channels and AFIO remappings. However minor additional efforts are needed since
+  it is not possible to implement a foreign trait for a foreign  type. The trick is to use
+  the newtype pattern. Here is an example:
+
+  ```
+  use stm32f1xx_hal::stm32::TIM3;
+  use stm32f1xx_hal::gpio::gpiob::{PB4, PB5};
+  use stm32f1xx_hal::gpio::{Alternate, PushPull};
+  use stm32f1xx_hal::pwm::{Pins, Pwm, C1, C2, C3, C4};
+
+  struct MyChannels(PB4<Alternate<PushPull>>,  PB5<Alternate<PushPull>>);
+
+  impl Pins<TIM3> for MyChannels
+  {
+    const REMAP: u8 = 0b10; // use TIM3 AFIO remapping for PB4, PB5, PB0, PB1 pins
+    const C1: bool = true;
+    const C2: bool = true;
+    const C3: bool = false;
+    const C4: bool = false;
+    type Channels = (Pwm<TIM3, C1>, Pwm<TIM3, C2>)
+  }
+
+  ...
+
+  let gpiob = ..; // Set up and split GPIOB
+
+  let p1 = gpiob.pb4.into_alternate_push_pull(&mut gpiob.crl);
+  let p2 = gpiob.pb5.into_alternate_push_pull(&mut gpiob.crl);
+
+  ...
+
+  let device: pac::Peripherals = ..;
+
+  let (c1, c2) = device.TIM3.pwm(
+      MyChannels(p1, p2),
+      &mut afio.mapr,
+      100.hz(),
+      clocks,
+      &mut rcc.apb1
+  );
+
+  // Set the duty cycle of channel 0 to 50%
+  c1.set_duty(c1.get_max_duty() / 2);
+  // PWM outputs are disabled by default
+  c1.enable()
+
   ```
 */
 
@@ -84,15 +137,6 @@ impl Pins<TIM2>
     type Channels = (Pwm<TIM2, C1>, Pwm<TIM2, C2>, Pwm<TIM2, C3>, Pwm<TIM2, C4>);
 }
 
-impl Pins<TIM2> for PA0<Alternate<PushPull>> {
-    const REMAP: u8 = 0b00;
-    const C1: bool = true;
-    const C2: bool = false;
-    const C3: bool = false;
-    const C4: bool = false;
-    type Channels = Pwm<TIM2, C1>;
-}
-
 impl Pins<TIM3>
     for (
         PA6<Alternate<PushPull>>,
@@ -109,15 +153,6 @@ impl Pins<TIM3>
     type Channels = (Pwm<TIM3, C1>, Pwm<TIM3, C2>, Pwm<TIM3, C3>, Pwm<TIM3, C4>);
 }
 
-impl Pins<TIM3> for (PB0<Alternate<PushPull>>, PB1<Alternate<PushPull>>) {
-    const REMAP: u8 = 0b00;
-    const C1: bool = false;
-    const C2: bool = false;
-    const C3: bool = true;
-    const C4: bool = true;
-    type Channels = (Pwm<TIM3, C3>, Pwm<TIM3, C4>);
-}
-
 impl Pins<TIM4>
     for (
         PB6<Alternate<PushPull>>,
@@ -126,7 +161,7 @@ impl Pins<TIM4>
         PB9<Alternate<PushPull>>,
     )
 {
-    const REMAP: u8 = 0b0;
+    const REMAP: u8 = 0b00;
     const C1: bool = true;
     const C2: bool = true;
     const C3: bool = true;


### PR DESCRIPTION
Hi all,

In practical applications various selections of PWM channels may be needed. For instance, one or two channels attached to gpio pins for non-default remapping. It is possible to keep adding implementations of the 'Pins' trait into pwm module for all the needed channel/pin combinations. However it does not look practical unless there exist some clever way to describe all possible combinations w/o boilerplate code.

Another option is to keep only basic implementations in pwm module, e.g. 'all the channels for default pin remapping'. As for the custom channel selections, it is possible to use newtype pattern to implement 'Pins'  trait in the user application. This PR adds documentation and example demonstrating the use of newtype pattern for creation of custom PWM channel configuration.

Thoughts ? Comments ?

Regards,
Sergey