### PR TITLE
README explain cargo run permission for gdb #113

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ If no microcontroller is specified, the crate will not compile.
 
 ### Trying out the examples
 
+You may need to give `cargo` permission to call `gdb` from the working directory.
+- Linux
+  ```bash
+  echo "set auto-load safe-path $(pwd)" >> ~/.gdbinit
+  ```
+- Windows
+  ```batch
+  echo set auto-load safe-path %CD% >> %USERPROFILE%\.gdbinit
+  ```
+
+Compile, load, and launch the hardware debugger.
 ```bash
 $ rustup target add thumbv7m-none-eabi
 


### PR DESCRIPTION
Update `README.md` to explain how to give `cargo run` permission to launch `gdb`.
As discussed in discord and #113, on first-run the gdb debugger doesn't give `cargo run` permission to run `gdb` automatically and load the FW to the HW.

This PR updates the `README.md` to show a command which can give this permission, and limits the permission addition to the scope of the `stm32f1xx-hal` repository in use.

Because of the different conventions between Linux and Windows, the two commands were unable to be distilled into the same line of text.

It is unknown if only the Linux example is wanted, and the windows version of the command should be removed?
It seems the `README.md` already makes this assumption elsewhere?

Suggestions are welcome.