### PR TITLE
Set i2c frequency using Hertz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Renames `set_seconds` and `seconds` methods on RTC to `set_time` and `current_time`, respectively
 - Starting the timer does not generate interrupt requests anymore
 - Make MAPR::mapr() private
+- i2c mode now takes Hertz instead of a generic u32
 
 ### Fixed
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -46,6 +46,14 @@ pub enum Mode {
 }
 
 impl Mode {
+    pub fn standard<F: Into<Hertz>>(frequency: F) -> Self {
+        Mode::Standard{frequency: frequency.into()}
+    }
+
+    pub fn fast<F: Into<Hertz>>(frequency: F, duty_cycle: DutyCycle) -> Self {
+        Mode::Fast{frequency: frequency.into(), duty_cycle}
+    }
+
     pub fn get_frequency(&self) -> Hertz {
         match self {
             &Mode::Standard { frequency } => frequency,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,7 @@
 //! Inter-Integrated Circuit (I2C) bus
 
 use crate::afio::MAPR;
+use crate::time::Hertz;
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7, PB8, PB9};
 use crate::gpio::{Alternate, OpenDrain};
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
@@ -36,16 +37,16 @@ pub enum DutyCycle {
 #[derive(Debug, PartialEq)]
 pub enum Mode {
     Standard {
-        frequency: u32,
+        frequency: Hertz,
     },
     Fast {
-        frequency: u32,
+        frequency: Hertz,
         duty_cycle: DutyCycle,
     },
 }
 
 impl Mode {
-    pub fn get_frequency(&self) -> u32 {
+    pub fn get_frequency(&self) -> Hertz {
         match self {
             &Mode::Standard { frequency } => frequency,
             &Mode::Fast { frequency, .. } => frequency,
@@ -251,7 +252,7 @@ macro_rules! hal {
 
                     let pclk1 = clocks.pclk1().0;
 
-                    assert!(mode.get_frequency() <= 400_000);
+                    assert!(mode.get_frequency().0 <= 400_000);
 
                     let mut i2c = I2c { i2c, pins, mode, pclk1 };
                     i2c.init();
@@ -273,7 +274,7 @@ macro_rules! hal {
                                 w.trise().bits((pclk1_mhz + 1) as u8)
                             });
                             self.i2c.ccr.write(|w| unsafe {
-                                w.ccr().bits(((self.pclk1 / (freq * 2)) as u16).max(4))
+                                w.ccr().bits(((self.pclk1 / (freq.0 * 2)) as u16).max(4))
                             });
                         },
                         Mode::Fast { ref duty_cycle, .. } => {
@@ -283,8 +284,8 @@ macro_rules! hal {
 
                             self.i2c.ccr.write(|w| {
                                 let (freq, duty) = match duty_cycle {
-                                    &DutyCycle::Ratio2to1 => (((self.pclk1 / (freq * 3)) as u16).max(1), false),
-                                    &DutyCycle::Ratio16to9 => (((self.pclk1 / (freq * 25)) as u16).max(1), true)
+                                    &DutyCycle::Ratio2to1 => (((self.pclk1 / (freq.0* 3)) as u16).max(1), false),
+                                    &DutyCycle::Ratio16to9 => (((self.pclk1 / (freq.0 * 25)) as u16).max(1), true)
                                 };
 
                                 unsafe {

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,19 +5,19 @@ use cortex_m::peripheral::DWT;
 use crate::rcc::Clocks;
 
 /// Bits per second
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Bps(pub u32);
 
 /// Hertz
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Hertz(pub u32);
 
 /// KiloHertz
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct KiloHertz(pub u32);
 
 /// MegaHertz
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct MegaHertz(pub u32);
 
 /// Time unit


### PR DESCRIPTION
In #127 I realised that i2c doesn't use the Hertz structs to set freuency. This seems strange, so I fixed it.

Unlike the other peripherals, this doesn't allow construction from `KiloHertz` or `MegaHertz` as that would have required making the `mode` struct generic, which would propagate a lot. It might still be a good idea to do so, though perhaps it's better to pass the frequency separately to the i2c "constructor". This would require less generics.