### PR TITLE
Reexport cortex-m

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,3 +12,4 @@ pub use crate::rcc::RccExt as _stm32_hal_rcc_RccExt;
 //pub use crate::serial::ReadDma as _stm32_hal_serial_ReadDma;
 //pub use crate::serial::WriteDma as _stm32_hal_serial_WriteDma;
 pub use crate::time::U32Ext as _stm32_hal_time_U32Ext;
+pub use cortex_m;


### PR DESCRIPTION
I had trouble compiling a previously working project where I was importing `cortex-m` directly.

`Cargo.toml` :

```toml
[dependencies]
cortex-m = "0.6"

[dependencies.stm32f1xx-hal]
features = ["rt","stm32f103"]
git = "https://github.com/stm32-rs/stm32f1xx-hal"
```
Produced the following error :
```
warning: Linking globals named 'CORE_PERIPHERALS': symbol multiply defined!

error: failed to load bc of "cortex_m.bmw16o9v-cgu.0": 

error: aborting due to previous error
```

Reexporting cortex-m from this crate and using it directly instead of depending directly on `cortex-m` fixes this issue.
Please tell me if you can reproduce it :smile: