### PR TITLE
Add configuration options to QEI interface

### DIFF
--- a/examples/qei.rs
+++ b/examples/qei.rs
@@ -9,7 +9,7 @@ use panic_semihosting as _;
 use cortex_m_semihosting::hprintln;
 
 use cortex_m_rt::entry;
-use stm32f1xx_hal::{delay::Delay, pac, prelude::*, timer::Timer};
+use stm32f1xx_hal::{delay::Delay, pac, prelude::*, qei::QeiOptions, timer::Timer};
 
 #[entry]
 fn main() -> ! {
@@ -38,7 +38,11 @@ fn main() -> ! {
     let c1 = gpiob.pb6;
     let c2 = gpiob.pb7;
 
-    let qei = Timer::tim4(dp.TIM4, &clocks, &mut rcc.apb1).qei((c1, c2), &mut afio.mapr);
+    let qei = Timer::tim4(dp.TIM4, &clocks, &mut rcc.apb1).qei(
+        (c1, c2),
+        &mut afio.mapr,
+        QeiOptions::default(),
+    );
     let mut delay = Delay::new(cp.SYST, clocks);
 
     loop {

--- a/examples/qei.rs
+++ b/examples/qei.rs
@@ -8,13 +8,8 @@ use panic_semihosting as _;
 
 use cortex_m_semihosting::hprintln;
 
-use stm32f1xx_hal::{
-    prelude::*,
-    pac,
-    delay::Delay,
-    timer::Timer,
-};
 use cortex_m_rt::entry;
+use stm32f1xx_hal::{delay::Delay, pac, prelude::*, timer::Timer};
 
 #[entry]
 fn main() -> ! {
@@ -43,8 +38,7 @@ fn main() -> ! {
     let c1 = gpiob.pb6;
     let c2 = gpiob.pb7;
 
-    let qei = Timer::tim4(dp.TIM4, &clocks, &mut rcc.apb1)
-        .qei((c1, c2), &mut afio.mapr);
+    let qei = Timer::tim4(dp.TIM4, &clocks, &mut rcc.apb1).qei((c1, c2), &mut afio.mapr);
     let mut delay = Delay::new(cp.SYST, clocks);
 
     loop {

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -4,26 +4,21 @@
   NOTE: In some cases you need to specify remap you need, especially for TIM2
   (see [Alternate function remapping](super::timer)):
 */
-
 use core::u16;
 
 use core::marker::PhantomData;
 
 use crate::hal::{self, Direction};
-#[cfg(any(
-    feature = "stm32f100",
-    feature = "stm32f103",
-    feature = "stm32f105",
-))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
 use crate::pac::TIM1;
-use crate::pac::{TIM2, TIM3};
 #[cfg(feature = "medium")]
 use crate::pac::TIM4;
+use crate::pac::{TIM2, TIM3};
 
 use crate::afio::MAPR;
 
-use crate::timer::{Timer, sealed::Remap};
 use crate::pwm_input::Pins;
+use crate::timer::{sealed::Remap, Timer};
 
 pub struct Qei<TIM, REMAP, PINS> {
     tim: TIM,
@@ -31,11 +26,7 @@ pub struct Qei<TIM, REMAP, PINS> {
     _remap: PhantomData<REMAP>,
 }
 
-#[cfg(any(
-    feature = "stm32f100",
-    feature = "stm32f103",
-    feature = "stm32f105",
-))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
 impl Timer<TIM1> {
     pub fn qei<REMAP, PINS>(self, pins: PINS, mapr: &mut MAPR) -> Qei<TIM1, REMAP, PINS>
     where
@@ -143,11 +134,7 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(
-    feature = "stm32f100",
-    feature = "stm32f103",
-    feature = "stm32f105",
-))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
 hal! {
     TIM1: (_tim1, tim1en, tim1rst),
 }


### PR DESCRIPTION
This PR adds the `QeiOptions` struct which allows configuration of the timer slave mode (affecting QEI) and the QEI auto reload register value. There's also some minor formatting noise so apologies for that.

I've tested this on a Blue Pill with a CNC jog pendant that produces 400 PPR. Seems to work well.

I'm unsure of the names for everything added. They're taken almost verbatim from the datasheet, but aren't very descriptive or intuitive. Should we bikeshed this or leave it as is for now?