### PR TITLE
Documentation updates and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ panic-semihosting = "0.5.2"
 panic-itm = "0.4.1"
 cortex-m-rtfm = "0.4.3"
 cortex-m-semihosting = "0.3.3"
-enc28j60 = "0.2.1"
 heapless = "0.4.3"
 m = "0.1.1"
 mfrc522 = "0.2.0"
@@ -72,25 +71,9 @@ version = "0.4.0"
 default-features = false
 version = "1.5.2"
 
-#[dev-dependencies.jnet]
-#git = "https://github.com/japaric/jnet"
-#rev = "df96b408049ca952ad7844d6552e87cf8fc18d2a"
-
-#[dev-dependencies.motor-driver]
-#git = "https://github.com/japaric/motor-driver"
-#rev = "00c8b15223643090d69f1acfb8b7a7a43a440417"
-
-#[dev-dependencies.mpu9250]
-#git = "https://github.com/japaric/mpu9250"
-#rev = "8f9ecad690093cb71c41301ca5e5705706150610"
-
 [dev-dependencies.serde]
 default-features = false
 version = "1.0.90"
-
-#[dev-dependencies.serde-json-core]
-#git = "https://github.com/japaric/serde-json-core"
-#rev = "6f12b77c1ffeae167989fe06e0d8b15978bd6d18"
 
 [features]
 device-selected = []

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -10,7 +10,7 @@ use cortex_m::asm;
 use stm32f1xx_hal::{
     prelude::*,
     pac,
-    timer::Timer,
+    timer::{Tim2NoRemap, Timer},
 };
 use cortex_m_rt::entry;
 
@@ -25,14 +25,16 @@ fn main() -> ! {
 
     let mut afio = p.AFIO.constrain(&mut rcc.apb2);
 
-    // let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
-    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+    let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
+    // let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
 
     // TIM2
     let c1 = gpioa.pa0.into_alternate_push_pull(&mut gpioa.crl);
     let c2 = gpioa.pa1.into_alternate_push_pull(&mut gpioa.crl);
     let c3 = gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl);
-    let c4 = gpioa.pa3.into_alternate_push_pull(&mut gpioa.crl);
+    // If you don't want to use all channels, just leave some out
+    // let c4 = gpioa.pa3.into_alternate_push_pull(&mut gpioa.crl);
+    let pins = (c1, c2, c3);
 
     // TIM3
     // let c1 = gpioa.pa6.into_alternate_push_pull(&mut gpioa.crl);
