### PR TITLE
Re-add core::fmt::Write for serial Tx

### DIFF
--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -1,0 +1,80 @@
+//! Serial interface write formatted strings test
+//!
+//! You need to connect the Tx pin to the Rx pin of a serial-usb converter
+//! so you can see the message in a serial console (e.g. Arduino console).
+
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use stm32f1xx_hal::{
+    prelude::*,
+    pac,
+    serial::{Config, Serial},
+};
+use cortex_m_rt::entry;
+
+use core::fmt::Write;
+
+#[entry]
+fn main() -> ! {
+    // Get access to the device specific peripherals from the peripheral access crate
+    let p = pac::Peripherals::take().unwrap();
+
+    // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+    // HAL structs
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
+    // `clocks`
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    // Prepare the alternate function I/O registers
+    let mut afio = p.AFIO.constrain(&mut rcc.apb2);
+
+    // Prepare the GPIOB peripheral
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+
+    // USART1
+    // let tx = gpioa.pa9.into_alternate_push_pull(&mut gpioa.crh);
+    // let rx = gpioa.pa10;
+
+    // USART1
+    // let tx = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
+    // let rx = gpiob.pb7;
+
+    // USART2
+    // let tx = gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl);
+    // let rx = gpioa.pa3;
+
+    // USART3
+    // Configure pb10 as a push_pull output, this will be the tx pin
+    let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
+    // Take ownership over pb11
+    let rx = gpiob.pb11;
+
+    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // the registers are used to enable and configure the device.
+    let serial = Serial::usart3(
+        p.USART3,
+        (tx, rx),
+        &mut afio.mapr,
+        Config::default().baudrate(9600.bps()),
+        clocks,
+        &mut rcc.apb1,
+    );
+
+    // Split the serial struct into a receiving and a transmitting part
+    let (mut tx, _rx) = serial.split();
+
+    let number = 103;
+    writeln!(tx, "Hello formatted string {}", number).unwrap();
+
+    // for windows
+    // write!(tx, "Hello formatted string {}\r\n", number).unwrap();
+
+    loop {}
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -43,6 +43,7 @@ use core::sync::atomic::{self, Ordering};
 use nb;
 use crate::pac::{USART1, USART2, USART3};
 use void::Void;
+use embedded_hal::serial::Write;
 
 use crate::afio::MAPR;
 use crate::dma::{dma1, CircBuffer, Static, Transfer, R, W, RxDma, TxDma};
@@ -417,6 +418,18 @@ macro_rules! hal {
                 }
             }
         )+
+    }
+}
+
+impl<USART> core::fmt::Write for Tx<USART>
+where
+    Tx<USART>: embedded_hal::serial::Write<u8>,
+{
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        s.as_bytes()
+            .iter()
+            .try_for_each(|c| nb::block!(self.write(*c)))
+            .map_err(|_| core::fmt::Error)
     }
 }
 


### PR DESCRIPTION
This fixes issue #110.

Also add example `serial-fmt` for using writeln! with serial Tx.