### PR TITLE
Add public functions to toggle PWREN bits

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -80,6 +80,23 @@ impl APB1 {
     }
 }
 
+
+impl APB1 {
+    /// Set power interface clock (PWREN) bit in RCC_APB1ENR
+    pub fn set_pwren(&mut self) {
+        self.enr().modify(|_r, w| {
+            w.pwren().set_bit()
+        })
+    }
+
+    /// Clear power interface clock (PWREN) bit in RCC_APB1ENR
+    pub fn clear_pwren(&mut self) {
+        self.enr().modify(|_r, w| {
+            w.pwren().clear_bit()
+        })
+    }
+}
+
 /// Advanced Peripheral Bus 2 (APB2) registers
 pub struct APB2 {
     _0: (),

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -88,13 +88,6 @@ impl APB1 {
             w.pwren().set_bit()
         })
     }
-
-    /// Clear power interface clock (PWREN) bit in RCC_APB1ENR
-    pub fn clear_pwren(&mut self) {
-        self.enr().modify(|_r, w| {
-            w.pwren().clear_bit()
-        })
-    }
 }
 
 /// Advanced Peripheral Bus 2 (APB2) registers


### PR DESCRIPTION
Discussion started in https://github.com/stm32-rs/stm32f1xx-hal/issues/62 so I'll just copy description from there:

When enabling standby mode, there is a need to set `PWREN` bit in APB1 ENR register.

Right now it can be achieved by calling `constrain` on `rcc.bkp`. https://github.com/stm32-rs/stm32f1xx-hal/blob/master/src/rcc.rs#L367

And while it does set the right bits in the right places, it enables other registers as well, which may to may not be desirable.

Ideally, I'd like to be able to do it manually:

```
rcc.apb1.enr().modify(|_r, w| {
    w.pwren().set_bit()
});
```

Or maybe just call a function that does it for me, something like what `set_sleepdeep()` does: https://github.com/rust-embedded/cortex-m/blob/master/src/peripheral/scb.rs#L585

```
rcc.apb1.set_pwren();
```

---

As suggested by @TheZoq2 in the same issue https://github.com/stm32-rs/stm32f1xx-hal/issues/62#issuecomment-489339751, this is the PR for further discussion.