### PR TITLE
Add more configuration options to UART

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- *Breaking change* Add additional configuration options to USART.
+    - Baud rate now has to be set using configuration struct
 - Now requires stm32f1 v0.7 (breaking change)
 - enable PWM on stm32f100
 - Fix gpio misconfiguration when using a timer in pwm input mode. Now the gpio has to be configured in floating input mode.
@@ -44,6 +46,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Use correct clock for serial baudrate computation
+
+
+
 
 ## [v0.2.0] - 2019-02-10
 

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -11,7 +11,7 @@ use cortex_m::{asm, singleton};
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    serial::Serial,
+    serial::{Config, Serial},
     dma::Half,
 };
 use cortex_m_rt::entry;
@@ -51,7 +51,7 @@ fn main() -> ! {
         p.USART1,
         (tx, rx),
         &mut afio.mapr,
-        9_600.bps(),
+        Config::default().baudrate(9_600.bps()),
         clocks,
         &mut rcc.apb2,
     );

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -11,7 +11,7 @@ use cortex_m::{asm, singleton};
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    serial::Serial,
+    serial::{Config, Serial},
 };
 use cortex_m_rt::entry;
 
@@ -50,7 +50,7 @@ fn main() -> ! {
         p.USART1,
         (tx, rx),
         &mut afio.mapr,
-        115_200.bps(),
+        Config::default(),
         clocks,
         &mut rcc.apb2,
     );

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -11,7 +11,7 @@ use cortex_m::{asm, singleton};
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    serial::Serial,
+    serial::{Config, Serial},
 };
 use cortex_m_rt::entry;
 
@@ -50,7 +50,7 @@ fn main() -> ! {
         p.USART1,
         (tx, rx),
         &mut afio.mapr,
-        9_600.bps(),
+        Config::default().baudrate(9_600.bps()),
         clocks,
         &mut rcc.apb2,
     );

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -11,7 +11,7 @@ use cortex_m::asm;
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    serial::Serial,
+    serial::{Config, Serial},
 };
 use cortex_m_rt::entry;
 
@@ -50,7 +50,7 @@ fn main() -> ! {
         p.USART1,
         (tx, rx),
         &mut afio.mapr,
-        9_600.bps(),
+        Config::default().baudrate(9600.bps()),
         clocks,
         &mut rcc.apb2,
     );

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -75,13 +75,8 @@ fn main() -> ! {
     // Split the serial struct into a receiving and a transmitting part
     let (mut tx, mut rx) = serial.split();
 
-    let mut timer = Timer::tim2(p.TIM2, 1000.hz(), clocks, &mut rcc.apb1);
-
     let sent = b'U';
     block!(tx.write(sent)).ok();
-    // block!(timer.wait());
-    // timer.start(1000.hz());
-    // block!(timer.wait());
     block!(tx.write(sent)).ok();
 
 

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -15,7 +15,8 @@ use nb::block;
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    serial::{Config, Serial},
+    serial::{self, Serial},
+    timer::Timer,
 };
 use cortex_m_rt::entry;
 
@@ -63,7 +64,10 @@ fn main() -> ! {
         p.USART3,
         (tx, rx),
         &mut afio.mapr,
-        Config::default().baudrate(9600.bps()),
+        serial::Config::default()
+            .baudrate(9600.bps())
+            .stopbits(serial::StopBits::STOP2)
+            .parity_odd(),
         clocks,
         &mut rcc.apb1,
     );
@@ -71,19 +75,15 @@ fn main() -> ! {
     // Split the serial struct into a receiving and a transmitting part
     let (mut tx, mut rx) = serial.split();
 
-    let sent = b'X';
+    let mut timer = Timer::tim2(p.TIM2, 1000.hz(), clocks, &mut rcc.apb1);
 
-    // Write `X` and wait until the write is successful
+    let sent = b'U';
+    block!(tx.write(sent)).ok();
+    // block!(timer.wait());
+    // timer.start(1000.hz());
+    // block!(timer.wait());
     block!(tx.write(sent)).ok();
 
-    // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(rx.read()).unwrap();
-
-    // Since we have connected tx and rx, the byte we sent should be the one we received
-    assert_eq!(received, sent);
-
-    // Trigger a breakpoint to allow us to inspect the values
-    asm::bkpt();
 
     loop {}
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -159,7 +159,7 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Config {
-        let baudrate = 19_200_u32.bps();
+        let baudrate = 115_200_u32.bps();
         Config {
             baudrate,
             parity: Parity::ParityNone,


### PR DESCRIPTION
This PR adds the the ability to configure the stop bits and parity bits of the serial device. It is inspired by the implementation in the f4 hal but it does differ a bit from that.

The main difference is that this implementation doesn't allow you to specify word length which I did for 2 reasons:

- Reading/sending 9 bits would require using a u16 instead of u8
- "Word length" includes parity bits

The second point means that a device configured to send 9 bit words with one parity bit actually sends 8 bit words and the parity bit. This seems to go against the way UART protocols are usually defined. To avoid that confusion, I decided to just disable the option of changing word size and assume the user wants to send 8 bits of actual data.

Another difference to the f4 impl is that I don't use a separate config submodule. To me, that feels unnecessary, but feel free to convince me otherwise.

Finally, this works until we add support for USART5 and 6 which don't allow 1.5 and 0.5 stop bits. Should we future proof this design for that?

