### PR TITLE
Removed crate level allow(unused_unsafe) in favour of attributes on the specific instances

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,11 +94,6 @@
 
 #![no_std]
 
-// Some pac crates have fields specified in such a way that they are safe and other
-// have them unsafe (likely an SVD error that needs patching). Unsafe blocks for 
-// one device cause warnings for the safe devices. This disables that warning.
-#![allow(unused_unsafe)]
-
 // If no target specified, print error message.
 #[cfg(not(any(feature = "stm32f100", feature = "stm32f101", feature = "stm32f103")))]
 compile_error!("Target not found. A `--feature <target-name>` is required.");

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -103,6 +103,9 @@ impl Rtc {
         // Set alarm time
         // See section 18.3.5 for explanation
         let alarm_value = counter_value - 1;
+        
+        // TODO: Remove this `allow` once these fields are made safe for stm32f100
+        #[allow(unused_unsafe)]                    
         self.perform_write(|s| {
             s.regs.alrh.write(|w| unsafe{w.alrh().bits((alarm_value >> 16) as u16)});
             s.regs.alrl.write(|w| unsafe{w.alrl().bits(alarm_value as u16)});

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -289,6 +289,9 @@ macro_rules! hal {
 
                     let (psc, arr) = compute_arr_presc(timeout.into().0, self.clk.0);
                     self.tim.psc.write(|w| w.psc().bits(psc) );
+                    
+                    // TODO: Remove this `allow` once this field is made safe for stm32f100
+                    #[allow(unused_unsafe)]
                     self.tim.arr.write(|w| unsafe { w.arr().bits(arr) });
 
                     // Trigger an update event to load the prescaler value to the clock


### PR DESCRIPTION
Resolves #139 

I temporary added `#![deny(unused_unsafe)] and built all variants to find the instances of unused unsafe. Turned out there were only two left after the recent PAC update.