### PR TITLE
Improve time keeping with Timer and RTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Change timer/pwm init API
 - Remove `set_low` and `set_high` for pins in Alternate output mode
+- Renames `set_seconds` and `seconds` methods on RTC to `set_time` and `current_time`, respectively
 
 ### Changed
 
 - DMA traits now require AsSlice instead of AsRef
 - Add `micros_since` and `reset` methods to timer
-- Add `select_frequency` method to rtc
+- Add `select_frequency` method to RTC
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - RCC `Bus` trait + private `Enable` and `Reset` traits
+- Added `micros_since` and `reset` methods to timer
+- Added `select_frequency` method to RTC
 
 ### Breaking changes
 
@@ -21,8 +23,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - DMA traits now require AsSlice instead of AsRef
-- Add `micros_since` and `reset` methods to timer
-- Add `select_frequency` method to RTC
 
 ## [v0.4.0] - 2019-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Replace gpio traits with digital::v2
 - Bump `stm32f1` dependency (`0.8.0`)
-- ADC now requires the clock configuration for intialisation
+- ADC now requires the clock configuration for initialisation
 - `disable_jtag` now transforms PA15, PB3 and PB4 to forbid their use without desactivating JTAG
 
 ### Changed
 
 - Fix hclk miscalculation
+- Starting the timer does not generate interrupt requests anymore
 
 ## [v0.3.0] - 2019-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change timer/pwm init API
 - Remove `set_low` and `set_high` for pins in Alternate output mode
 - Renames `set_seconds` and `seconds` methods on RTC to `set_time` and `current_time`, respectively
+- Starting the timer does not generate interrupt requests anymore
 
 ### Changed
 
 - DMA traits now require AsSlice instead of AsRef
 - Add `micros_since` and `reset` methods to timer
 - Add `select_frequency` method to RTC
-
-### Changed
-
-- Starting the timer does not generate interrupt requests anymore
 
 ## [v0.4.0] - 2019-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - DMA traits now require AsSlice instead of AsRef
+- Add `micros_since` and `reset` methods to timer
+- Add `select_frequency` method to rtc
+
+### Changed
+
+- Starting the timer does not generate interrupt requests anymore
 
 ## [v0.4.0] - 2019-08-09
 
@@ -44,7 +50,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Fix hclk miscalculation
-- Starting the timer does not generate interrupt requests anymore
 
 ## [v0.3.0] - 2019-04-27
 

--- a/examples/blinky_rtc.rs
+++ b/examples/blinky_rtc.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     let mut led_on = false;
     loop {
         // Set the current time to 0
-        rtc.set_seconds(0);
+        rtc.set_time(0);
         // Trigger the alarm in 5 seconds
         rtc.set_alarm(5);
         block!(rtc.wait_alarm()).unwrap();

--- a/examples/pwm_input.rs
+++ b/examples/pwm_input.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     let (_pa15, _pb3, pb4) = afio.mapr.disable_jtag(gpioa.pa15, gpiob.pb3, gpiob.pb4);
     let pb5 = gpiob.pb5;
 
-    let mut pwm_input = Timer::tim3(p.TIM3, &clocks, &mut rcc.apb1)
+    let pwm_input = Timer::tim3(p.TIM3, &clocks, &mut rcc.apb1)
         .pwm_input(
             (pb4, pb5),
             &mut afio.mapr,

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -26,6 +26,6 @@ fn main() -> ! {
     let rtc = Rtc::rtc(p.RTC, &mut backup_domain);
 
     loop {
-        hprintln!("time: {}", rtc.seconds()).unwrap();
+        hprintln!("time: {}", rtc.current_time()).unwrap();
     }
 }

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -14,7 +14,6 @@ use stm32f1xx_hal::{
     prelude::*,
     pac,
     serial::{self, Serial},
-    timer::Timer,
 };
 use cortex_m_rt::entry;
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -70,7 +70,7 @@ impl Rtc {
         })
     }
 
-    /// Selects the frequency of the counter
+    /// Selects the frequency of the RTC Timer
     /// NOTE: Maximum frequency of 16384 Hz using the internal LSE
     pub fn select_frequency(&mut self, timeout: impl Into<Hertz>) {
         let frequency = timeout.into().0;
@@ -86,11 +86,11 @@ impl Rtc {
         });
     }
 
