### PR TITLE
ccmrX_input

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,3 +12,4 @@ pub use crate::dma::CircReadDma as _stm32_hal_dma_CircReadDma;
 pub use crate::dma::ReadDma as _stm32_hal_dma_ReadDma;
 pub use crate::dma::WriteDma as _stm32_hal_dma_WriteDma;
 pub use crate::time::U32Ext as _stm32_hal_time_U32Ext;
+pub use crate::timer::CcmrIO as _stm32_hal_timer_CcmrIO;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -307,22 +307,22 @@ macro_rules! hal {
 
                 if PINS::C1 {
                     tim.ccmr1_output
-                        .modify(|_, w| unsafe { w.oc1pe().set_bit().oc1m().bits(6) });
+                        .modify(|_, w| w.oc1pe().set_bit().oc1m().pwm_mode1());
                 }
 
                 if PINS::C2 {
                     tim.ccmr1_output
-                        .modify(|_, w| unsafe { w.oc2pe().set_bit().oc2m().bits(6) });
+                        .modify(|_, w| w.oc2pe().set_bit().oc2m().pwm_mode1());
                 }
 
                 if PINS::C3 {
                     tim.ccmr2_output
-                        .modify(|_, w| unsafe { w.oc3pe().set_bit().oc3m().bits(6) });
+                        .modify(|_, w| w.oc3pe().set_bit().oc3m().pwm_mode1());
                 }
 
                 if PINS::C4 {
                     tim.ccmr2_output
-                        .modify(|_, w| unsafe { w.oc4pe().set_bit().oc4m().bits(6) });
+                        .modify(|_, w| w.oc4pe().set_bit().oc4m().pwm_mode1());
                 }
                 let clk = $TIMX::get_clk(&clocks).0;
                 let freq = freq.0;

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -12,7 +12,7 @@ use crate::gpio::gpiob::{PB3, PB4, PB5, PB6, PB7};
 use crate::gpio::{Floating, Input};
 use crate::rcc::{Clocks, APB1};
 use crate::time::Hertz;
-use crate::timer::PclkSrc;
+use crate::timer::{PclkSrc,CcmrIO};
 
 pub trait Pins<TIM> {
     const REMAP: u8;
@@ -211,13 +211,7 @@ macro_rules! hal {
 
             // Define the direction of the channel (input/output)
             // and the used input
-            // 01: CC1 channel is configured as input, IC1 is mapped on TI1.
-            // 10: CC1 channel is configured as input, IC1 is mapped on TI2.
-            tim.ccmr1_output.modify( |_,w| unsafe {w.cc1s().bits(0b01)});
-
-            // 01: CC2 channel is configured as input, IC2 is mapped on TI2
-            // 10: CC2 channel is configured as input, IC2 is mapped on TI1
-            tim.ccmr1_output.modify( |_,w| unsafe {w.cc2s().bits(0b10)});
+            tim.ccmr1_output.input().modify( |_,w| w.cc1s().ti1().cc2s().ti1());
 
             tim.dier.write(|w| w.cc1ie().set_bit());
 

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -9,6 +9,7 @@ use crate::gpio::gpioa::{PA0, PA1, PA6, PA7};
 use crate::gpio::gpiob::{PB6, PB7};
 use crate::gpio::{Floating, Input};
 use crate::rcc::APB1;
+use crate::timer::CcmrIO;
 
 pub trait Pins<TIM> {
     const REMAP: u8;
@@ -78,8 +79,8 @@ macro_rules! hal {
                     apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
                     // Configure TxC1 and TxC2 as captures
-                    tim.ccmr1_output
-                        .write(|w| unsafe { w.bits({ (0b01 << 0) | (0b01 << 8) }) });
+                    tim.ccmr1_output.input()
+                        .write(|w| w.cc1s().ti1().cc2s().ti2());
 
                     // enable and configure to capture on rising edge
                     tim.ccer.write(|w| {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -222,3 +222,40 @@ hal! {
     TIM3: (tim3, tim3en, tim3rst, APB1),
     TIM4: (tim4, tim4en, tim4rst, APB1),
 }
+
+pub trait CcmrIO {
+    type Input;
+    fn input(&self) -> &Self::Input;
+}
+
+
+macro_rules! ccmr {
+    ($($timX:ident: {
+        $($OUTX:ident: $INX:ident,)+
+    },)+) => {
+        $(
+            $(
+                impl CcmrIO for crate::pac::$timX::$OUTX {
+                    type Input = crate::pac::$timX::$INX;
+                    fn input(&self) -> &Self::Input {
+                        unsafe {
+                            &*((self as *const Self) as *const Self::Input)
+                        }
+                    }
+                }
+            )+
+        )+
+    }
+}
+
+
+ccmr! {
+    tim1: {
+        CCMR1_OUTPUT: CCMR1_INPUT,
+        CCMR2_OUTPUT: CCMR2_INPUT,
+    },
+    tim2: {
+        CCMR1_OUTPUT: CCMR1_INPUT,
+        CCMR2_OUTPUT: CCMR2_INPUT,
+    },
+}


### PR DESCRIPTION
This workaround adds input() method to ccmr1_output for access to ccmr1_input.
Depends on https://github.com/stm32-rs/stm32-rs/pull/223

@gbip, can you test this?