### PR TITLE
Fix `MonoTimer`s frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixed
+
+- Fix wrong frequency reported by `MonoTimer`
+
 ## [v0.6.0] - 2020-06-06
 
 ### Breaking changes

--- a/src/time.rs
+++ b/src/time.rs
@@ -241,7 +241,7 @@ impl MonoTimer {
         drop(dwt);
 
         MonoTimer {
-            frequency: clocks.sysclk(),
+            frequency: clocks.hclk(),
         }
     }
 


### PR DESCRIPTION
The `MonoTimer` internally counts the cycles of the Cortex core. According to the reference ([RM0008](https://www.st.com/content/ccc/resource/technical/document/reference_manual/59/b9/ba/7f/11/af/43/d5/CD00171190.pdf/files/CD00171190.pdf/jcr:content/translations/en.CD00171190.pdf), Section 8.2) the core is driven by the HCLK, not the SYSCLK, so that should be the frequency reported by `MonoTimer`.

I originally encountered that issue on an STM32F3 board and submitted a fix to the stm32f3xx-hal [here](https://github.com/stm32-rs/stm32f3xx-hal/pull/56). Unfortunately, I'm not able to verify this bug and its fix for an F1 board as I don't own one. So it would be good if someone else could verify.