### PR TITLE
Impl Read<u8> / Write<u8> for Serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Add `InputPin` impl for generic open drain outputs
+- Implement `Read<u8>` / `Write<u8>` for `Serial` (#171)
 
 ## [v0.5.2] - 2019-12-15
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -118,9 +118,9 @@ impl Pins<USART3> for (PD8<Alternate<PushPull>>, PD9<Input<Floating>>) {
 ///
 /// Note that reading / writing is done on the USART peripheral, not on the
 /// rx / tx pins!
-trait UsartReadWrite<Word> {
-    fn read() -> nb::Result<Word, Error>;
-    fn write(byte: Word) -> nb::Result<(), Infallible>;
+trait UsartReadWrite {
+    fn read() -> nb::Result<u8, Error>;
+    fn write(byte: u8) -> nb::Result<(), Infallible>;
     fn flush() -> nb::Result<(), Infallible>;
 }
 
@@ -357,7 +357,7 @@ macro_rules! hal {
                 }
             }
 
-            impl UsartReadWrite<u8> for $USARTX {
+            impl UsartReadWrite for $USARTX {
                 fn read() -> nb::Result<u8, Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let sr = unsafe { (*$USARTX::ptr()).sr.read() };


### PR DESCRIPTION
Fixes #167.

I managed to implement this without having split tx/rx pins in the `Serial` struct thanks to the help of @Disasm. Instead, it uses a private trait (`UsartReadWrite`) to avoid having duplicated peripheral access logic. There should be no breaking change in this PR.