### PR TITLE
Implement more general GPIO pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - DMA traits now require AsSlice instead of AsRef
+- GPIO `downgrade` function now returns a `Pxx` instead of a type specific to a
+  GPIO port
 
 ## [v0.4.0] - 2019-08-09
 

--- a/examples/blinky_generic.rs
+++ b/examples/blinky_generic.rs
@@ -1,0 +1,53 @@
+//! Blinks several LEDs stored in an array
+
+#![deny(unsafe_code)]
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+use nb::block;
+
+use stm32f1xx_hal::{
+    prelude::*,
+    pac,
+    timer::Timer,
+};
+use cortex_m_rt::entry;
+use embedded_hal::digital::v2::OutputPin;
+
+#[entry]
+fn main() -> ! {
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    // Acquire the GPIO peripherals
+    let mut gpioa = dp.GPIOA.split(&mut rcc.apb2);
+    let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
+
+    // Configure the syst timer to trigger an update every second
+    let mut timer = Timer::syst(cp.SYST, &clocks).start_count_down(1.hz());
+
+    // Create an array of LEDS to blink
+    let mut leds = [
+        gpioc.pc13.into_push_pull_output(&mut gpioc.crh).downgrade(),
+        gpioa.pa1.into_push_pull_output(&mut gpioa.crl).downgrade()
+    ];
+
+    // Wait for the timer to trigger an update and change the state of the LED
+    loop {
+        block!(timer.wait()).unwrap();
+        for led in leds.iter_mut() {
+            led.set_high().unwrap();
+        }
+        block!(timer.wait()).unwrap();
+        for led in leds.iter_mut() {
+            led.set_low().unwrap();
+        }
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -217,7 +217,6 @@ macro_rules! gpio {
 
 
 
-
             $(
                 /// Pin
                 pub struct $PXi<MODE> {
@@ -542,6 +541,7 @@ macro_rules! impl_pxx {
                     $(Pxx::$pin(pin) => pin.set_high()),*
                 }
             }
+
             fn set_low(&mut self) -> Result<(), Void> {
                 match self {
                     $(Pxx::$pin(pin) => pin.set_low()),*
@@ -570,6 +570,7 @@ macro_rules! impl_pxx {
                     $(Pxx::$pin(pin) => pin.is_high()),*
                 }
             }
+
             fn is_low(&self) -> Result<bool, Void> {
                 match self {
                     $(Pxx::$pin(pin) => pin.is_low()),*

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -151,7 +151,7 @@ macro_rules! gpio {
                 }
             }
 
-            /// Partially erased pin
+            /// Partially erased pin. Only used in the Pxx enum
             pub struct Generic<MODE> {
                 i: u8,
                 _mode: PhantomData<MODE>,
@@ -454,14 +454,19 @@ macro_rules! gpio {
 
                 impl<MODE> $PXi<MODE> where MODE: Active {
                     /// Erases the pin number from the type
-                    ///
-                    /// This is useful when you want to collect the pins into an array where you
-                    /// need all the elements to have the same type
-                    pub fn into_port(self) -> Generic<MODE> {
+                    fn into_generic(self) -> Generic<MODE> {
                         Generic {
                             i: $i,
                             _mode: self._mode,
                         }
+                    }
+
+                    /// Erases the pin number and port from the type
+                    ///
+                    /// This is useful when you want to collect the pins into an array where you
+                    /// need all the elements to have the same type
+                    pub fn downgrade(self) -> Pxx<MODE> {
+                        self.into_generic().downgrade()
                     }
                 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -681,5 +681,3 @@ gpio!(GPIOE, gpioe, gpioa, PEx, [
     PE14: (pe14, 14, Input<Floating>, CRH),
     PE15: (pe15, 15, Input<Floating>, CRH),
 ]);
-
-

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -152,18 +152,18 @@ macro_rules! gpio {
             }
 
             /// Partially erased pin
-            pub struct $PXx<MODE> {
+            pub struct Generic<MODE> {
                 i: u8,
                 _mode: PhantomData<MODE>,
             }
 
-            impl<MODE> $PXx<MODE> {
+            impl<MODE> Generic<MODE> {
                 pub fn downgrade(self) -> Pxx<MODE> {
                     Pxx::$PXx(self)
                 }
             }
 
-            impl<MODE> OutputPin for $PXx<Output<MODE>> {
+            impl<MODE> OutputPin for Generic<Output<MODE>> {
                 type Error = Void;
                 fn set_high(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
@@ -176,7 +176,7 @@ macro_rules! gpio {
                 }
             }
 
-            impl<MODE> InputPin for $PXx<Input<MODE>> {
+            impl<MODE> InputPin for Generic<Input<MODE>> {
                 type Error = Void;
                 fn is_high(&self) -> Result<bool, Self::Error> {
                     self.is_low().map(|b| !b)
@@ -188,7 +188,7 @@ macro_rules! gpio {
                 }
             }
 
-            impl <MODE> StatefulOutputPin for $PXx<Output<MODE>> {
+            impl <MODE> StatefulOutputPin for Generic<Output<MODE>> {
                 fn is_set_high(&self) -> Result<bool, Self::Error> {
                     self.is_set_low().map(|b| !b)
                 }
@@ -199,9 +199,9 @@ macro_rules! gpio {
                 }
             }
 
-            impl <MODE> toggleable::Default for $PXx<Output<MODE>> {}
+            impl <MODE> toggleable::Default for Generic<Output<MODE>> {}
 
-            impl InputPin for $PXx<Output<OpenDrain>> {
+            impl InputPin for Generic<Output<OpenDrain>> {
                 type Error = Void;
                 fn is_high(&self) -> Result<bool, Self::Error> {
                     self.is_low().map(|b| !b)
@@ -212,6 +212,11 @@ macro_rules! gpio {
                     Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 })
                 }
             }
+
+            pub type $PXx<MODE> = Pxx<MODE>;
+
+
+
 
             $(
                 /// Pin
@@ -452,8 +457,8 @@ macro_rules! gpio {
                     ///
                     /// This is useful when you want to collect the pins into an array where you
                     /// need all the elements to have the same type
-                    pub fn downgrade(self) -> $PXx<MODE> {
-                        $PXx {
+                    pub fn into_port(self) -> Generic<MODE> {
+                        Generic {
                             i: $i,
                             _mode: self._mode,
                         }
@@ -521,7 +526,7 @@ macro_rules! impl_pxx {
 
         pub enum Pxx<MODE> {
             $(
-                $pin($port::$pin<MODE>)
+                $pin($port::Generic<MODE>)
             ),*
         }
 


### PR DESCRIPTION
This adds the generic pin enum which spun out of #114 

I'm not sure if only having the downgrade function on the already downgraded pins is a good idea as you'd have to do `.downgrade().downgrade()` if you want to go all the way, which I imagine is the thing people want to do most often. Actually, do we even have a use for the half downgraded pins anymore?

This has a fair amount of code duplication, do you think I should make another macro to automatically impl the individual functions. Or should we use the enum_dispatch crate? I'm not a huge fan of adding external dependencies for a single use, mainly for security concerns, but perhaps someone disagrees.

Also, for now this is untested on actual hardware, but I don't see any reason it wouldn't work since it's just an alias.