### PR TITLE
Changed timer stop_in_debug to modify dbg.cr instead of overwriting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix some F1 variants crashing when modifying MAPR if JTAG is disabled
+- Switched Timer stop_in_debug to modify cr instead of writing it to prevent it clobbering the rest of the register (was breaking ITM output when configuring pwm_input for example)
 
 ### Changed
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -157,7 +157,7 @@ macro_rules! hal {
                 /// Stopping timer in debug mode can cause troubles when sampling the signal
                 #[inline(always)]
                 pub fn stop_in_debug(&mut self, dbg: &mut DBG, state: bool) {
-                    dbg.cr.write(|w| w.$dbg_timX_stop().bit(state));
+                    dbg.cr.modify(|_, w| w.$dbg_timX_stop().bit(state));
                 }
 
                 /// Releases the TIM Peripheral


### PR DESCRIPTION
Quick fix to prevent configuring pwm_input clobbering the dbg.cr register.

The issue I was having was ITM was breaking after the call to stop_in_debug in timer.rs because part of the ITM config lives in dbg.cr and the call to write was resetting everything to 0.

I had a quick scan for other similar issues in timer.rs but didn't see any.