### PR TITLE
adc: add support for channels 16 and 17 in ADC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove all PWM channel configurations except 'all the channels for default remapping' configuratons
 - Update PWM documentation: clarify custom selection of channels
 - Add PWM example for custom selection of channels
+- Add ADC1 reading functions for channels 16 (temperature) and 17 (internal reference voltage)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update PWM documentation: clarify custom selection of channels
 - Add PWM example for custom selection of channels
 - Add ADC1 reading functions for channels 16 (temperature) and 17 (internal reference voltage)
+- Update existing ADC example according to ADC API changes
+- Add new ADC example to read ambient temperature using ADC1 CH16
 
 ### Changed
 

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -9,7 +9,7 @@ use stm32f1xx_hal::{
     pac,
     adc,
 };
-use cortex_m_rt::{entry,exception,ExceptionFrame};
+use cortex_m_rt::entry;
 
 use cortex_m_semihosting::hprintln;
 
@@ -53,14 +53,4 @@ fn main() -> ! {
             hprintln!("adc2: {}", data1).unwrap();
         }
     }
-}
-
-#[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
-}
-
-#[exception]
-fn DefaultHandler(irqn: i16) {
-    panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -29,10 +29,10 @@ fn main() -> ! {
     hprintln!("adc freq: {}", clocks.adcclk().0).unwrap();
 
     // Setup ADC
-    let mut adc1 = adc::Adc::adc1(p.ADC1, &mut rcc.apb2);
+    let mut adc1 = adc::Adc::adc1(p.ADC1, &mut rcc.apb2, clocks.adcclk());
 
     #[cfg(feature = "stm32f103")]
-    let mut adc2 = adc::Adc::adc2(p.ADC2, &mut rcc.apb2);
+    let mut adc2 = adc::Adc::adc2(p.ADC2, &mut rcc.apb2, clocks.adcclk());
 
     // Setup GPIOB
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);

--- a/examples/adc_temperature.rs
+++ b/examples/adc_temperature.rs
@@ -9,7 +9,7 @@ use stm32f1xx_hal::{
     pac,
     adc,
 };
-use cortex_m_rt::{entry,exception,ExceptionFrame};
+use cortex_m_rt::entry;
 
 use cortex_m_semihosting::hprintln;
 
@@ -44,14 +44,4 @@ fn main() -> ! {
 
         hprintln!("temp: {}", temp).unwrap();
     }
-}
-
-#[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
-}
-
-#[exception]
-fn DefaultHandler(irqn: i16) {
-    panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/adc_temperature.rs
+++ b/examples/adc_temperature.rs
@@ -20,18 +20,7 @@ fn main() -> ! {
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
 
-    // Several examples of HSE, PCLK1, ADC clocks
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(8.mhz()).pclk1(2.mhz()).adcclk(1.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(16.mhz()).pclk1(4.mhz()).adcclk(2.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(24.mhz()).pclk1(9.mhz()).adcclk(3.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(24.mhz()).pclk1(12.mhz()).adcclk(4.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(24.mhz()).pclk1(12.mhz()).adcclk(6.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(36.mhz()).pclk1(12.mhz()).adcclk(6.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(32.mhz()).pclk1(16.mhz()).adcclk(8.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(40.mhz()).pclk1(20.mhz()).adcclk(10.mhz()).freeze(&mut flash.acr);
-    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(48.mhz()).pclk1(24.mhz()).adcclk(12.mhz()).freeze(&mut flash.acr);
     let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(56.mhz()).pclk1(28.mhz()).adcclk(14.mhz()).freeze(&mut flash.acr);
-
     hprintln!("sysclk freq: {}", clocks.sysclk().0).unwrap();
     hprintln!("adc freq: {}", clocks.adcclk().0).unwrap();
 

--- a/examples/adc_temperature.rs
+++ b/examples/adc_temperature.rs
@@ -1,0 +1,57 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use panic_semihosting as _;
+
+use stm32f1xx_hal::{
+    prelude::*,
+    pac,
+    adc,
+};
+use cortex_m_rt::{entry,exception,ExceptionFrame};
+
+use cortex_m_semihosting::hprintln;
+
+#[entry]
+fn main() -> ! {
+    // Aquire peripherals
+    let p = pac::Peripherals::take().unwrap();
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    // Several examples of HSE, PCLK1, ADC clocks
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(8.mhz()).pclk1(2.mhz()).adcclk(1.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(16.mhz()).pclk1(4.mhz()).adcclk(2.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(24.mhz()).pclk1(9.mhz()).adcclk(3.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(24.mhz()).pclk1(12.mhz()).adcclk(4.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(24.mhz()).pclk1(12.mhz()).adcclk(6.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(36.mhz()).pclk1(12.mhz()).adcclk(6.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(32.mhz()).pclk1(16.mhz()).adcclk(8.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(40.mhz()).pclk1(20.mhz()).adcclk(10.mhz()).freeze(&mut flash.acr);
+    //let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(48.mhz()).pclk1(24.mhz()).adcclk(12.mhz()).freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.use_hse(8.mhz()).sysclk(56.mhz()).pclk1(28.mhz()).adcclk(14.mhz()).freeze(&mut flash.acr);
+
+    hprintln!("sysclk freq: {}", clocks.sysclk().0).unwrap();
+    hprintln!("adc freq: {}", clocks.adcclk().0).unwrap();
+
+    // Setup ADC
+    let mut adc = adc::Adc::adc1(p.ADC1, &mut rcc.apb2, clocks.adcclk());
+
+    // Read temperature sensor
+    loop {
+        let temp = adc.read_temp();
+
+        hprintln!("temp: {}", temp).unwrap();
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}


### PR DESCRIPTION
Add reading methods to read from ADC1 special channels:
- channel 16: temperature sensor
- channel 17: internal reference voltage

Note that these methods should be implemented only for ADC1 block
since in ADC2 and ADC3 those channels are connected to Vss.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>