### PR TITLE
Fix race condition causing ADCs to read stale values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix PWM on `TIM1`
+- Fix ADC race condition causing incorrect reads at certain frequencies
 
 ## [v0.5.3] - 2020-01-20
 


### PR DESCRIPTION
Fixes #201

This was a *fun* bug to track down.

Some decided that it would be a good idea to make one way of starting the ADC conversion to write a `1` to the `adon` bit if the `adon` bit is already one. But that might trigger a read when you want to modify other parts of the register, so this behaviour only happens if no other bits are modified. Thus, `modify` on the `cr2` register will start a conversion unless at least one bit is *actually* modified.

This was accidentally done as the first part of the `convert` function, which started a conversion which would be ready roughly by the time the CPU starts checking for `eoc` bits.

The race condition occurs if the CPU gets to the `EOC` check, before the ADC has time to reset the bit as a result of the `swstart` trigger. This relies on the CPU being faster than the ADC clock which explains the behaviour at high prescalers.

Finally, it seems like the line
```rust
while self.rb.cr2.read().swstart().bit_is_set() {}
```
*should* have prevented this as the ADC should have taken care of the `swstart` and reset the `EOC` before that line. For whatever reason, that did not happen

Thnaks @adamgreig for helping debug this :), and for a more detailed log of the steps we used to track it down, see the commit message.
