### PR TITLE
Support for connectivity line devices (stm32f105 and stm32f107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
           - stm32f100
           - stm32f101
           - stm32f103
+          - stm32f105
+          - stm32f107
         rust:
           - stable
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Support for connectivity line devices: `stm32f105xx` and `stm32f107xx`
 - Consistently use PAC as `pac` and mark `device` and `stm32` informally as deprecated
 - Replace default blocking spi Write implementation with an optimized one
 - Use `Deref` for SPI generic implementations instead of macros

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,8 @@ rt = ["stm32f1/rt"]
 stm32f100 = ["stm32f1/stm32f100", "device-selected"]
 stm32f101 = ["stm32f1/stm32f101", "device-selected"]
 stm32f103 = ["stm32f1/stm32f103", "device-selected"]
+stm32f105 = ["stm32f1/stm32f107", "device-selected", "connectivity"]
+stm32f107 = ["stm32f1/stm32f107", "device-selected", "connectivity"]
 
 # Devices with 64 or 128 Kb ROM
 medium = []
@@ -93,6 +95,8 @@ medium = []
 high = ["medium"]
 # Devices with 768 Kb ROM or more
 xl = ["high"]
+# Connectivity line devices (`stm32f105xx` and `stm32f107xx`)
+connectivity = ["medium"]
 
 [profile.dev]
 incremental = false

--- a/README.md
+++ b/README.md
@@ -137,12 +137,16 @@ device) but check the datasheet or CubeMX to be sure.
 * C, D, E => `high` feature
 * F, G => `xl` feature
 
+For microcontrollers of the `connectivity line` (`stm32f105` and `stm32f107`) no
+density feature must be specified.
+
 ### Supported Microcontrollers
 
 * `stm32f100`
 * `stm32f101`
 * `stm32f103`
-
+* `stm32f105`
+* `stm32f107`
 
 ## Trying out the examples
 

--- a/src/backup_domain.rs
+++ b/src/backup_domain.rs
@@ -49,7 +49,7 @@ impl BackupDomain {
     /// DRx registers: 0 is DR11, up to 31 for DR42. Providing a number above 31
     /// will panic.
     /// NOTE: not available on medium- and low-density devices!
-    #[cfg(feature = "high")]
+    #[cfg(any(feature = "high", feature = "connectivity"))]
     pub fn read_data_register_high(&self, register: usize) -> u16 {
         read_drx!(self, bkp_dr, register)
     }
@@ -67,7 +67,7 @@ impl BackupDomain {
     /// DRx registers: 0 is DR11, up to 31 for DR42. Providing a number above 31
     /// will panic.
     /// NOTE: not available on medium- and low-density devices!
-    #[cfg(feature = "high")]
+    #[cfg(any(feature = "high", feature = "connectivity"))]
     pub fn write_data_register_high(&self, register: usize, data: u16) {
         write_drx!(self, bkp_dr, register, data)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //! - stm32f103
 //! - stm32f101
 //! - stm32f100
+//! - stm32f105
+//! - stm32f107
 //!
 //! ## Usage
 //!
@@ -30,6 +32,8 @@
 //! - `stm32f100`
 //! - `stm32f101`
 //! - `stm32f103`
+//! - `stm32f105`
+//! - `stm32f107`
 //!
 //! You may also need to specify the density of the device with `medium`, `high` or `xl`
 //! to enable certain peripherals. Generally the density can be determined by the 2nd character
@@ -66,14 +70,27 @@
 #![deny(intra_doc_link_resolution_failure)]
 
 // If no target specified, print error message.
-#[cfg(not(any(feature = "stm32f100", feature = "stm32f101", feature = "stm32f103")))]
+#[cfg(not(any(
+    feature = "stm32f100",
+    feature = "stm32f101",
+    feature = "stm32f103",
+    feature = "stm32f105",
+    feature = "stm32f107",
+)))]
 compile_error!("Target not found. A `--features <target-name>` is required.");
 
 // If any two or more targets are specified, print error message.
 #[cfg(any(
     all(feature = "stm32f100", feature = "stm32f101"),
     all(feature = "stm32f100", feature = "stm32f103"),
