### PR TITLE
split Timer on 2 stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Breaking changes
+
+- Change timer/pwm init API
+
 ## [v0.4.0] - 2019-08-09
 
 ### Added

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
     // in order to configure the port. For pins 0-7, crl should be passed instead.
     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
     // Configure the syst timer to trigger an update every second
-    let mut timer = Timer::syst(cp.SYST, 1.hz(), clocks);
+    let mut timer = Timer::syst(cp.SYST, &clocks).start_count_down(1.hz());
 
     // Wait for the timer to trigger an update and change the state of the LED
     loop {

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -10,6 +10,7 @@ use cortex_m::asm;
 use stm32f1xx_hal::{
     prelude::*,
     pac,
+    timer::Timer,
 };
 use cortex_m_rt::entry;
 
@@ -45,15 +46,8 @@ fn main() -> ! {
     let c3 = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
     let c4 = gpiob.pb9.into_alternate_push_pull(&mut gpiob.crh);
 
-    let mut pwm = p
-        .TIM4
-        .pwm(
-            (c1, c2, c3, c4),
-            &mut afio.mapr,
-            1.khz(),
-            clocks,
-            &mut rcc.apb1,
-        )
+    let mut pwm = Timer::tim4(p.TIM4, &clocks, &mut rcc.apb1)
+        .pwm((c1, c2, c3, c4), &mut afio.mapr, 1.khz())
         .3;
 
     let max = pwm.get_max_duty();

--- a/examples/pwm_custom.rs
+++ b/examples/pwm_custom.rs
@@ -10,10 +10,10 @@ use cortex_m::asm;
 use stm32f1xx_hal::{
     gpio::gpiob::{PB4, PB5},
     gpio::{Alternate, PushPull},
-    pac,
+    pac::{self,TIM3},
     prelude::*,
     pwm::{Pins, Pwm, C1, C2},
-    stm32::TIM3,
+    timer::Timer,
 };
 
 use cortex_m_rt::entry;
@@ -58,13 +58,12 @@ fn main() -> ! {
     let p0 = pb4.into_alternate_push_pull(&mut gpiob.crl);
     let p1 = gpiob.pb5.into_alternate_push_pull(&mut gpiob.crl);
 
-    let mut pwm = p.TIM3.pwm(
-        MyChannels(p0, p1),
-        &mut afio.mapr,
-        1.khz(),
-        clocks,
-        &mut rcc.apb1,
-    );
+    let mut pwm = Timer::tim3(p.TIM3, &clocks, &mut rcc.apb1)
+        .pwm(
+            MyChannels(p0, p1),
+            &mut afio.mapr,
+            1.khz(),
+        );
 
     let max = pwm.0.get_max_duty();
 

--- a/examples/pwm_input.rs
+++ b/examples/pwm_input.rs
@@ -10,6 +10,7 @@ use stm32f1xx_hal::{
     prelude::*,
     pac,
     pwm_input::*,
+    timer::Timer,
 };
 use cortex_m_rt::entry;
 
@@ -31,14 +32,13 @@ fn main() -> ! {
     let (_pa15, _pb3, pb4) = afio.mapr.disable_jtag(gpioa.pa15, gpiob.pb3, gpiob.pb4);
     let pb5 = gpiob.pb5;
 
-    let pwm_input = p.TIM3.pwm_input(
-        (pb4, pb5),
-        &mut rcc.apb1,
-        &mut afio.mapr,
-        &mut dbg,
-        &clocks,
-        Configuration::Frequency(10.khz()),
-    );
+    let mut pwm_input = Timer::tim3(p.TIM3, &clocks, &mut rcc.apb1)
+        .pwm_input(
+            (pb4, pb5),
+            &mut afio.mapr,
+            &mut dbg,
+            Configuration::Frequency(10.khz()),
+        );
 
     loop {
         let _freq = pwm_input

--- a/examples/qei.rs
+++ b/examples/qei.rs
@@ -12,7 +12,7 @@ use stm32f1xx_hal::{
     prelude::*,
     pac,
     delay::Delay,
-    qei::Qei,
+    timer::Timer,
 };
 use cortex_m_rt::entry;
 
@@ -43,7 +43,8 @@ fn main() -> ! {
     let c1 = gpiob.pb6;
     let c2 = gpiob.pb7;
 
-    let qei = Qei::tim4(dp.TIM4, (c1, c2), &mut afio.mapr, &mut rcc.apb1);
+    let qei = Timer::tim4(dp.TIM4, &clocks, &mut rcc.apb1)
+        .qei((c1, c2), &mut afio.mapr);
     let mut delay = Delay::new(cp.SYST, clocks);
 
     loop {

--- a/examples/timer-interrupt-rtfm.rs
+++ b/examples/timer-interrupt-rtfm.rs
@@ -17,7 +17,7 @@ use rtfm::app;
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    timer::{ Timer, Event },
+    timer::{ Timer, CountDownTimer, Event },
     gpio::{ gpioc::PC13, State, Output, PushPull },
 };
 use embedded_hal::digital::v2::OutputPin;
@@ -26,7 +26,7 @@ use embedded_hal::digital::v2::OutputPin;
 const APP: () = {
 
     static mut LED: PC13<Output<PushPull>> = ();
-    static mut TIMER_HANDLER: Timer<pac::TIM1> = ();
+    static mut TIMER_HANDLER: CountDownTimer<pac::TIM1> = ();
     static mut LED_STATE: bool = false;
     
     #[init]
@@ -48,7 +48,8 @@ const APP: () = {
         // function in order to configure the port. For pins 0-7, crl should be passed instead
         let led = gpioc.pc13.into_push_pull_output_with_state(&mut gpioc.crh, State::High);
         // Configure the syst timer to trigger an update every second and enables interrupt
-        let mut timer = Timer::tim1(device.TIM1, 1.hz(), clocks, &mut rcc.apb2);
+        let mut timer = Timer::tim1(device.TIM1, &clocks, &mut rcc.apb2)
+            .start_count_down(1.hz());
         timer.listen(Event::Update);
 
         // Init the static resources to use them later through RTFM

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@
 //!     // crl should be passed instead.
 //!     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
 //!     // Configure the syst timer to trigger an update every second
-//!     let mut timer = Timer::syst(cp.SYST, 1.hz(), clocks);
+//!     let mut timer = Timer::syst(cp.SYST, clocks)
+//!         .start_count_down(1.hz());
 //! 
 //!     // Wait for the timer to trigger an update and change the state of the LED
 //!     loop {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,7 +6,6 @@ pub use crate::hal::adc::OneShot as _embedded_hal_adc_OneShot;
 pub use crate::hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
 pub use crate::hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use crate::hal::prelude::*;
-pub use crate::pwm::PwmExt as _stm32_hal_pwm_PwmExt;
 pub use crate::rcc::RccExt as _stm32_hal_rcc_RccExt;
 pub use crate::dma::CircReadDma as _stm32_hal_dma_CircReadDma;
 pub use crate::dma::ReadDma as _stm32_hal_dma_ReadDma;

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -8,7 +8,8 @@ use crate::afio::MAPR;
 use crate::gpio::gpioa::{PA0, PA1, PA6, PA7};
 use crate::gpio::gpiob::{PB6, PB7};
 use crate::gpio::{Floating, Input};
-use crate::rcc::APB1;
+
+use crate::timer::Timer;
 
 pub trait Pins<TIM> {
     const REMAP: u8;
@@ -31,39 +32,42 @@ pub struct Qei<TIM, PINS> {
     pins: PINS,
 }
 
-impl<PINS> Qei<TIM2, PINS> {
-    pub fn tim2(tim: TIM2, pins: PINS, mapr: &mut MAPR, apb: &mut APB1) -> Self
+impl Timer<TIM2> {
+    pub fn qei<PINS>(self, pins: PINS, mapr: &mut MAPR) -> Qei<TIM2, PINS>
     where
         PINS: Pins<TIM2>,
     {
         mapr.mapr()
             .modify(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
 
-        Qei::_tim2(tim, pins, apb)
+        let Self { tim, clk: _ } = self;
+        Qei::_tim2(tim, pins)
     }
 }
 
-impl<PINS> Qei<TIM3, PINS> {
-    pub fn tim3(tim: TIM3, pins: PINS, mapr: &mut MAPR, apb: &mut APB1) -> Self
+impl Timer<TIM3> {
+    pub fn qei<PINS>(self, pins: PINS, mapr: &mut MAPR) -> Qei<TIM3, PINS>
     where
         PINS: Pins<TIM3>,
     {
         mapr.mapr()
             .modify(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
 
-        Qei::_tim3(tim, pins, apb)
+        let Self { tim, clk: _ } = self;
+        Qei::_tim3(tim, pins)
     }
 }
 
-impl<PINS> Qei<TIM4, PINS> {
-    pub fn tim4(tim: TIM4, pins: PINS, mapr: &mut MAPR, apb: &mut APB1) -> Self
+impl Timer<TIM4> {
+    pub fn qei<PINS>(self, pins: PINS, mapr: &mut MAPR) -> Qei<TIM4, PINS>
     where
         PINS: Pins<TIM4>,
     {
         mapr.mapr()
             .modify(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
 
-        Qei::_tim4(tim, pins, apb)
+        let Self { tim, clk: _ } = self;
+        Qei::_tim4(tim, pins)
     }
 }
 
@@ -71,12 +75,7 @@ macro_rules! hal {
     ($($TIMX:ident: ($timX:ident, $timXen:ident, $timXrst:ident),)+) => {
         $(
             impl<PINS> Qei<$TIMX, PINS> {
-                fn $timX(tim: $TIMX, pins: PINS, apb: &mut APB1) -> Self {
-                    // enable and reset peripheral to a clean slate state
-                    apb.enr().modify(|_, w| w.$timXen().set_bit());
-                    apb.rstr().modify(|_, w| w.$timXrst().set_bit());
-                    apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
-
+                fn $timX(tim: $TIMX, pins: PINS) -> Self {
                     // Configure TxC1 and TxC2 as captures
                     tim.ccmr1_input().write(|w| w.cc1s().ti1().cc2s().ti2());
 


### PR DESCRIPTION
cc @TheZoq2 
cc @therealprof 

```rust
// Simple count down timer
    let mut timer = Timer::syst(cp.SYST, &clocks)
        .start_count_down(1.hz());
// or
    let timer = Timer::tim1(device.TIM1, &clocks, &mut rcc.apb2);
    ...
    let mut timer = timer.start_count_down(1.hz());
    timer.listen(Event::Update);

/// PWM
    let mut pwm = Timer::tim4(p.TIM4, &clocks, &mut rcc.apb1)
        .pwm((c1, c2, c3, c4), &mut afio.mapr, 1.khz())
        .3;

// PWM input
    let mut pwm_input = Timer::tim3(p.TIM3, &clocks, &mut rcc.apb1)
        .pwm_input(
            (pb4, pb5),
            &mut afio.mapr,
            &mut dbg,
            Configuration::Frequency(10.khz()),
        );
```

See #89 

Timer now contains `clk: Hertz` instead of full `clocks: Clock` structure (reduce code size in debug mode).