@@ -46,9 +48,9 @@ fn main() -> ! {
     // let c3 = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
     // let c4 = gpiob.pb9.into_alternate_push_pull(&mut gpiob.crh);
 
-    let mut pwm = Timer::tim4(p.TIM4, &clocks, &mut rcc.apb1)
-        .pwm((c1, c2, c3, c4), &mut afio.mapr, 1.khz())
-        .3;
+    let mut pwm = Timer::tim2(p.TIM2, &clocks, &mut rcc.apb1)
+        .pwm::<Tim2NoRemap, _, _, _>(pins, &mut afio.mapr, 1.khz())
+        .2;
 
     let max = pwm.get_max_duty();
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -29,10 +29,10 @@ fn main() -> ! {
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
 
     // TIM2
-    // let c1 = gpioa.pa0.into_alternate_push_pull(&mut gpioa.crl);
-    // let c2 = gpioa.pa1.into_alternate_push_pull(&mut gpioa.crl);
-    // let c3 = gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl);
-    // let c4 = gpioa.pa3.into_alternate_push_pull(&mut gpioa.crl);
+    let c1 = gpioa.pa0.into_alternate_push_pull(&mut gpioa.crl);
+    let c2 = gpioa.pa1.into_alternate_push_pull(&mut gpioa.crl);
+    let c3 = gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl);
+    let c4 = gpioa.pa3.into_alternate_push_pull(&mut gpioa.crl);
 
     // TIM3
     // let c1 = gpioa.pa6.into_alternate_push_pull(&mut gpioa.crl);
@@ -40,11 +40,11 @@ fn main() -> ! {
     // let c3 = gpiob.pb0.into_alternate_push_pull(&mut gpiob.crl);
     // let c4 = gpiob.pb1.into_alternate_push_pull(&mut gpiob.crl);
 
-    // TIM4
-    let c1 = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
-    let c2 = gpiob.pb7.into_alternate_push_pull(&mut gpiob.crl);
-    let c3 = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
-    let c4 = gpiob.pb9.into_alternate_push_pull(&mut gpiob.crh);
+    // TIM4 (Only available with the "medium" density feature)
+    // let c1 = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
+    // let c2 = gpiob.pb7.into_alternate_push_pull(&mut gpiob.crl);
+    // let c3 = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
+    // let c4 = gpiob.pb9.into_alternate_push_pull(&mut gpiob.crh);
 
     let mut pwm = Timer::tim4(p.TIM4, &clocks, &mut rcc.apb1)
         .pwm((c1, c2, c3, c4), &mut afio.mapr, 1.khz())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,30 @@
 //! - stm32f103
 //! - stm32f100
 //!
-//! ```toml
-//! [dependencies.stm32f1xx-hal]
-//! version = "0.2.1"
-//! features = ["stm32f103", "rt"]
-//! ```
+//! ## Usage
+//!
+//! This crate supports multiple microcontrollers in the
+//! stm32f1 family. Which specific microcontroller you want to build for has to be
+//! specified with a feature, for example `stm32f103`.
+//!
+//! If no microcontroller is specified, the crate will not compile.
+//!
+//! The currently supported variants are
+//!
+//! - `stm32f100`
+//! - `stm32f101`
+//! - `stm32f103`
+//!
+//! You may also need to specify the density of the device with `medium`, `high` or `xl` 
+//! to enable certain peripherals. Generally the density can be determined by the 2nd character 
+//! after the number in the device name (i.e. For STM32F103C6U, the 6 indicates a low-density
+//! device) but check the datasheet or CubeMX to be sure.
+//! * 4, 6 => low density, no feature required
+//! * 8, B => `medium` feature
+//! * C, D, E => `high` feature
+//! * F, G => `xl` feature
+//!
+//! 
 //!
 //! [cortex-m-quickstart]: https://docs.rs/cortex-m-quickstart/0.3.1
 //!
@@ -36,7 +55,7 @@
 //! #![no_std]
 //! #![no_main]
 //! 
-//! extern crate panic_halt;
+//! use panic_halt as _;
 //! 
 //! use nb::block;
 //! 
@@ -46,6 +65,7 @@
 //!     timer::Timer,
 //! };
 //! use cortex_m_rt::entry;
+//! use embedded_hal::digital::v2::OutputPin;
 //! 
 //! #[entry]
 //! fn main() -> ! {
@@ -54,25 +74,23 @@
 //!     // Get access to the device specific peripherals from the peripheral access crate
 //!     let dp = pac::Peripherals::take().unwrap();
 //! 
-//!     // Take ownership over the raw flash and rcc devices and convert them
-//!     // into the corresponding HAL structs
+//!     // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+//!     // HAL structs
 //!     let mut flash = dp.FLASH.constrain();
 //!     let mut rcc = dp.RCC.constrain();
 //! 
-//!     // Freeze the configuration of all the clocks in the system and store
-//!     // the frozen frequencies in `clocks`
+//!     // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
+//!     // `clocks`
 //!     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 //! 
 //!     // Acquire the GPIOC peripheral
 //!     let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
 //! 
-//!     // Configure gpio C pin 13 as a push-pull output. The `crh` register is
-//!     // passed to the function in order to configure the port. For pins 0-7,
-//!     // crl should be passed instead.
+//!     // Configure gpio C pin 13 as a push-pull output. The `crh` register is passed to the function
+//!     // in order to configure the port. For pins 0-7, crl should be passed instead.
 //!     let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
 //!     // Configure the syst timer to trigger an update every second
-//!     let mut timer = Timer::syst(cp.SYST, clocks)
-//!         .start_count_down(1.hz());
+//!     let mut timer = Timer::syst(cp.SYST, &clocks).start_count_down(1.hz());
 //! 
 //!     // Wait for the timer to trigger an update and change the state of the LED
 //!     loop {

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -21,9 +21,9 @@
       gpioa.pa3.into_alternate_push_pull(&mut gpioa.crl),
   );
 
-  // Set up the timer as a PWM output. Since there are multiple remap
-  // options for tim2 that use the same pins, you need to specify
-  // the remap generic parameter.
+  // Set up the timer as a PWM output. If selected pins may correspond to different remap options,
+  // then you must specify the remap generic parameter. Otherwise, if there is no such ambiguity,
+  // the remap generic parameter can be omitted without complains from the compiler.
   let (c1, c2, c3, c4) = Timer::tim2(p.TIM2, &clocks, &mut rcc.apb1)
       .pwm::<Tim2NoRemap, _, _, _>(pins, &mut afio.mapr, 1.khz())
       .3;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -13,12 +13,24 @@
 
   ```rust
   let gpioa = ..; // Set up and split GPIOA
+  // Select the pins you want to use
   let pins = (
       gpioa.pa0.into_alternate_push_pull(&mut gpioa.crl),
       gpioa.pa1.into_alternate_push_pull(&mut gpioa.crl),
       gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl),
       gpioa.pa3.into_alternate_push_pull(&mut gpioa.crl),
   );
+
+  // Set up the timer as a PWM output. Since there are multiple remap
+  // options for tim2 that use the same pins, you need to specify
+  // the remap generic parameter.
+  let (c1, c2, c3, c4) = Timer::tim2(p.TIM2, &clocks, &mut rcc.apb1)
+      .pwm::<Tim2NoRemap, _, _, _>(pins, &mut afio.mapr, 1.khz())
+      .3;
+
+  // Start using the channels
+  c1.set_duty(c1.get_max_duty());
+  // ...
   ```
 
   Then call the `pwm` function on the corresponding timer.

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -1,4 +1,10 @@
-//! # Quadrature Encoder Interface
+/**
+  # Quadrature Encoder Interface
+
+  NOTE: In some cases you need to specify remap you need, especially for TIM2
+  (see [Alternate function remapping](super::timer)):
+*/
+
 use core::u16;
 
 use core::marker::PhantomData;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,6 +3,9 @@
 
   ## Alternate function remapping
 
+  This is a list of the remap settings you can use to assign pins to PWM channels
+  and the QEI peripherals
+
   ### TIM1
 
   Not available on STM32F101.


### PR DESCRIPTION
This fixes #144, both in terms of making that example compile without extra features, and documenting the features.

While i'm at it, I also updated the PWM and timer docs, and cleaned up `Cargo.toml`