### PR TITLE
Rewrite SWJ config when modifying MAPR (fixes #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove `set_low` and `set_high` for pins in Alternate output mode
 - Renames `set_seconds` and `seconds` methods on RTC to `set_time` and `current_time`, respectively
 - Starting the timer does not generate interrupt requests anymore
+- Make MAPR::mapr() private
+
+### Fixed
+
+- Fix some F1 variants crashing when modifying MAPR if JTAG is disabled
 
 ### Changed
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -97,7 +97,7 @@ impl<PINS> I2c<I2C1, PINS> {
     where
         PINS: Pins<I2C1>,
     {
-        mapr.mapr().modify(|_, w| w.i2c1_remap().bit(PINS::REMAP));
+        mapr.modify_mapr(|_, w| w.i2c1_remap().bit(PINS::REMAP));
         I2c::_i2c1(i2c, pins, mode, clocks, apb)
     }
 }
@@ -118,7 +118,7 @@ impl<PINS> BlockingI2c<I2C1, PINS> {
     where
         PINS: Pins<I2C1>,
     {
-        mapr.mapr().modify(|_, w| w.i2c1_remap().bit(PINS::REMAP));
+        mapr.modify_mapr(|_, w| w.i2c1_remap().bit(PINS::REMAP));
         BlockingI2c::_i2c1(
             i2c,
             pins,

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -212,8 +212,7 @@ impl Timer<TIM2> {
         PINS: Pins<TIM2>,
         T: Into<Hertz>,
     {
-        mapr.mapr()
-            .modify(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
+        mapr.modify_mapr(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
 
         let Self { tim, clk } = self;
         tim2(tim, _pins, freq.into(), clk)
@@ -231,8 +230,7 @@ impl Timer<TIM3> {
         PINS: Pins<TIM3>,
         T: Into<Hertz>,
     {
-        mapr.mapr()
-            .modify(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
+        mapr.modify_mapr(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
 
         let Self { tim, clk } = self;
         tim3(tim, _pins, freq.into(), clk)
@@ -250,8 +248,7 @@ impl Timer<TIM4> {
         PINS: Pins<TIM4>,
         T: Into<Hertz>,
     {
-        mapr.mapr()
-            .modify(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
+        mapr.modify_mapr(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
 
         let Self { tim, clk } = self;
         tim4(tim, _pins, freq.into(), clk)

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -106,8 +106,7 @@ impl Timer<TIM2> {
         PINS: Pins<TIM2>,
         T: Into<Hertz>,
     {
-        mapr.mapr()
-            .modify(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
+        mapr.modify_mapr(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
         self.stop_in_debug(dbg, false);
         let Self { tim, clk } = self;
         tim2(tim, pins, clk, mode)
@@ -126,8 +125,7 @@ impl Timer<TIM3> {
         PINS: Pins<TIM3>,
         T: Into<Hertz>,
     {
-        mapr.mapr()
-            .modify(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
+        mapr.modify_mapr(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
         self.stop_in_debug(dbg, false);
         let Self { tim, clk } = self;
         tim3(tim, pins, clk, mode)
@@ -146,8 +144,7 @@ impl Timer<TIM4> {
         PINS: Pins<TIM4>,
         T: Into<Hertz>,
     {
-        mapr.mapr()
-            .modify(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
+        mapr.modify_mapr(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
         self.stop_in_debug(dbg, false);
         let Self { tim, clk } = self;
         tim4(tim, pins, clk, mode)

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -37,8 +37,7 @@ impl Timer<TIM2> {
     where
         PINS: Pins<TIM2>,
     {
-        mapr.mapr()
-            .modify(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
+        mapr.modify_mapr(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
 
         let Self { tim, clk: _ } = self;
         Qei::_tim2(tim, pins)
@@ -50,8 +49,7 @@ impl Timer<TIM3> {
     where
         PINS: Pins<TIM3>,
     {
-        mapr.mapr()
-            .modify(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
+        mapr.modify_mapr(|_, w| unsafe { w.tim3_remap().bits(PINS::REMAP) });
 
         let Self { tim, clk: _ } = self;
         Qei::_tim3(tim, pins)
@@ -63,8 +61,7 @@ impl Timer<TIM4> {
     where
         PINS: Pins<TIM4>,
     {
-        mapr.mapr()
-            .modify(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
+        mapr.modify_mapr(|_, w| w.tim4_remap().bit(PINS::REMAP == 1));
 
         let Self { tim, clk: _ } = self;
         Qei::_tim4(tim, pins)

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -232,8 +232,7 @@ macro_rules! hal {
                     $USARTX::reset(apb);
 
                     #[allow(unused_unsafe)]
-                    mapr.mapr()
-                        .modify(|_, w| unsafe{
+                    mapr.modify_mapr(|_, w| unsafe{
                             w.$usartX_remap().$bit(($closure)(PINS::REMAP))
                         });
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -79,7 +79,7 @@ impl<PINS> Spi<SPI1, PINS> {
         F: Into<Hertz>,
         PINS: Pins<SPI1>,
     {
-        mapr.mapr().modify(|_, w| w.spi1_remap().bit(PINS::REMAP));
+        mapr.modify_mapr(|_, w| w.spi1_remap().bit(PINS::REMAP));
         Spi::_spi1(spi, pins, mode, freq.into(), clocks, apb)
     }
 }


### PR DESCRIPTION
This stack exchange post explains the issue pretty well https://electronics.stackexchange.com/questions/260757/timer1-remap-cause-debug-crash-on-stm32f103

The SWJ_CFG bits are write only, meaning that reads are undefined. On the blue pill, reads seem to work fine anyway, but on the RGT6, they return some other value which messes with the debug port.

My fix for it is to make the `mapr` function private, and only allow modifications via the `modify_mapr` function which remembers the state of the debug port and writes the config accordingly.

Since `mapr` was public, this is a breaking change. I see no reason to have it public, in fact, users can break the abstractions by modifying `mapr` so this new `modify_mapr` function is marked `pub(crate)`
