### PR TITLE
Changed Variable name in EXTI example

### DIFF
--- a/examples/exti.rs
+++ b/examples/exti.rs
@@ -23,18 +23,18 @@ use stm32f1xx_hal::gpio::*;
 // After enabling the interrupt, main() may not have any references to these objects any more.
 // For the sake of minimalism, we do not use RTFM here, which would be the better way.
 static mut LED  : MaybeUninit<stm32f1xx_hal::gpio::gpioc::PC13<Output<PushPull>>> = MaybeUninit::uninit();
-static mut EXTI : MaybeUninit<stm32f1xx_hal::gpio::gpioa::PA7<Input<Floating>>> = MaybeUninit::uninit();
+static mut INT_PIN : MaybeUninit<stm32f1xx_hal::gpio::gpioa::PA7<Input<Floating>>> = MaybeUninit::uninit();
 
 #[interrupt]
 fn EXTI9_5() {
     let led = unsafe { &mut *LED.as_mut_ptr()};
-    let exti = unsafe { &mut *EXTI.as_mut_ptr()};
+    let int_pin = unsafe { &mut *INT_PIN.as_mut_ptr()};
 
-    if exti.check_interrupt() {
+    if int_pin.check_interrupt() {
         led.toggle();
 
         // if we don't clear this bit, the ISR would trigger indefinitely
-        exti.clear_interrupt_pending_bit();
+        int_pin.clear_interrupt_pending_bit();
     }
 }
 
@@ -44,7 +44,7 @@ fn main() -> ! {
     let p = pac::Peripherals::take().unwrap();
     let cp = cortex_m::peripheral::Peripherals::take().unwrap();
     {
-        // the scope ensures that the exti reference is dropped before the first ISR can be executed.
+        // the scope ensures that the int_pin reference is dropped before the first ISR can be executed.
 
         let mut rcc = p.RCC.constrain();
         let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
@@ -54,11 +54,11 @@ fn main() -> ! {
         let led = unsafe { &mut *LED.as_mut_ptr()};
         *led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
 
-        let exti = unsafe { &mut *EXTI.as_mut_ptr()};
-        *exti = gpioa.pa7.into_floating_input(&mut gpioa.crl);
-        exti.make_interrupt_source(&mut afio);
-        exti.trigger_on_edge(&p.EXTI, Edge::RISING_FALLING);
-        exti.enable_interrupt(&p.EXTI);
+        let int_pin = unsafe { &mut *INT_PIN.as_mut_ptr()};
+        *int_pin = gpioa.pa7.into_floating_input(&mut gpioa.crl);
+        int_pin.make_interrupt_source(&mut afio);
+        int_pin.trigger_on_edge(&p.EXTI, Edge::RISING_FALLING);
+        int_pin.enable_interrupt(&p.EXTI);
     } // initialization ends here
 
     let mut nvic = cp.NVIC;


### PR DESCRIPTION
the `exti` and `EXTI` variables are actually references to a pin and not to the Interrupt controller.
The interrupt controller registers are `p.EXIT`.
Therefore, I changed the variable name to reduce confusion.