### PR TITLE
Hertz: Replace Into impls with From impls

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -141,21 +141,21 @@ impl U32Ext for u32 {
     }
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
+impl From<KiloHertz> for Hertz {
+    fn from(val: KiloHertz) -> Self {
+        Self(val.0 * 1_000)
     }
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
+impl From<MegaHertz> for Hertz {
+    fn from(val: MegaHertz) -> Self {
+        Self(val.0 * 1_000_000)
     }
 }
 
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
+impl From<MegaHertz> for KiloHertz {
+    fn from(val: MegaHertz) -> Self {
+        Self(val.0 * 1_000)
     }
 }
 


### PR DESCRIPTION
From the Rust docs:

> One should always prefer implementing From over Into because
> implementing From automatically provides one with an implementation of
> Into thanks to the blanket implementation in the standard library.