### PR TITLE
Added all timers for all variants as described by CubeMX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `select_frequency` method to RTC
 - Unidirectional DMA support for SPI (TX only)
 - Added USB driver for `stm32f102` and `stm32f103` devices
-
+- Added all timers for all variants as described by CubeMX. Commented out {TIM9, TIM10} for XL and {TIM12, TIM13, TIM14} for XL and F100-HIGH due to missing fields for those devices in stm32-rs.
 - ADC measurement now can be run by timer
 
 ### Breaking changes
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Starting the timer does not generate interrupt requests anymore
 - Make MAPR::mapr() private
 - i2c mode now takes Hertz instead of a generic u32
+- Timers that were previously incorrectly available without medium/high/xl density features may now be missing
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,18 @@
 
 This crate supports multiple microcontrollers in the
 stm32f1 family. Which specific microcontroller you want to build for has to be
-specified with a feature, for example `stm32f103`.
+specified with a feature, for example `stm32f103`. 
 
 If no microcontroller is specified, the crate will not compile.
+
+You may also need to specify the density of the device with `medium`, `high` or `xl` 
+to enable certain peripherals. Generally the density can be determined by the 2nd character 
+after the number in the device name (i.e. For STM32F103C6U, the 6 indicates a low-density
+device) but check the datasheet or CubeMX to be sure.
+* 4, 6 => low density, no feature required
+* 8, B => `medium` feature
+* C, D, E => `high` feature
+* F, G => `xl` feature
 
 ### Supported Microcontrollers
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -11,10 +11,13 @@ use core::sync::atomic::{self, Ordering};
 use cortex_m::asm::delay;
 
 use crate::stm32::ADC1;
-#[cfg(any(
-    feature = "stm32f103",
-))]
+#[cfg(feature = "stm32f103")]
 use crate::stm32::ADC2;
+#[cfg(all(
+    feature = "stm32f103",
+    feature = "high",
+))]
+use crate::stm32::ADC3;
 
 /// Continuous mode
 pub struct Continuous;
@@ -484,11 +487,17 @@ adc_hal! {
     ADC1: (adc1),
 }
 
-#[cfg(any(
-    feature = "stm32f103",
-))]
+#[cfg(feature = "stm32f103")]
 adc_hal! {
     ADC2: (adc2),
+}
+
+#[cfg(all(
+    feature = "stm32f103",
+    feature = "high",
+))]
+adc_hal! {
+    ADC3: (adc3),
 }
 
 pub struct AdcPayload<PINS, MODE> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,14 +94,21 @@
 
 #![no_std]
 
+// Some pac crates have fields specified in such a way that they are safe and other
+// have them unsafe (likely an SVD error that needs patching). Unsafe blocks for 
+// one device cause warnings for the safe devices. This disables that warning.
+#![allow(unused_unsafe)]
+
 // If no target specified, print error message.
 #[cfg(not(any(feature = "stm32f100", feature = "stm32f101", feature = "stm32f103")))]
 compile_error!("Target not found. A `--feature <target-name>` is required.");
 
 // If any two or more targets are specified, print error message.
