### PR TITLE
Fix cortex-m-quickstart link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! features = ["stm32f103", "rt"]
 //! ```
 //!
-//! [cortex-m-quickstart]: https://docs.rs/cortex-m-quickstart/0.3.1
+//! [cortex-m-quickstart]: https://rust-embedded.github.io/cortex-m-quickstart/cortex_m_quickstart/
 //!
 //! ## Usage example
 //!


### PR DESCRIPTION
The current URL (https://docs.rs/cortex-m-quickstart/0.3.1/cortex_m_quickstart/) leads to an outdated version of cortex-m-quickstart docs that for example includes the incorrect instruction to call `git clone cortex-m-quickstart --vers 0.3.0` (it should be `cargo clone ...`).

Since version 0.3.2, the docs fail to build: https://docs.rs/crate/cortex-m-quickstart/

However, the [crates page](https://crates.io/crates/cortex-m-quickstart) links to another documentation page which seems to be up-to-date: https://rust-embedded.github.io/cortex-m-quickstart/cortex_m_quickstart/