### PR TITLE
as_slice instead of as_ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Change timer/pwm init API
 
+### Changed
+
+- DMA traits now require AsSlice instead of AsRef
+
 ## [v0.4.0] - 2019-08-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cortex-m = "0.6.0"
 nb = "0.1.2"
 cortex-m-rt = "0.6.8"
 stm32f1 = "0.8.0"
+as-slice = "0.1"
 
 [dependencies.void]
 default-features = false

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -583,12 +583,12 @@ impl<PIN> AdcDma<PIN> where PIN: Channel<ADC1> {
 
 impl<B, PIN> crate::dma::CircReadDma<B, u16> for AdcDma<PIN>
 where
-    B: AsMut<[u16]>,
+    B: as_slice::AsMutSlice<Element=u16>,
     PIN: Channel<ADC1>,
 {
     fn circ_read(mut self, buffer: &'static mut [B; 2]) -> CircBuffer<B, Self> {
         {
-            let buffer = buffer[0].as_mut();
+            let buffer = buffer[0].as_mut_slice();
             self.channel.set_peripheral_address(unsafe{ &(*ADC1::ptr()).dr as *const _ as u32 }, false);
             self.channel.set_memory_address(buffer.as_ptr() as u32, true);
             self.channel.set_transfer_length(buffer.len() * 2);
@@ -613,12 +613,12 @@ where
 
 impl<B, PIN> crate::dma::ReadDma<B, u16> for AdcDma<PIN>
 where
-    B: AsMut<[u16]>,
+    B: as_slice::AsMutSlice<Element=u16>,
     PIN: Channel<ADC1>,
 {
     fn read(mut self, buffer: &'static mut B) -> Transfer<W, &'static mut B, Self> {
         {
-            let buffer = buffer.as_mut();
+            let buffer = buffer.as_mut_slice();
             self.channel.set_peripheral_address(unsafe{ &(*ADC1::ptr()).dr as *const _ as u32 }, false);
             self.channel.set_memory_address(buffer.as_ptr() as u32, true);
             self.channel.set_transfer_length(buffer.len());

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -482,7 +482,7 @@ pub trait Transmit {
 
 pub trait CircReadDma<B, RS>: Receive
 where
-    B: AsMut<[RS]>,
+    B: as_slice::AsMutSlice<Element=RS>,
     Self: core::marker::Sized,
 {
     fn circ_read(self, buffer: &'static mut [B; 2]) -> CircBuffer<B, Self>;
@@ -490,7 +490,7 @@ where
 
 pub trait ReadDma<B, RS>: Receive
 where
-    B: AsMut<[RS]>,
+    B: as_slice::AsMutSlice<Element=RS>,
     Self: core::marker::Sized,
 {
     fn read(
@@ -501,7 +501,7 @@ where
 
 pub trait WriteDma<A, B, TS>: Transmit
 where
-    A: AsRef<[TS]>,
+    A: as_slice::AsSlice<Element=TS>,
     B: Static<A>,
     Self: core::marker::Sized,
 {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -551,12 +551,12 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<B> crate::dma::CircReadDma<B, u8> for $rxdma where B: AsMut<[u8]> {
+            impl<B> crate::dma::CircReadDma<B, u8> for $rxdma where B: as_slice::AsMutSlice<Element=u8> {
                 fn circ_read(mut self, buffer: &'static mut [B; 2],
                 ) -> CircBuffer<B, Self>
                 {
                     {
-                        let buffer = buffer[0].as_mut();
+                        let buffer = buffer[0].as_mut_slice();
                         self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
                         self.channel.set_memory_address(buffer.as_ptr() as u32, true);
                         self.channel.set_transfer_length(buffer.len() * 2);
@@ -579,12 +579,12 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<B> crate::dma::ReadDma<B, u8> for $rxdma where B: AsMut<[u8]> {
+            impl<B> crate::dma::ReadDma<B, u8> for $rxdma where B: as_slice::AsMutSlice<Element=u8> {
                 fn read(mut self, buffer: &'static mut B,
                 ) -> Transfer<W, &'static mut B, Self>
                 {
                     {
-                        let buffer = buffer.as_mut();
+                        let buffer = buffer.as_mut_slice();
                         self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
                         self.channel.set_memory_address(buffer.as_ptr() as u32, true);
                         self.channel.set_transfer_length(buffer.len());
@@ -604,12 +604,12 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<A, B> crate::dma::WriteDma<A, B, u8> for $txdma where A: AsRef<[u8]>, B: Static<A> {
+            impl<A, B> crate::dma::WriteDma<A, B, u8> for $txdma where A: as_slice::AsSlice<Element=u8>, B: Static<A> {
                 fn write(mut self, buffer: B
                 ) -> Transfer<R, B, Self>
                 {
                     {
-                        let buffer = buffer.borrow().as_ref();
+                        let buffer = buffer.borrow().as_slice();
 
                         self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
 


### PR DESCRIPTION
cc @therealprof 

Use as_slice/as_mut_slice for dma buffers, as as_ref restricted by 32-sized buffers.