### PR TITLE
Handle debugger pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking changes
 
 - ADC now requires the clock configuration for intialisation
+- `disable_jtag` now transforms PA15, PB3 and PB4 to forbid their use without desactivating JTAG
 
 ### Changed
 

--- a/examples/nojtag.rs
+++ b/examples/nojtag.rs
@@ -17,12 +17,20 @@ fn main() -> ! {
     let p = pac::Peripherals::take().unwrap();
 
     let mut rcc = p.RCC.constrain();
+    let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
     let mut afio = p.AFIO.constrain(&mut rcc.apb2);
 
-    afio.mapr.disable_jtag();
+    let (pa15, pb3, pb4) = afio.mapr.disable_jtag(gpioa.pa15, gpiob.pb3, gpiob.pb4);
 
-    gpiob.pb4.into_push_pull_output(&mut gpiob.crl).set_low();
+    let mut pa15 = pa15.into_push_pull_output(&mut gpioa.crh);
+    let mut pb3 = pb3.into_push_pull_output(&mut gpiob.crl);
+    let mut pb4 = pb4.into_push_pull_output(&mut gpiob.crl);
 
-    loop {}
+    loop {
+        pa15.toggle();
+        pb3.toggle();
+        pb4.toggle();
+        cortex_m::asm::delay(8_000_000);
+    }
 }

