### PR TITLE
error on any invalid target combination

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,16 @@
 
 #![no_std]
 
+// If no target specified, print error message.
+#[cfg(not(any(feature = "stm32f100", feature = "stm32f101", feature = "stm32f103")))]
+compile_error!("Target not found. A `--feature <target-name>` is required.");
+
+// If any two or more targets are specified, print error message.
+#[cfg(all(feature = "stm32f100", feature = "stm32f101"))]
+#[cfg(all(feature = "stm32f100", feature = "stm32f103"))]
+#[cfg(all(feature = "stm32f101", feature = "stm32f103"))]
+compile_error!("Multiple targets specified. Only a single `--feature <target-name>` can be specified.");
+
 #[cfg(feature = "device-selected")]
 use embedded_hal as hal;
 


### PR DESCRIPTION
Only allow exactly one target "feature" to be set at any time, as discussed in #112 and discord.
Otherwise a compile-time error message will be given.

Is the "greater than one target specified" case useful to error on as well?
The "zero target specified" case has a confusing message about missing imports and methods, but the compiler has a message which might already be close enough.
```bash
error[E0252]: the name `pac` is defined multiple times
   --> src\lib.rs:104:9
    |
101 | pub use stm32f1::stm32f100 as pac;
    |         ------------------------- previous import of the module `pac` here
...
104 | pub use stm32f1::stm32f101 as pac;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ `pac` reimported here
    |
    = note: `pac` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
    |
104 | pub use stm32f1::stm32f101 as other_pac;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```

Is only the first "zero targets specified" error message wanted?
Feedback is welcome.