### PR TITLE
Implement serial::{Tx,Rx}::{listen,unlisten}.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add ADC1 reading functions for channels 16 (temperature) and 17 (internal reference voltage)
 - Update existing ADC example according to ADC API changes
 - Add new ADC example to read ambient temperature using ADC1 CH16
+- Add `listen` and `unlisten` to `serial::Tx` and `serial::Rx`.
 
 
 ### Breaking changes

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -326,6 +326,26 @@ macro_rules! hal {
                 }
             }
 
+            impl Tx<$USARTX> {
+                pub fn listen(&mut self) {
+                    unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) };
+                }
+
+                pub fn unlisten(&mut self) {
+                    unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) };
+                }
+            }
+
+            impl Rx<$USARTX> {
+                pub fn listen(&mut self) {
+                    unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) };
+                }
+
+                pub fn unlisten(&mut self) {
+                    unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) };
+                }
+            }
+
             impl crate::hal::serial::Read<u8> for Rx<$USARTX> {
                 type Error = Error;
 


### PR DESCRIPTION
This PR adds listen and unlisten to Tx and Rx, acting identically to Serial::listen/unlisten(Txe/Rxne).

(I'm not super happy with the duplication here, but it didn't seem trivial to extract it to a helper. Let me know if you want me to do so.)