### PR TITLE
Consistently use PAC as `pac`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Consistently use PAC as `pac` and mark `device` and `stm32` informally as deprecated
 - Replace default blocking spi Write implementation with an optimized one
 - Use `Deref` for SPI generic implementations instead of macros
 

--- a/examples/blinky_timer_irq.rs
+++ b/examples/blinky_timer_irq.rs
@@ -15,7 +15,7 @@ use stm32f1xx_hal as hal;
 use crate::hal::{
     gpio::*,
     prelude::*,
-    stm32::{interrupt, Interrupt, Peripherals, TIM2},
+    pac::{interrupt, Interrupt, Peripherals, TIM2},
     timer::*,
 };
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -15,7 +15,7 @@ use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
 #[entry]
 fn main() -> ! {
-    let dp = stm32::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();

--- a/examples/usb_serial_interrupt.rs
+++ b/examples/usb_serial_interrupt.rs
@@ -8,7 +8,7 @@ extern crate panic_semihosting;
 use cortex_m::asm::{delay, wfi};
 use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
-use stm32f1xx_hal::stm32::{interrupt, Interrupt};
+use stm32f1xx_hal::pac::{interrupt, Interrupt};
 use stm32f1xx_hal::usb::{Peripheral, UsbBus, UsbBusType};
 use stm32f1xx_hal::{prelude::*, stm32};
 use usb_device::{bus::UsbBusAllocator, prelude::*};
@@ -21,7 +21,7 @@ static mut USB_DEVICE: Option<UsbDevice<UsbBusType>> = None;
 #[entry]
 fn main() -> ! {
     let p = cortex_m::Peripherals::take().unwrap();
-    let dp = stm32::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -10,14 +10,14 @@ use crate::dma::{Receive, TransferPayload, dma1::C1, CircBuffer, Transfer, W, Rx
 use core::sync::atomic::{self, Ordering};
 use cortex_m::asm::delay;
 
-use crate::stm32::ADC1;
+use crate::pac::ADC1;
 #[cfg(feature = "stm32f103")]
-use crate::stm32::ADC2;
+use crate::pac::ADC2;
 #[cfg(all(
     feature = "stm32f103",
     feature = "high",
 ))]
-use crate::stm32::ADC3;
+use crate::pac::ADC3;
 
 /// Continuous mode
 pub struct Continuous;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -17,7 +17,7 @@
 use core::marker::PhantomData;
 
 use crate::rcc::APB2;
-use crate::stm32::EXTI;
+use crate::pac::EXTI;
 use crate::afio;
 
 /// Extension trait to split a GPIO peripheral in independent pins and registers
@@ -108,7 +108,7 @@ macro_rules! gpio {
 
             use crate::hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, toggleable};
             use crate::pac::{$gpioy, $GPIOX};
-            use crate::stm32::EXTI;
+            use crate::pac::EXTI;
             use crate::afio;
 
             use crate::rcc::{APB2, Enable, Reset};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,11 @@ pub use stm32f1::stm32f101 as pac;
 pub use stm32f1::stm32f103 as pac;
 
 #[cfg(feature = "device-selected")]
+#[deprecated(since="0.6.0", note="please use `pac` instead")]
 pub use crate::pac as device;
 
 #[cfg(feature = "device-selected")]
+#[deprecated(since="0.6.0", note="please use `pac` instead")]
 pub use crate::pac as stm32;
 
 #[cfg(feature = "device-selected")]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -193,7 +193,7 @@ pub struct Tx<USART> {
 }
 
 /// Internal trait for the serial read / write logic.
-trait UsartReadWrite: Deref<Target=crate::stm32::usart1::RegisterBlock> {
+trait UsartReadWrite: Deref<Target=crate::pac::usart1::RegisterBlock> {
     fn read(&self) -> nb::Result<u8, Error> {
         let sr = self.sr.read();
 
@@ -259,7 +259,7 @@ trait UsartReadWrite: Deref<Target=crate::stm32::usart1::RegisterBlock> {
         }
     }
 }
-impl UsartReadWrite for &crate::stm32::usart1::RegisterBlock {}
+impl UsartReadWrite for &crate::pac::usart1::RegisterBlock {}
 
 macro_rules! hal {
     ($(

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,7 +1,7 @@
 //! Watchdog peripherals
 
 use crate::{
-    stm32::{IWDG, DBGMCU as DBG},
+    pac::{IWDG, DBGMCU as DBG},
     hal::watchdog::{Watchdog, WatchdogEnable},
     time::MilliSeconds,
 };


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>