+    all(feature = "stm32f100", feature = "stm32f105"),
+    all(feature = "stm32f100", feature = "stm32f107"),
     all(feature = "stm32f101", feature = "stm32f103"),
+    all(feature = "stm32f101", feature = "stm32f105"),
+    all(feature = "stm32f101", feature = "stm32f107"),
+    all(feature = "stm32f103", feature = "stm32f105"),
+    all(feature = "stm32f103", feature = "stm32f107"),
+    all(feature = "stm32f105", feature = "stm32f107"),
 ))]
 compile_error!(
     "Multiple targets specified. Only a single `--features <target-name>` can be specified."
@@ -90,6 +107,9 @@ pub use stm32f1::stm32f101 as pac;
 
 #[cfg(feature = "stm32f103")]
 pub use stm32f1::stm32f103 as pac;
+
+#[cfg(any(feature = "stm32f105", feature = "stm32f107"))]
+pub use stm32f1::stm32f107 as pac;
 
 #[cfg(feature = "device-selected")]
 #[deprecated(since = "0.6.0", note = "please use `pac` instead")]

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -58,7 +58,7 @@ use core::marker::PhantomData;
 use core::mem;
 
 use crate::hal;
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 use crate::pac::TIM1;
 #[cfg(feature = "medium")]
 use crate::pac::TIM4;
@@ -135,7 +135,7 @@ pins_impl!(
     (P4), (Ch4), (C4);
 );
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 impl Timer<TIM1> {
     pub fn pwm<REMAP, P, PINS, T>(
         self,
@@ -490,7 +490,7 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 hal! {
     TIM1: (tim1),
 }

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use core::mem;
 
 use crate::pac::DBGMCU as DBG;
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 use crate::pac::TIM1;
 #[cfg(feature = "medium")]
 use crate::pac::TIM4;
@@ -82,7 +82,7 @@ where
     RawValues { arr: u16, presc: u16 },
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 impl Timer<TIM1> {
     pub fn pwm_input<REMAP, PINS, T>(
         mut self,
@@ -305,7 +305,7 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 hal! {
     TIM1: (tim1),
 }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -9,7 +9,7 @@ use core::u16;
 use core::marker::PhantomData;
 
 use crate::hal::{self, Direction};
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 use crate::pac::TIM1;
 #[cfg(feature = "medium")]
 use crate::pac::TIM4;
@@ -71,7 +71,7 @@ pub struct Qei<TIM, REMAP, PINS> {
     _remap: PhantomData<REMAP>,
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 impl Timer<TIM1> {
     pub fn qei<REMAP, PINS>(
         self,
@@ -199,7 +199,7 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 hal! {
     TIM1: (_tim1, tim1en, tim1rst),
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -34,7 +34,7 @@ use core::ops::Deref;
 use core::ptr;
 
 pub use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
-#[cfg(feature = "high")]
+#[cfg(any(feature = "high", feature = "connectivity"))]
 use crate::pac::SPI3;
 use crate::pac::{SPI1, SPI2};
 
@@ -43,6 +43,8 @@ use crate::dma::dma1::{C3, C5};
 use crate::dma::{Static, Transfer, TransferPayload, Transmit, TxDma, R};
 use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
+#[cfg(feature = "connectivity")]
+use crate::gpio::gpioc::{PC10, PC11, PC12};
 use crate::gpio::{Alternate, Floating, Input, PushPull};
 use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset};
 use crate::time::Hertz;
@@ -141,7 +143,7 @@ remap!(Spi1Remap, SPI1, true, PB3, PB4, PB5);
 remap!(Spi2NoRemap, SPI2, false, PB13, PB14, PB15);
 #[cfg(feature = "high")]
 remap!(Spi3NoRemap, SPI3, false, PB3, PB4, PB5);
-#[cfg(feature = "stm32f105")]
+#[cfg(feature = "connectivity")]
 remap!(Spi3Remap, SPI3, true, PC10, PC11, PC12);
 
 impl<REMAP, PINS> Spi<SPI1, REMAP, PINS> {
@@ -182,7 +184,7 @@ impl<REMAP, PINS> Spi<SPI2, REMAP, PINS> {
     }
 }
 
-#[cfg(feature = "high")]
+#[cfg(any(feature = "high", feature = "connectivity"))]
 impl<REMAP, PINS> Spi<SPI3, REMAP, PINS> {
     pub fn spi3<F, POS>(
         spi: SPI3,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -48,20 +48,17 @@
 */
 
 use crate::hal::timer::{CountDown, Periodic};
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 use crate::pac::TIM1;
 #[cfg(feature = "medium")]
 use crate::pac::TIM4;
-#[cfg(feature = "high")]
+#[cfg(any(feature = "high", feature = "connectivity"))]
 use crate::pac::TIM5;
-#[cfg(any(feature = "stm32f100", feature = "stm32f105", feature = "high",))]
+#[cfg(any(feature = "stm32f100", feature = "high", feature = "connectivity",))]
 use crate::pac::TIM6;
 #[cfg(any(
-    all(
-        feature = "high",
-        any(feature = "stm32f101", feature = "stm32f103", feature = "stm32f107",),
-    ),
-    any(feature = "stm32f100", feature = "stm32f105",)
+    all(feature = "high", any(feature = "stm32f101", feature = "stm32f103",),),
+    any(feature = "stm32f100", feature = "connectivity",)
 ))]
 use crate::pac::TIM7;
 #[cfg(all(feature = "stm32f103", feature = "high",))]
@@ -125,12 +122,12 @@ use crate::gpio::gpioa::{PA0, PA1, PA15, PA2, PA3, PA6, PA7};
 use crate::gpio::gpiob::{PB0, PB1, PB10, PB11, PB3, PB4, PB5};
 use crate::gpio::gpioc::{PC6, PC7, PC8, PC9};
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 use crate::gpio::{
     gpioa::{PA10, PA11, PA8, PA9},
     gpioe::{PE11, PE13, PE14, PE9},
 };
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 remap!(
     Tim1NoRemap: (TIM1, 0b00, PA8, PA9, PA10, PA11),
     //Tim1PartialRemap: (TIM1, 0b01, PA8, PA9, PA10, PA11),
@@ -426,22 +423,19 @@ hal! {
     TIM3: (tim3, dbg_tim3_stop, tim2),
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "stm32f105",))]
+#[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 hal! {
     TIM1: (tim1, dbg_tim1_stop, tim1),
 }
 
-#[cfg(any(feature = "stm32f100", feature = "stm32f105", feature = "high",))]
+#[cfg(any(feature = "stm32f100", feature = "high", feature = "connectivity",))]
 hal! {
     TIM6: (tim6, dbg_tim6_stop, tim6),
 }
 
 #[cfg(any(
-    all(
-        feature = "high",
-        any(feature = "stm32f101", feature = "stm32f103", feature = "stm32f107",),
-    ),
-    any(feature = "stm32f100", feature = "stm32f105",)
+    all(feature = "high", any(feature = "stm32f101", feature = "stm32f103",),),
+    any(feature = "stm32f100", feature = "connectivity",)
 ))]
 hal! {
     TIM7: (tim7, dbg_tim7_stop, tim6),
@@ -459,7 +453,7 @@ hal! {
     TIM4: (tim4, dbg_tim4_stop, tim2),
 }
 
-#[cfg(feature = "high")]
+#[cfg(any(feature = "high", feature = "connectivity"))]
 hal! {
     TIM5: (tim5, dbg_tim5_stop, tim2),
 }


### PR DESCRIPTION
This PR adds support for the `stm32f105xx` and `stm32f107xx` devices which are also knows as *connectivity line*.
They have a peripheral configuration similar to the stm32f103 high-density devices but feature USB OTG FS peripheral and the stm32f107xx devices additionally have an ethernet controller.

Both share a common SVD file with the name stm32f107. I introduced the `connectivity` cargo feature to always cover both devices. The `connectivity` feature replaces all previously abandoned `stm32f107` and `stm32f105` features in configuration attributes.

I could blink a LED on a STM32F105 board with a crystal oscillator. No other tests were run on real hardware.

Please have a look and let me know if I missed something and what can be improved.