### PR TITLE
Fixed I2C reading problems

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -199,7 +199,7 @@ pub fn blocking_i2c<I2C, PINS>(
 }
 
 macro_rules! wait_for_flag {
-    ($i2c:expr, $flag:ident) => {{
+    ($i2c:expr, $flag:ident, $is_set:expr) => {{
         let sr1 = $i2c.sr1.read();
 
         if sr1.berr().bit_is_set() {
@@ -210,7 +210,7 @@ macro_rules! wait_for_flag {
             Err(Other(Error::Acknowledge))
         } else if sr1.ovr().bit_is_set() {
             Err(Other(Error::Overrun))
-        } else if sr1.$flag().bit_is_set() {
+        } else if sr1.$flag().bit_is_set() == $is_set {
             Ok(())
         } else {
             Err(WouldBlock)
@@ -317,7 +317,7 @@ macro_rules! hal {
                 }
 
                 fn wait_after_sent_start(&mut self) -> NbResult<(), Error> {
-                    wait_for_flag!(self.i2c, sb)
+                    wait_for_flag!(self.i2c, sb, true)
                 }
 
                 fn send_addr(&self, addr: u8, read: bool) {
@@ -325,7 +325,7 @@ macro_rules! hal {
                 }
 
                 fn wait_after_sent_addr(&self) -> NbResult<(), Error> {
-                    wait_for_flag!(self.i2c, addr)?;
+                    wait_for_flag!(self.i2c, addr, true)?;
                     self.i2c.sr2.read();
                     Ok(())
                 }
@@ -385,10 +385,10 @@ macro_rules! hal {
                     self.send_addr_and_wait(addr, false)?;
 
                     for byte in bytes {
-                        busy_wait_cycles!(wait_for_flag!(self.nb.i2c, tx_e), self.data_timeout)?;
+                        busy_wait_cycles!(wait_for_flag!(self.nb.i2c, tx_e, true), self.data_timeout)?;
                         self.nb.i2c.dr.write(|w| { w.dr().bits(*byte) });
                     }
-                    busy_wait_cycles!(wait_for_flag!(self.nb.i2c, tx_e), self.data_timeout)?;
+                    busy_wait_cycles!(wait_for_flag!(self.nb.i2c, tx_e, true), self.data_timeout)?;
 
                     Ok(())
                 }
@@ -410,46 +410,58 @@ macro_rules! hal {
 
                 fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
                     self.send_start_and_wait()?;
+                    self.nb.i2c.sr1.read();
+                    self.nb.send_addr(addr, true);
+                    busy_wait_cycles!(wait_for_flag!(self.nb.i2c, addr, true), self.addr_timeout)?;
 
                     match buffer.len() {
                         1 => {
-                            self.nb.send_addr(addr, true);
-                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, addr), self.addr_timeout)?;
                             self.nb.i2c.cr1.modify(|_, w| w.ack().clear_bit());
-                            let _ = self.nb.i2c.sr2.read();
+                            self.nb.i2c.sr1.read();
+                            self.nb.i2c.sr2.read();
                             self.nb.send_stop();
 
-                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne), self.data_timeout)?;
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne, true), self.data_timeout)?;
                             buffer[0] = self.nb.i2c.dr.read().dr().bits();
+
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, stopf, false), self.data_timeout)?;
+                            self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
                         }
                         2 => {
                             self.nb.i2c.cr1.modify(|_, w| w.pos().set_bit().ack().set_bit());
-                            self.send_addr_and_wait(addr, true)?;
-                            self.nb.i2c.cr1.modify(|_, w| w.pos().clear_bit().ack().clear_bit());
+                            self.nb.i2c.sr1.read();
+                            self.nb.i2c.sr2.read();
+                            self.nb.i2c.cr1.modify(|_, w| w.ack().clear_bit());
 
-                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, btf), self.data_timeout)?;
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, btf, true), self.data_timeout)?;
                             self.nb.send_stop();
                             buffer[0] = self.nb.i2c.dr.read().dr().bits();
                             buffer[1] = self.nb.i2c.dr.read().dr().bits();