-#[cfg(all(feature = "stm32f100", feature = "stm32f101"))]
-#[cfg(all(feature = "stm32f100", feature = "stm32f103"))]
-#[cfg(all(feature = "stm32f101", feature = "stm32f103"))]
+#[cfg(any(
+    all(feature = "stm32f100", feature = "stm32f101"),
+    all(feature = "stm32f100", feature = "stm32f103"),
+    all(feature = "stm32f101", feature = "stm32f103"),
+))]
 compile_error!("Multiple targets specified. Only a single `--feature <target-name>` can be specified.");
 
 #[cfg(feature = "device-selected")]

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -163,142 +163,132 @@ fn compute_arr_presc(freq: u32, clock: u32) -> (u16, u16) {
     (core::cmp::max(1, arr as u16), presc as u16)
 }
 macro_rules! hal {
-   ($($TIMX:ident: ($timX:ident, $pclkX:ident ),)+) => {
-      $(
-         fn $timX<PINS,T>(
-            tim: $TIMX,
-            _pins: PINS,
-            clk: Hertz,
-            mode : Configuration<T>,
+    ($($TIMX:ident: ($timX:ident, $pclkX:ident ),)+) => {
+        $(
+            fn $timX<PINS,T>(
+                tim: $TIMX,
+                _pins: PINS,
+                clk: Hertz,
+                mode : Configuration<T>,
             ) -> PwmInput<$TIMX,PINS>
-         where
-         PINS: Pins<$TIMX>,
-         T : Into<Hertz>
-         {
-            use crate::pwm_input::Configuration::*;
-            // Disable capture on both channels during setting
-            // (for Channel X bit is CCXE)
-            tim.ccer.modify(|_,w| w.cc1e().clear_bit().cc2e().clear_bit()
-                            .cc1p().clear_bit().cc2p().set_bit());
+            where
+                PINS: Pins<$TIMX>,
+                T : Into<Hertz>
+            {
+                use crate::pwm_input::Configuration::*;
+                // Disable capture on both channels during setting
+                // (for Channel X bit is CCXE)
+                tim.ccer.modify(|_,w| w.cc1e().clear_bit().cc2e().clear_bit()
+                                       .cc1p().clear_bit().cc2p().set_bit());
 
+                // Define the direction of the channel (input/output)
+                // and the used input
+                tim.ccmr1_input().modify( |_,w| w.cc1s().ti1().cc2s().ti1());
 
-            // Define the direction of the channel (input/output)
-            // and the used input
-            tim.ccmr1_input().modify( |_,w| w.cc1s().ti1().cc2s().ti1());
+                tim.dier.write(|w| w.cc1ie().set_bit());
 
-            tim.dier.write(|w| w.cc1ie().set_bit());
+                // Configure slave mode control register
+                // Selects the trigger input to be used to synchronize the counter
+                // 101: Filtered Timer Input 1 (TI1FP1)
+                // ---------------------------------------
+                // Slave Mode Selection :
+                //  100: Reset Mode - Rising edge of the selected trigger input (TRGI)
+                //  reinitializes the counter and generates an update of the registers.
+                tim.smcr.modify( |_,w| unsafe {w.ts().bits(0b101).sms().bits(0b100)});
 
-            // Configure slave mode control register
-            // Selects the trigger input to be used to synchronize the counter
-            // 101: Filtered Timer Input 1 (TI1FP1)
-            // ---------------------------------------
-            // Slave Mode Selection :
-            //  100: Reset Mode - Rising edge of the selected trigger input (TRGI)
-            //  reinitializes the counter and generates an update of the registers.
-            tim.smcr.modify( |_,w| unsafe {w.ts().bits(0b101).sms().bits(0b100)});
+                match mode {
+                    Frequency(f)  => {
+                        let freq = f.into().0;
+                        let max_freq = if freq > 5 {freq/5} else {1};
+                        let (arr,presc) = compute_arr_presc(max_freq, clk.0);
+                        tim.arr.write(|w| w.arr().bits(arr));
+                        tim.psc.write(|w| w.psc().bits(presc) );
+                    },
+                    DutyCycle(f) => {
+                        let freq = f.into().0;
+                        let max_freq = if freq > 2 {freq/2 + freq/4 + freq/8} else {1};
+                        let (arr,presc) = compute_arr_presc(max_freq, clk.0);
+                        tim.arr.write(|w| w.arr().bits(arr));
+                        tim.psc.write(|w| w.psc().bits(presc) );
+                    },
+                    RawFrequency(f) => {
+                        let freq = f.into().0;
+                        let (arr,presc) = compute_arr_presc(freq, clk.0);
+                        tim.arr.write(|w| w.arr().bits(arr));
+                        tim.psc.write(|w| w.psc().bits(presc) );
+                    }
+                    RawValues{arr, presc} => {
+                        tim.arr.write(|w| w.arr().bits(arr));
+                        tim.psc.write(|w| w.psc().bits(presc) );
+                    }
+                }
 
-            match mode {
-               Frequency(f)  => {
-                  let freq = f.into().0;
-                  let max_freq = if freq > 5 {freq/5} else {1};
-                  let (arr,presc) = compute_arr_presc(max_freq, clk.0);
-                  tim.arr.write(|w| w.arr().bits(arr));
-                  tim.psc.write(|w| w.psc().bits(presc) );
+                // Enable Capture on both channels
+                tim.ccer.modify(|_,w| w.cc1e().set_bit().cc2e().set_bit());
 
-               },
-               DutyCycle(f) => {
-                  let freq = f.into().0;
-                  let max_freq = if freq > 2 {freq/2 + freq/4 + freq/8} else {1};
-                  let (arr,presc) = compute_arr_presc(max_freq, clk.0);
-                  tim.arr.write(|w| w.arr().bits(arr));
-                  tim.psc.write(|w| w.psc().bits(presc) );
-               },
-               RawFrequency(f) => {
-                  let freq = f.into().0;
-                  let (arr,presc) = compute_arr_presc(freq, clk.0);
-                  tim.arr.write(|w| w.arr().bits(arr));
-                  tim.psc.write(|w| w.psc().bits(presc) );
-               }
-               RawValues{arr, presc} => {
-                  tim.arr.write(|w| w.arr().bits(arr));
-                  tim.psc.write(|w| w.psc().bits(presc) );
-
-               }
+                tim.cr1.modify(|_,w| w.cen().set_bit());
+                unsafe { mem::MaybeUninit::uninit().assume_init() }
             }
 
-            // Enable Capture on both channels
-            tim.ccer.modify(|_,w| w.cc1e().set_bit().cc2e().set_bit());
+            impl<PINS> PwmInput<$TIMX,PINS> where PINS : Pins<$TIMX> {
+                /// Return the frequency sampled by the timer
+                pub fn read_frequency(&self, mode : ReadMode, clocks : &Clocks) -> Result<Hertz,Error> {
+                    match mode {
+                        ReadMode::WaitForNextCapture => self.wait_for_capture(),
+                        _ => (),
+                    }
+                    
+                    let presc = unsafe { (*$TIMX::ptr()).psc.read().bits() as u16};
+                    let ccr1 = unsafe { (*$TIMX::ptr()).ccr1.read().bits() as u16};
 
+                    // Formulas :
+                    //
+                    // F_timer = F_pclk / (PSC+1)*(ARR+1)
+                    // Frac_arr = (CCR1+1)/(ARR+1)
+                    // F_signal = F_timer/Frac_arr
+                    // <=> F_signal = [(F_plck)/((PSC+1)*(ARR+1))] * [(ARR+1)/(CCR1+1)]
+                    // <=> F_signal = F_pclk / ((PSC+1)*(CCR1+1))
+                    //
+                    // Where :
+                    // * PSC is the prescaler register
+                    // * ARR is the auto-reload register
+                    // * F_timer is the number of time per second where the timer overflow under normal
+                    // condition
+                    //
+                    if ccr1 == 0 {
+                        Err(Error::FrequencyTooLow)
+                    } else {
+                        let clk : u32 = clocks.$pclkX().0;
+                        Ok(Hertz(clk/((presc+1) as u32*(ccr1 + 1)as u32)))
+                    }
+                }
 
-            tim.cr1.modify(|_,w| w.cen().set_bit());
+                /// Return the duty in the form of a fraction : (duty_cycle/period)
+                pub fn read_duty(&self, mode : ReadMode) -> Result<(u16,u16),Error> {
+                    match mode {
+                        ReadMode::WaitForNextCapture => self.wait_for_capture(),
+                        _ => (),
+                    }
 
+                    // Formulas :
+                    // Duty_cycle = (CCR2+1)/(CCR1+1)
+                    let ccr1 = unsafe { (*$TIMX::ptr()).ccr1.read().bits() as u16};
+                    let ccr2 = unsafe { (*$TIMX::ptr()).ccr2.read().bits() as u16};
+                    if ccr1 == 0 {
+                        Err(Error::FrequencyTooLow)
+                    } else {
+                        Ok((ccr2,ccr1))
+                    }
+                }
 
-            unsafe { mem::MaybeUninit::uninit().assume_init() }
-         }
-
-      impl<PINS> PwmInput<$TIMX,PINS> where PINS : Pins<$TIMX> {
-         /// Return the frequency sampled by the timer
-         pub fn read_frequency(&self, mode : ReadMode, clocks : &Clocks) -> Result<Hertz,Error> {
-
-            match mode {
-               ReadMode::WaitForNextCapture => self.wait_for_capture(),
-                  _ => (),
+                /// Wait until the timer has captured a period
+                fn wait_for_capture(&self) {
+                    unsafe { (*$TIMX::ptr()).sr.write(|w| w.uif().clear_bit().cc1if().clear_bit().cc1of().clear_bit())};
+                    while unsafe { (*$TIMX::ptr()).sr.read().cc1if().bit_is_clear()} {}
+                }
             }
-            let presc = unsafe { (*$TIMX::ptr()).psc.read().bits() as u16};
-            let ccr1 = unsafe { (*$TIMX::ptr()).ccr1.read().bits() as u16};
-
-            // Formulas :
-            //
-            // F_timer = F_pclk / (PSC+1)*(ARR+1)
-            // Frac_arr = (CCR1+1)/(ARR+1)
-            // F_signal = F_timer/Frac_arr
-            // <=> F_signal = [(F_plck)/((PSC+1)*(ARR+1))] * [(ARR+1)/(CCR1+1)]
-            // <=> F_signal = F_pclk / ((PSC+1)*(CCR1+1))
-            //
-            // Where :
-            // * PSC is the prescaler register
-            // * ARR is the auto-reload register
-            // * F_timer is the number of time per second where the timer overflow under normal
-            // condition
-            //
-            if ccr1 == 0 {
-               Err(Error::FrequencyTooLow)
-            }
-            else {
-               let clk : u32 = clocks.$pclkX().0;
-               Ok(Hertz(clk/((presc+1) as u32*(ccr1 + 1)as u32)))
-            }
-         }
-
-
-         /// Return the duty in the form of a fraction : (duty_cycle/period)
-         pub fn read_duty(&self, mode : ReadMode) -> Result<(u16,u16),Error> {
-
-            match mode {
-               ReadMode::WaitForNextCapture => self.wait_for_capture(),
-               _ => (),
-            }
-
-            // Formulas :
-            // Duty_cycle = (CCR2+1)/(CCR1+1)
-            let ccr1 = unsafe { (*$TIMX::ptr()).ccr1.read().bits() as u16};
-            let ccr2 = unsafe { (*$TIMX::ptr()).ccr2.read().bits() as u16};
-            if ccr1 == 0 {
-               Err(Error::FrequencyTooLow)
-            } else {
-               Ok((ccr2,ccr1))
-            }
-         }
-
-         /// Wait until the timer has captured a period
-         fn wait_for_capture(&self) {
-            unsafe { (*$TIMX::ptr()).sr.write(|w| w.uif().clear_bit().cc1if().clear_bit().cc1of().clear_bit())};
-            while unsafe { (*$TIMX::ptr()).sr.read().cc1if().bit_is_clear()} {}
-         }
-      }
-
-      )+
-   }
+        )+
+    }
 }
 
 hal! {

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -4,11 +4,15 @@
 use core::marker::PhantomData;
 use core::mem;
 
-use crate::stm32::{DBGMCU as DBG, TIM1, TIM2, TIM3, TIM4};
+use crate::pac::{DBGMCU as DBG, TIM2, TIM3};
+#[cfg(feature = "medium")]
+use crate::pac::TIM4;
 
 use crate::afio::MAPR;
-use crate::gpio::gpioa::{PA0, PA1, PA15, PA6, PA7, PA8, PA9};
-use crate::gpio::gpiob::{PB3, PB4, PB5, PB6, PB7};
+use crate::gpio::gpioa::{PA0, PA1, PA15, PA6, PA7};
+use crate::gpio::gpiob::{PB3, PB4, PB5};
+#[cfg(feature = "medium")]
+use crate::gpio::gpiob::{PB6, PB7};
 use crate::gpio::{Floating, Input};
 use crate::rcc::Clocks;
 use crate::time::Hertz;
@@ -18,6 +22,7 @@ pub trait Pins<TIM> {
     const REMAP: u8;
 }
 
+#[cfg(feature = "medium")]
 impl Pins<TIM4> for (PB6<Input<Floating>>, PB7<Input<Floating>>) {
     const REMAP: u8 = 0b0;
 }
@@ -36,10 +41,6 @@ impl Pins<TIM2> for (PA0<Input<Floating>>, PA1<Input<Floating>>) {
 
 impl Pins<TIM2> for (PA15<Input<Floating>>, PB3<Input<Floating>>) {
     const REMAP: u8 = 0b11;
-}
-
-impl Pins<TIM1> for (PA8<Input<Floating>>, PA9<Input<Floating>>) {
-    const REMAP: u8 = 0b00;
 }
 
 /// PWM Input
@@ -132,6 +133,7 @@ impl Timer<TIM3> {
     }
 }
 
+#[cfg(feature = "medium")]
 impl Timer<TIM4> {
     pub fn pwm_input<PINS, T>(
         mut self,
@@ -300,7 +302,11 @@ macro_rules! hal {
 }
 
 hal! {
-   TIM2: (tim2, pclk1_tim),
-   TIM3: (tim3, pclk1_tim),
-   TIM4: (tim4, pclk1_tim),
+    TIM2: (tim2, pclk1_tim),
+    TIM3: (tim3, pclk1_tim),
+}
+
+#[cfg(feature = "medium")]
+hal! {
+    TIM4: (tim4, pclk1_tim),
 }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -269,7 +269,7 @@ impl CFGR {
             _ => (true, false),
         };
 
-        let apre_bits = self
+        let apre_bits: u8 = self
             .adcclk
             .map(|adcclk| match pclk2 / adcclk {
                 0..=2 => 0b00,
@@ -530,17 +530,14 @@ macro_rules! ahb_bus {
     }
 }
 
-#[cfg(any(
-    feature = "stm32f100",
-    feature = "stm32f103",
-))]
-bus! {
-    TIM1 => (APB2, tim1en, tim1rst),
-}
 #[cfg(feature = "stm32f103")]
 bus! {
     ADC2 => (APB2, adc2en, adc2rst),
     CAN1 => (APB1, canen, canrst),
+}
+#[cfg(all(feature = "stm32f103", feature = "high",))]
+bus! {
+    ADC3 => (APB2, adc3en, adc3rst),
 }
 bus! {
     ADC1 => (APB2, adc1en, adc1rst),
@@ -554,18 +551,10 @@ bus! {
     I2C2 => (APB1, i2c2en, i2c2rst),
     SPI1 => (APB2, spi1en, spi1rst),
     SPI2 => (APB1, spi2en, spi2rst),
-    TIM2 => (APB1, tim2en, tim2rst),
-    TIM3 => (APB1, tim3en, tim3rst),
-    TIM4 => (APB1, tim4en, tim4rst),
     USART1 => (APB2, usart1en, usart1rst),
     USART2 => (APB1, usart2en, usart2rst),
     USART3 => (APB1, usart3en, usart3rst),
     WWDG => (APB1, wwdgen, wwdgrst),
-}
-#[cfg(feature = "high")]
-bus! {
-    TIM6 => (APB1, tim6en, tim6rst),
-    TIM7 => (APB1, tim7en, tim7rst),
 }
 
 ahb_bus! {
@@ -577,4 +566,66 @@ ahb_bus! {
 #[cfg(feature = "high")]
 ahb_bus! {
     FSMC => (fsmcen),
+}
+
+bus! {
+    TIM2 => (APB1, tim2en, tim2rst),
+    TIM3 => (APB1, tim3en, tim3rst),
+}
+
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+bus! {
+    TIM1 => (APB2, tim1en, tim1rst),
+}
+
+#[cfg(any(feature = "stm32f100", feature = "stm32f105", feature = "high",))]
+bus! {
+    TIM6 => (APB1, tim6en, tim6rst),
+}
+
+#[cfg(any(
+    all(
+        feature = "high",
+        any(feature = "stm32f101", feature = "stm32f103", feature = "stm32f107",)
+    ),
+    any(feature = "stm32f100", feature = "stm32f105",)
+))]
+bus! {
+    TIM7 => (APB1, tim7en, tim7rst),
+}
+
+#[cfg(feature = "stm32f100")]
+bus! {
+    TIM15 => (APB2, tim15en, tim15rst),
+    TIM16 => (APB2, tim16en, tim16rst),
+    TIM17 => (APB2, tim17en, tim17rst),
+}
+
+#[cfg(feature = "medium")]
+bus! {
+    TIM4 => (APB1, tim4en, tim4rst),
+}
+
+#[cfg(feature = "high")]
+bus! {
+    TIM5 => (APB1, tim5en, tim5rst),
+}
+
+#[cfg(any(feature = "xl", all(feature = "stm32f100", feature = "high",)))]
+bus! {
+    TIM12 => (APB1, tim12en, tim12rst),
+    TIM13 => (APB1, tim13en, tim13rst),
+    TIM14 => (APB1, tim14en, tim14rst),
+}
+
+#[cfg(all(feature = "stm32f103", feature = "high",))]
+bus! {
+    TIM8 => (APB2, tim8en, tim8rst),
+}
+
+#[cfg(feature = "xl")]
+bus! {
+    TIM9 => (APB2, tim9en, tim9rst),
+    TIM10 => (APB2, tim10en, tim10rst),
+    TIM11 => (APB2, tim11en, tim11rst),
 }


### PR DESCRIPTION
I've added all the timers according to the CubeMX database with the correct device & density flags.

The only one's I've had to comment out are 9, 10, 12, 13 and 14 on some devices because fields for these are missing from the underlying pac. The code is there to enable them when stm32-rs fixes up those SVDs.

This might be a minor breaking change as previously some of the devices had timers enabled that aren't actually available across the whole range - the fix is to add the appropriate density feature. I've added some info about this to the README so hopefully people will find this without a problem.

There's also some minor formatting stuff mostly from rustfmt in case you are wondering about the whitespace changes in pwm_input.

I should also draw your attention to the fact I added #![allow(unused_unsafe)] (with a comment) to lib.rs to hide the extremely numerous warnings that were coming up because some pac have safe fields incorrectly identified as unsafe. I think adding #![allow(unused_unsafe)] to the crate is fine and preffererable to it being harder to read the compiler output but I'm happy to be persuaded otherwise if you disagree.