### PR TITLE
Changes DMA traits to take &mut reference

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -581,12 +581,12 @@ impl<PIN> AdcDma<PIN> where PIN: Channel<ADC1> {
     }
 }
 
-impl<B, PIN> crate::dma::CircReadDma<B, u16> for AdcDma<PIN>
+impl<'a, B, PIN> crate::dma::CircReadDma<'a, B, u16> for AdcDma<PIN>
 where
     B: AsMut<[u16]>,
     PIN: Channel<ADC1>,
 {
-    fn circ_read(mut self, buffer: &'static mut [B; 2]) -> CircBuffer<B, Self> {
+    fn circ_read(&'a mut self, buffer: &'static mut [B; 2]) -> CircBuffer<B, &mut Self> {
         {
             let buffer = buffer[0].as_mut();
             self.channel.set_peripheral_address(unsafe{ &(*ADC1::ptr()).dr as *const _ as u32 }, false);
@@ -611,12 +611,12 @@ where
     }
 }
 
-impl<B, PIN> crate::dma::ReadDma<B, u16> for AdcDma<PIN>
+impl<'a, B, PIN> crate::dma::ReadDma<'a, B, u16> for AdcDma<PIN>
 where
     B: AsMut<[u16]>,
     PIN: Channel<ADC1>,
 {
-    fn read(mut self, buffer: &'static mut B) -> Transfer<W, &'static mut B, Self> {
+    fn read(&'a mut self, buffer: &'static mut B) -> Transfer<W, &'static mut B, &mut Self> {
         {
             let buffer = buffer.as_mut();
             self.channel.set_peripheral_address(unsafe{ &(*ADC1::ptr()).dr as *const _ as u32 }, false);

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -480,30 +480,27 @@ pub trait Transmit {
     type ReceivedWord;
 }
 
-pub trait CircReadDma<B, RS>: Receive
+pub trait CircReadDma<'a, B, RS>: Receive
 where
     B: AsMut<[RS]>,
     Self: core::marker::Sized,
 {
-    fn circ_read(self, buffer: &'static mut [B; 2]) -> CircBuffer<B, Self>;
+    fn circ_read(&'a mut self, buffer: &'static mut [B; 2]) -> CircBuffer<B, &'a mut Self>;
 }
 
-pub trait ReadDma<B, RS>: Receive
+pub trait ReadDma<'a, B, RS>: Receive
 where
     B: AsMut<[RS]>,
     Self: core::marker::Sized,
 {
-    fn read(
-        self,
-        buffer: &'static mut B,
-    ) -> Transfer<W, &'static mut B, Self>;
+    fn read(&'a mut self, buffer: &'static mut B) -> Transfer<W, &'static mut B, &'a mut Self>;
 }
 
-pub trait WriteDma<A, B, TS>: Transmit
+pub trait WriteDma<'a, A, B, TS>: Transmit
 where
     A: AsRef<[TS]>,
     B: Static<A>,
     Self: core::marker::Sized,
 {
-    fn write(self, buffer: B) -> Transfer<R, B, Self>;
+    fn write(&'a mut self, buffer: B) -> Transfer<R, B, &'a mut Self>;
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -551,9 +551,9 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<B> crate::dma::CircReadDma<B, u8> for $rxdma where B: AsMut<[u8]> {
-                fn circ_read(mut self, buffer: &'static mut [B; 2],
-                ) -> CircBuffer<B, Self>
+            impl<'a, B> crate::dma::CircReadDma<'a, B, u8> for $rxdma where B: AsMut<[u8]> {
+                fn circ_read(&'a mut self, buffer: &'static mut [B; 2],
+                ) -> CircBuffer<B, &'a mut Self>
                 {
                     {
                         let buffer = buffer[0].as_mut();
@@ -579,9 +579,9 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<B> crate::dma::ReadDma<B, u8> for $rxdma where B: AsMut<[u8]> {
-                fn read(mut self, buffer: &'static mut B,
-                ) -> Transfer<W, &'static mut B, Self>
+            impl<'a, B> crate::dma::ReadDma<'a, B, u8> for $rxdma where B: AsMut<[u8]> {
+                fn read(&'a mut self, buffer: &'static mut B,
+                ) -> Transfer<W, &'static mut B, &mut Self>
                 {
                     {
                         let buffer = buffer.as_mut();
@@ -604,9 +604,9 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<A, B> crate::dma::WriteDma<A, B, u8> for $txdma where A: AsRef<[u8]>, B: Static<A> {
-                fn write(mut self, buffer: B
-                ) -> Transfer<R, B, Self>
+            impl<'a, A, B> crate::dma::WriteDma<'a, A, B, u8> for $txdma where A: AsRef<[u8]>, B: Static<A> {
+                fn write(&'a mut self, buffer: B
+                ) -> Transfer<R, B, &mut Self>
                 {
                     {
                         let buffer = buffer.borrow().as_ref();


### PR DESCRIPTION
This change will make it easier to use the read and write functions due to them not moving the struct. This will cause them to work in the same contexts as read and write do (in the case of serial read and writes).

My main issue was in the context of RTFM, where I would like to use the dma read and write functions in the idle thread and had rx_dma and tx_dma as resources. I could not use them due to not owning them.

This is one of my first PR's so if there is a problem, please say so and I will attempt modify it.

------------------------------------------------------------
Changes CircReadDma, ReadDmam WriteDma
from taking self to &mut self.

Signed-off-by: Cor Peters <prive@corpeters.nl>