### PR TITLE
initial CRC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Extend the Pwm implementation to cover the full embedded_hal::Pwm API
 - Add `QeiOptions` struct to configure slave mode and auto reload value of QEI interface
 - Implement multiplication and division for frequency wrappers (#193)
+- Add support for CRC
 
 ### Changed
 

--- a/examples/crc.rs
+++ b/examples/crc.rs
@@ -1,0 +1,27 @@
+//! CRC calculation
+
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::hprintln;
+use stm32f1xx_hal::{pac, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    let p = pac::Peripherals::take().unwrap();
+
+    let mut rcc = p.RCC.constrain();
+    let mut crc = p.CRC.new(&mut rcc.ahb);
+
+    crc.reset();
+    crc.write(0x12345678);
+
+    let val = crc.read();
+    hprintln!("found={:08x}, expected={:08x}", val, 0xdf8a8a2bu32).ok();
+
+    loop {}
+}

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,0 +1,39 @@
+//! CRC
+
+use crate::pac::CRC;
+use crate::rcc::{Enable, AHB};
+
+/// Extension trait to constrain the CRC peripheral
+pub trait CrcExt {
+    /// Constrains the CRC peripheral to play nicely with the other abstractions
+    fn new(self, ahb: &mut AHB) -> Crc;
+}
+
+impl CrcExt for CRC {
+    fn new(self, ahb: &mut AHB) -> Crc {
+        CRC::enable(ahb);
+        Crc { crc: self }
+    }
+}
+
+/// Constrained CRC peripheral
+pub struct Crc {
+    crc: CRC,
+}
+
+impl Crc {
+    pub fn read(&self) -> u32 {
+        self.crc.dr.read().bits()
+    }
+
+    pub fn write(&mut self, val: u32) {
+        self.crc.dr.write(|w| w.dr().bits(val))
+    }
+
+    pub fn reset(&self) {
+        self.crc.cr.write(|w| w.reset().set_bit());
+        // calling CRC::dr::write() just after CRC::cr::reset() will not work as expected, and
+        // inserting single nop() seems to solve the problem.
+        cortex_m::asm::nop();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@ pub mod backup_domain;
 #[cfg(feature = "device-selected")]
 pub mod bb;
 #[cfg(feature = "device-selected")]
+pub mod crc;
+#[cfg(feature = "device-selected")]
 pub mod delay;
 #[cfg(feature = "device-selected")]
 pub mod dma;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::adc::ChannelTimeSequence as _stm32_hal_adc_ChannelTimeSequence;
 pub use crate::afio::AfioExt as _stm32_hal_afio_AfioExt;
+pub use crate::crc::CrcExt as _stm32_hal_crc_CrcExt;
 pub use crate::dma::CircReadDma as _stm32_hal_dma_CircReadDma;
 pub use crate::dma::DmaExt as _stm32_hal_dma_DmaExt;
 pub use crate::dma::ReadDma as _stm32_hal_dma_ReadDma;


### PR DESCRIPTION
I'm complete newcomer on microcontroller & stm32, so please feel free to comment.

 - Tested on `stm32f103c8`
 - I'm not sure how it interacts with other peripherals. For example it seems that SPI protocol requires CRC calculation. Does stm32 SPI uses CRC peripherals for CRC calculation of there's another CRC hardware dedicated to SPI CRC?
 - I'm not sure if I should use `split` or `constrain`.
 - small additional diff on `prelude` caused by `rustfmt`.