+
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, stopf, false), self.data_timeout)?;
+                            self.nb.i2c.cr1.modify(|_, w| w.pos().clear_bit().ack().clear_bit());
+                            self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
                         }
                         buffer_len => {
-                            self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
-                            self.send_addr_and_wait(addr, true)?;
+                            self.nb.i2c.sr1.read();
+                            self.nb.i2c.sr2.read();
 
                             let (first_bytes, last_two_bytes) = buffer.split_at_mut(buffer_len - 3);
                             for byte in first_bytes {
-                                self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
-                                busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne), self.data_timeout)?;
+                                busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne, true), self.data_timeout)?;
                                 *byte = self.nb.i2c.dr.read().dr().bits();
                             }
 
-                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, btf), self.data_timeout)?;
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, btf, true), self.data_timeout)?;
                             self.nb.i2c.cr1.modify(|_, w| w.ack().clear_bit());
                             last_two_bytes[0] = self.nb.i2c.dr.read().dr().bits();
                             self.nb.send_stop();
                             last_two_bytes[1] = self.nb.i2c.dr.read().dr().bits();
-                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne), self.data_timeout)?;
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, rx_ne, true), self.data_timeout)?;
                             last_two_bytes[2] = self.nb.i2c.dr.read().dr().bits();
+
+                            busy_wait_cycles!(wait_for_flag!(self.nb.i2c, stopf, false), self.data_timeout)?;
+                            self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
                         }
                     }
 


### PR DESCRIPTION
This PR fixes some issues I had with I2C.
I wanted to query exactly 2 bytes over I2C, but I got an I2C arbitration error.
Because of this I fixed the code to follow exactly the rules described [here](http://st.com/content/ccc/resource/technical/document/application_note/5d/ae/a3/6f/08/69/4e/9b/CD00209826.pdf/files/CD00209826.pdf/jcr:content/translations/en.CD00209826.pdf).
Now it is working fine for me.

Example code:
```rust
#![no_std]
#![no_main]

use cortex_m::iprintln;
use cortex_m_rt::entry;
use mpu6050::*;
use stm32f1xx_hal::{delay::Delay, i2c, prelude::*, stm32};

#[allow(unused_imports)]
use panic_itm;

#[entry]
fn main() -> ! {
    let device = stm32::Peripherals::take().unwrap();
    let mut cp = cortex_m::Peripherals::take().unwrap();
    let stim = &mut cp.ITM.stim[0];

    let mut flash = device.FLASH.constrain();
    let mut rcc = device.RCC.constrain();

    let clocks = rcc.cfgr.freeze(&mut flash.acr);
    let mut afio = device.AFIO.constrain(&mut rcc.apb2);

    let mode = i2c::Mode::Standard {
        frequency: 100_000.hz(),
    };

    let mut gpiob = device.GPIOB.split(&mut rcc.apb2);

    let scl_pin = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
    let sda_pin = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);

    let delay = Delay::new(cp.SYST, clocks);

    let i2c_val = i2c::BlockingI2c::i2c1(
        device.I2C1,
        (scl_pin, sda_pin),
        &mut afio.mapr,
        mode,
        clocks,
        &mut rcc.apb1,
        50000,
        10,
        50000,
        50000,
    );

    let mut mpu = Mpu6050::new(i2c_val, delay);
    mpu.init().unwrap();
    mpu.soft_calib(Steps(100)).unwrap();
    mpu.calc_variance(Steps(50)).unwrap();

    iprintln!(stim, "Calibrated with bias: {:?}", mpu.get_bias().unwrap());
    iprintln!(
        stim,
        "Calculated variance: {:?}",
        mpu.get_variance().unwrap()
    );

    loop {
        /*
        // Didn't work before
        let mut buf: [u8; 2] = [0; 2];
        mpu.read_bytes(0x41, &mut buf).unwrap();
        iprintln!(stim, "{:?}", buf);
        */

        /*
        let acc = mpu.get_acc().unwrap();
        let gyro = mpu.get_gyro().unwrap();
        let temp = mpu.get_temp().unwrap();
        iprintln!(stim, "Acc: {:?}; Gyro: {:?}; Temp: {:?}", acc, gyro, temp);
        */

        let acc = mpu.get_acc_angles_avg(Steps(200)).unwrap();
        iprintln!(stim, "Acc: {:?}", acc);
    }
}

```