### PR TITLE
Examples: Add timed one shot interrupts

### DIFF
--- a/examples/interrupt-rtc.rs
+++ b/examples/interrupt-rtc.rs
@@ -1,0 +1,56 @@
+//! Demonstrates real time clock based one shot interrupts
+
+#![no_std]
+#![no_main]
+
+use cortex_m::asm;
+use cortex_m_rt::entry;
+use cortex_m_semihosting::hprintln;
+use panic_semihosting as _; // panic handler
+use stm32f1xx_hal::{
+    pac::{interrupt, Interrupt, Peripherals, NVIC},
+    prelude::*,
+    rtc::Rtc,
+};
+
+#[interrupt]
+fn RTC() {
+    hprintln!("RTC fired.").ok();
+
+    // Disable the RTC interrupt so this won't fire again
+    NVIC::mask(Interrupt::RTC);
+}
+
+#[entry]
+fn main() -> ! {
+    hprintln!("Entered main.").ok();
+
+    // Extract needed peripherals
+    let dp = Peripherals::take().expect("Peripherals have been taken before");
+    let rcc = dp.RCC.constrain();
+    let mut apb1 = rcc.apb1;
+    let mut pwr = dp.PWR;
+    let mut backup_domain = rcc.bkp.constrain(dp.BKP, &mut apb1, &mut pwr);
+
+    // Create and configure Rtc
+    let mut rtc = Rtc::rtc(dp.RTC, &mut backup_domain);
+    rtc.select_frequency(1.hz());
+    rtc.listen_alarm();
+
+    hprintln!("Entering main loop.").ok();
+    loop {
+        rtc.set_alarm(rtc.current_time() + 1);
+
+        // Clear the RTC interrupt's pending state
+        NVIC::unpend(Interrupt::RTC);
+        unsafe {
+            // Enable the RTC interrupt (again)
+            // Safe as this is not a mask-based critical section
+            NVIC::unmask(Interrupt::RTC);
+        }
+
+        // Wait for an event like the RTC interrupt to occur
+        asm::wfe();
+        hprintln!("An event occured.").ok();
+    }
+}

--- a/examples/interrupt-tim2.rs
+++ b/examples/interrupt-tim2.rs
@@ -1,0 +1,55 @@
+//! Demonstrates timer based one shot interrupts
+
+#![no_std]
+#![no_main]
+
+use cortex_m::asm;
+use cortex_m_rt::entry;
+use cortex_m_semihosting::hprintln;
+use panic_semihosting as _; // panic handler
+use stm32f1xx_hal::{
+    pac::{interrupt, Interrupt, Peripherals, NVIC},
+    prelude::*,
+    timer::{Event, Timer},
+};
+
+#[interrupt]
+fn TIM2() {
+    hprintln!("TIM2 fired.").ok();
+
+    // Disable the TIM2 interrupt so this won't fire again
+    NVIC::mask(Interrupt::TIM2);
+}
+
+#[entry]
+fn main() -> ! {
+    hprintln!("Start").ok();
+
+    // Extract needed peripherals
+    let dp = Peripherals::take().expect("Peripherals have been taken before");
+    let rcc = dp.RCC.constrain();
+    let mut acr = dp.FLASH.constrain().acr;
+    let clocks = rcc.cfgr.freeze(&mut acr);
+    let mut apb1 = rcc.apb1;
+
+    // Create and configure CountDownTimer<TIM2>
+    let mut timer = Timer::tim2(dp.TIM2, &clocks, &mut apb1).start_count_down(1.hz());
+    timer.listen(Event::Update);
+
+    hprintln!("Entering main loop.").ok();
+    loop {
+        timer.clear_update_interrupt_flag();
+
+        // Clear the TIM2 interrupt's pending state
+        NVIC::unpend(Interrupt::TIM2);
+        unsafe {
+            // Enable the TIM2 interrupt (again)
+            // Safe as this is not a mask-based critical section
+            NVIC::unmask(Interrupt::TIM2);
+        }
+
+        // Wait for an event like the TIM2 interrupt to occur
+        asm::wfe();
+        hprintln!("An event occured.").ok();
+    }
+}


### PR DESCRIPTION
This adds examples for firing one shot interrupts repeatedly with `RTC` and `TIM2`.

I wrote those to understand this topic better and think it could be useful to others.

What do you think?