-    /// Set the current rtc counter value to the specified amount
-    pub fn set_time(&mut self, seconds: u32) {
+    /// Set the current RTC counter value to the specified amount
+    pub fn set_time(&mut self, counter_value: u32) {
         self.perform_write(|s| {
-            s.regs.cnth.write(|w| unsafe{w.bits(seconds >> 16)});
-            s.regs.cntl.write(|w| unsafe{w.bits(seconds as u16 as u32)});
+            s.regs.cnth.write(|w| unsafe{w.bits(counter_value >> 16)});
+            s.regs.cntl.write(|w| unsafe{w.bits(counter_value as u16 as u32)});
         });
     }
 
@@ -99,10 +99,10 @@ impl Rtc {
 
       This also clears the alarm flag if it is set
     */
-    pub fn set_alarm(&mut self, seconds: u32) {
+    pub fn set_alarm(&mut self, counter_value: u32) {
         // Set alarm time
         // See section 18.3.5 for explanation
-        let alarm_value = seconds - 1;
+        let alarm_value = counter_value - 1;
         self.perform_write(|s| {
             s.regs.alrh.write(|w| unsafe{w.alrh().bits((alarm_value >> 16) as u16)});
             s.regs.alrl.write(|w| unsafe{w.alrl().bits(alarm_value as u16)});

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -31,7 +31,6 @@ pub struct Rtc {
     regs: RTC,
 }
 
-
 impl Rtc {
     /**
       Initialises the RTC. The `BackupDomain` struct is created by
@@ -88,7 +87,7 @@ impl Rtc {
     }
 
     /// Set the current rtc counter value to the specified amount
-    pub fn set_seconds(&mut self, seconds: u32) {
+    pub fn set_time(&mut self, seconds: u32) {
         self.perform_write(|s| {
             s.regs.cnth.write(|w| unsafe{w.bits(seconds >> 16)});
             s.regs.cntl.write(|w| unsafe{w.bits(seconds as u16 as u32)});
@@ -129,7 +128,7 @@ impl Rtc {
     }
 
     /// Reads the current counter
-    pub fn seconds(&self) -> u32 {
+    pub fn current_time(&self) -> u32 {
         // Wait for the APB1 interface to be ready
         while self.regs.crl.read().rsf().bit() == false {}
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -43,6 +43,10 @@ impl Timer<SYST> {
         timer.start(timeout);
         timer
     }
+
+    pub fn release(self) -> SYST {
+        self.tim
+    }
 }
 
 impl CountDownTimer<SYST> {
@@ -81,14 +85,15 @@ impl CountDownTimer<SYST> {
     }
 
     /// Stops the timer
-    pub fn stop(&mut self) {
+    pub fn stop(mut self) -> Timer<SYST> {
         self.tim.disable_counter();
+        let Self {tim, clk} = self;
+        Timer {tim, clk}
     }
 
     /// Releases the SYST
-    pub fn release(mut self) -> SYST {
-        self.stop();
-        self.tim
+    pub fn release(self) -> SYST {
+        self.stop().release()
     }
 }
 
@@ -177,8 +182,7 @@ macro_rules! hal {
                 }
 
                 /// Stops the timer
-                pub fn stop(mut self) -> Timer<$TIMX> {
-                    self.unlisten(Event::Update);
+                pub fn stop(self) -> Timer<$TIMX> {
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
                     let Self { tim, clk } = self;
                     Timer { tim, clk }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -64,7 +64,7 @@ impl CountDownTimer<SYST> {
         }
     }
 
-    /// Resets the timer
+    /// Resets the counter
     pub fn reset(&mut self) {
         // According to the Cortex-M3 Generic User Guide, the interrupt request is only generated
         // when the counter goes from 1 to 0, so writing zero should not trigger an interrupt
@@ -215,7 +215,7 @@ macro_rules! hal {
                     u32(1_000_000 * cnt / freq_divider).unwrap()
                 }
 
-                /// Resets the counter and generates an update event
+                /// Resets the counter
                 pub fn reset(&mut self) {
                     // Sets the URS bit to prevent an interrupt from being triggered by
                     // the UG bit

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -72,7 +72,7 @@ impl CountDownTimer<SYST> {
     /// it is very easy to lose an update event.
     pub fn micros_since(&self) -> u32 {
         let reload_value = SYST::get_reload();
-        let timer_clock = u64(self.clocks.sysclk().0);
+        let timer_clock = u64(self.clk.0);
         let ticks = u64(reload_value - SYST::get_current());
 
         // It is safe to make this cast since the maximum ticks is (2^24 - 1) and the minimum sysclk
@@ -198,7 +198,7 @@ macro_rules! hal {
                 /// *NOTE:* This method is not a very good candidate to keep track of time, because
                 /// it is very easy to lose an update event.
                 pub fn micros_since(&self) -> u32 {
-                    let timer_clock = $TIMX::get_clk(&self.clocks).0;
+                    let timer_clock = self.clk.0;
                     let psc = u32(self.tim.psc.read().psc().bits());
                     
                     // freq_divider is always bigger than 0, since (psc + 1) is always less than


### PR DESCRIPTION
Closes https://github.com/stm32-rs/stm32f1xx-hal/issues/89 and closes https://github.com/stm32-rs/stm32f1xx-hal/issues/41.

Right now it would be ok to leave the URS bit set, since the HAL has ownership over the registers and we don't implement anything which requires URS bit cleared. However, I decided to clear the URS bit after the update event to prevent future side effects, but I don't have strong feelings about that...