### PR TITLE
spi-dma example: swap buffer and SPI device in return value of a transfer's wait

### DIFF
--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -61,7 +61,7 @@ fn main() -> ! {
 
     // Wait for it to finnish. The transfer takes ownership over the SPI device
     // and the data being sent anb those things are returned by transfer.wait
-    let (_spi_dma, _buffer) = transfer.wait();
+    let (_buffer, _spi_dma) = transfer.wait();
 
     loop {
     }


### PR DESCRIPTION
`wait` method returns tuple of `(BUFFER, TxDma<PAYLOAD, $CX>)`