--- a/examples/pwm_custom.rs
+++ b/examples/pwm_custom.rs
@@ -50,11 +50,12 @@ fn main() -> ! {
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
     let mut afio = p.AFIO.constrain(&mut rcc.apb2);
-
+    let gpioa = p.GPIOA.split(&mut rcc.apb2);
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+    let (_pa15, _pb3, pb4) = afio.mapr.disable_jtag(gpioa.pa15, gpiob.pb3, gpiob.pb4);
 
     // TIM3
-    let p0 = gpiob.pb4.into_alternate_push_pull(&mut gpiob.crl);
+    let p0 = pb4.into_alternate_push_pull(&mut gpiob.crl);
     let p1 = gpiob.pb5.into_alternate_push_pull(&mut gpiob.crl);
 
     let mut pwm = p.TIM3.pwm(

--- a/examples/pwm_input.rs
+++ b/examples/pwm_input.rs
@@ -25,9 +25,10 @@ fn main() -> ! {
     let mut afio = p.AFIO.constrain(&mut rcc.apb2);
     let mut dbg = p.DBGMCU;
 
-    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+    let gpioa = p.GPIOA.split(&mut rcc.apb2);
+    let gpiob = p.GPIOB.split(&mut rcc.apb2);
 
-    let pb4 = gpiob.pb4;
+    let (_pa15, _pb3, pb4) = afio.mapr.disable_jtag(gpioa.pa15, gpiob.pb3, gpiob.pb4);
     let pb5 = gpiob.pb5;
 
     let pwm_input = p.TIM3.pwm_input(

--- a/src/afio.rs
+++ b/src/afio.rs
@@ -65,9 +65,9 @@ impl MAPR {
     /// Disables the JTAG to free up pa15, pb3 and pb4 for normal use
     pub fn disable_jtag(
         &mut self,
-        _pa15: PA15<Debugger>,
-        _pb3: PB3<Debugger>,
-        _pb4: PB4<Debugger>
+        pa15: PA15<Debugger>,
+        pb3: PB3<Debugger>,
+        pb4: PB4<Debugger>
     ) -> (
         PA15<Input<Floating>>,
         PB3<Input<Floating>>,
@@ -76,8 +76,8 @@ impl MAPR {
         self.mapr()
             .modify(|_, w| unsafe { w.swj_cfg().bits(0b010) });
 
-        // NOTE(unsafe) zero sized type, and recreated in its initial state
-        unsafe { core::mem::MaybeUninit::uninit().assume_init() }
+        // NOTE(unsafe) The pins are now in the good state.
+        unsafe { (pa15.activate(), pb3.activate(), pb4.activate()) }
     }
 }
 

--- a/src/afio.rs
+++ b/src/afio.rs
@@ -3,6 +3,14 @@ use crate::pac::{afio, AFIO};
 
 use crate::rcc::APB2;
 
+use crate::gpio::{
+    Debugger,
+    Input,
+    Floating,
+    gpioa::PA15,
+    gpiob::{PB3, PB4},
+};
+
 pub trait AfioExt {
     fn constrain(self, apb2: &mut APB2) -> Parts;
 }
@@ -54,10 +62,22 @@ impl MAPR {
         unsafe { &(*AFIO::ptr()).mapr }
     }
 
-    /// Disables the JTAG to free up pb3, pb4 and pa15 for normal use
-    pub fn disable_jtag(&mut self) {
+    /// Disables the JTAG to free up pa15, pb3 and pb4 for normal use
+    pub fn disable_jtag(
+        &mut self,
+        _pa15: PA15<Debugger>,
+        _pb3: PB3<Debugger>,
+        _pb4: PB4<Debugger>
+    ) -> (
+        PA15<Input<Floating>>,
+        PB3<Input<Floating>>,
+        PB4<Input<Floating>>,
+    ) {
         self.mapr()
-            .modify(|_, w| unsafe { w.swj_cfg().bits(0b010) })
+            .modify(|_, w| unsafe { w.swj_cfg().bits(0b010) });
+
+        // NOTE(unsafe) zero sized type, and recreated in its initial state
+        unsafe { core::mem::MaybeUninit::uninit().assume_init() }
     }
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -18,6 +18,8 @@ pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
 
+/// Used by the debugger (type state)
+pub struct Debugger;
 /// Floating input (type state)
 pub struct Floating;
 /// Pulled down input (type state)
@@ -503,17 +505,17 @@ gpio!(GPIOA, gpioa, gpioa, iopaen, ioparst, PAx, [
     PA10: (pa10, 10, Input<Floating>, CRH),
     PA11: (pa11, 11, Input<Floating>, CRH),
     PA12: (pa12, 12, Input<Floating>, CRH),
-    PA13: (pa13, 13, Input<Floating>, CRH),
-    PA14: (pa14, 14, Input<Floating>, CRH),
-    PA15: (pa15, 15, Input<Floating>, CRH),
+    PA13: (pa13, 13, super::Debugger, CRH),
+    PA14: (pa14, 14, super::Debugger, CRH),
+    PA15: (pa15, 15, super::Debugger, CRH),
 ]);
 
 gpio!(GPIOB, gpiob, gpioa, iopben, iopbrst, PBx, [
     PB0: (pb0, 0, Input<Floating>, CRL),
     PB1: (pb1, 1, Input<Floating>, CRL),
     PB2: (pb2, 2, Input<Floating>, CRL),
-    PB3: (pb3, 3, Input<Floating>, CRL),
-    PB4: (pb4, 4, Input<Floating>, CRL),
+    PB3: (pb3, 3, super::Debugger, CRL),
+    PB4: (pb4, 4, super::Debugger, CRL),
     PB5: (pb5, 5, Input<Floating>, CRL),
     PB6: (pb6, 6, Input<Floating>, CRL),
     PB7: (pb7, 7, Input<Floating>, CRL),

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -13,10 +13,14 @@ pub trait GpioExt {
     fn split(self, apb2: &mut APB2) -> Self::Parts;
 }
 
+/// Marker trait for active states.
+pub trait Active {}
+
 /// Input mode (type state)
 pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
+impl<MODE> Active for Input<MODE> {}
 
 /// Used by the debugger (type state)
 pub struct Debugger;
@@ -31,6 +35,7 @@ pub struct PullUp;
 pub struct Output<MODE> {
     _mode: PhantomData<MODE>,
 }
+impl<MODE> Active for Output<MODE> {}
 
 /// Push pull output (type state)
 pub struct PushPull;
@@ -39,11 +44,13 @@ pub struct OpenDrain;
 
 /// Analog mode (type state)
 pub struct Analog;
+impl Active for Analog {}
 
 /// Alternate function
 pub struct Alternate<MODE> {
     _mode: PhantomData<MODE>,
 }
+impl<MODE> Active for Alternate<MODE> {}
 
 pub enum State {
     High,
@@ -71,6 +78,7 @@ macro_rules! gpio {
                 PushPull,
                 Analog,
                 State,
+                Active,
             };
 
             /// GPIO parts
@@ -186,7 +194,7 @@ macro_rules! gpio {
                     _mode: PhantomData<MODE>,
                 }
 
-                impl<MODE> $PXi<MODE> {
+                impl<MODE> $PXi<MODE> where MODE: Active {
                     /// Configures the pin to operate as an alternate function push-pull output
                     /// pin.
                     pub fn into_alternate_push_pull(
@@ -404,7 +412,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> $PXi<MODE> {
+                impl<MODE> $PXi<MODE> where MODE: Active {
                     /// Erases the pin number from the type
                     ///
                     /// This is useful when you want to collect the pins into an array where you

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -79,6 +79,7 @@ macro_rules! gpio {
                 Analog,
                 State,
                 Active,
+                Debugger,
             };
 
             /// GPIO parts
@@ -192,6 +193,15 @@ macro_rules! gpio {
                 /// Pin
                 pub struct $PXi<MODE> {
                     _mode: PhantomData<MODE>,
+                }
+
+                impl $PXi<Debugger> {
+                    /// Put the pin in an active state. The caller
+                    /// must enforce that the pin is really in this
+                    /// state in the hardware.
+                    pub(crate) unsafe fn activate(self) -> $PXi<Input<Floating>> {
+                        $PXi { _mode: PhantomData }
+                    }
                 }
 
                 impl<MODE> $PXi<MODE> where MODE: Active {
@@ -513,17 +523,17 @@ gpio!(GPIOA, gpioa, gpioa, iopaen, ioparst, PAx, [
     PA10: (pa10, 10, Input<Floating>, CRH),
     PA11: (pa11, 11, Input<Floating>, CRH),
     PA12: (pa12, 12, Input<Floating>, CRH),
-    PA13: (pa13, 13, super::Debugger, CRH),
-    PA14: (pa14, 14, super::Debugger, CRH),
-    PA15: (pa15, 15, super::Debugger, CRH),
+    PA13: (pa13, 13, Debugger, CRH),
+    PA14: (pa14, 14, Debugger, CRH),
+    PA15: (pa15, 15, Debugger, CRH),
 ]);
 
 gpio!(GPIOB, gpiob, gpioa, iopben, iopbrst, PBx, [
     PB0: (pb0, 0, Input<Floating>, CRL),
     PB1: (pb1, 1, Input<Floating>, CRL),
     PB2: (pb2, 2, Input<Floating>, CRL),
-    PB3: (pb3, 3, super::Debugger, CRL),
-    PB4: (pb4, 4, super::Debugger, CRL),
+    PB3: (pb3, 3, Debugger, CRL),
+    PB4: (pb4, 4, Debugger, CRL),
     PB5: (pb5, 5, Input<Floating>, CRL),
     PB6: (pb6, 6, Input<Floating>, CRL),
     PB7: (pb7, 7, Input<Floating>, CRL),


### PR DESCRIPTION
At startup, pins used by the debugger are in `Debugger` state, prohibiting their
use. `disable_jtag` allow to get PA15, PB3 and PB4 usable as GPIO or alternate
functions at the cost of disabling JTAG.

Discussed in #77 

cc @MauroMombelli