### PR TITLE
Controller Area Network (CAN)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ nb = "0.1.2"
 cortex-m-rt = "0.6.8"
 stm32f1 = "0.11.0"
 as-slice = "0.1"
+typenum = "1.12.0"
 
 [dependencies.void]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ codegen-units = 1
 [profile.release]
 codegen-units = 1
 debug = true
-opt-level = "s"
 lto = true
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ nb = "0.1.2"
 cortex-m-rt = "0.6.8"
 stm32f1 = "0.11.0"
 as-slice = "0.1"
-typenum = "1.12.0"
 
 [dependencies.void]
 default-features = false
@@ -99,6 +98,7 @@ codegen-units = 1
 [profile.release]
 codegen-units = 1
 debug = true
+opt-level = "s"
 lto = true
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,5 +137,9 @@ name = "can-echo"
 required-features = ["connectivity"]
 
 [[example]]
+name = "can-loopback"
+required-features = ["stm32f103", "stm32f105", "stm32f107"]
+
+[[example]]
 name = "can-rtfm"
 required-features = ["connectivity", "rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,5 +134,9 @@ name = "exti"
 required-features = ["rt"]
 
 [[example]]
+name = "can-echo"
+required-features = ["connectivity"]
+
+[[example]]
 name = "can-rtfm"
-required-features = ["rt"]
+required-features = ["connectivity", "rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ required-features = ["has-can"]
 
 [[example]]
 name = "can-rtfm"
-required-features = ["connectivity", "rt"]
+required-features = ["has-can", "rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ panic-semihosting = "0.5.2"
 panic-itm = "0.4.1"
 cortex-m-rtfm = "0.5"
 cortex-m-semihosting = "0.3.3"
-heapless = "0.4.3"
+heapless = "0.5.5"
 m = "0.1.1"
 mfrc522 = "0.2.0"
 serde_derive = "1.0.90"
@@ -130,4 +130,8 @@ required-features = ["rt", "medium"]
 
 [[example]]
 name = "exti"
+required-features = ["rt"]
+
+[[example]]
+name = "can-rtfm"
 required-features = ["rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ doc = []
 rt = ["stm32f1/rt"]
 stm32f100 = ["stm32f1/stm32f100", "device-selected"]
 stm32f101 = ["stm32f1/stm32f101", "device-selected"]
-stm32f103 = ["stm32f1/stm32f103", "device-selected"]
+stm32f103 = ["stm32f1/stm32f103", "device-selected", "has-can"]
 stm32f105 = ["stm32f1/stm32f107", "device-selected", "connectivity"]
 stm32f107 = ["stm32f1/stm32f107", "device-selected", "connectivity"]
 
@@ -89,7 +89,9 @@ high = ["medium"]
 # Devices with 768 Kb ROM or more
 xl = ["high"]
 # Connectivity line devices (`stm32f105xx` and `stm32f107xx`)
-connectivity = ["medium"]
+connectivity = ["medium", "has-can"]
+# Devices with CAN interface
+has-can = []
 
 [profile.dev]
 incremental = false
@@ -138,7 +140,7 @@ required-features = ["connectivity"]
 
 [[example]]
 name = "can-loopback"
-required-features = ["stm32f103", "stm32f105", "stm32f107"]
+required-features = ["has-can"]
 
 [[example]]
 name = "can-rtfm"

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -1,3 +1,5 @@
+//! Simple CAN example. Requires a transceiver connected to PB5 and PB6.
+
 #![no_main]
 #![no_std]
 
@@ -22,14 +24,13 @@ fn main() -> ! {
     // resonator must be used.
     rcc.cfgr.use_hse(8.mhz()).freeze(&mut flash.acr);
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut can2 = Can::new(dp.CAN2, &mut rcc.apb1);
 
-    // Select some pins for CAN2.
+    // Select pins for CAN2.
+    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
     let can_rx_pin = gpiob.pb5.into_floating_input(&mut gpiob.crl);
     let can_tx_pin = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
     let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
-
-    let mut can2 = Can::new(dp.CAN2, &mut rcc.apb1);
     can2.assign_pins((can_tx_pin, can_rx_pin), &mut afio.mapr);
 
     can2.configure(|config| {
@@ -37,9 +38,6 @@ fn main() -> ! {
         // Value was calculated with http://www.bittiming.can-wiki.info/
         config.set_bit_timing(0x001c_0003);
     });
-
-    // Get the transmitter part.
-    let mut tx = can2.take_tx().unwrap();
 
     // Filters are required to use the receiver part of CAN2.
     // Because the filter banks are part of CAN1 we first need to enable CAN1
@@ -51,7 +49,10 @@ fn main() -> ! {
     let (_filters1, mut filters2) = can1.split_filters(0).unwrap();
     assert_eq!(filters2.num_available(), NUM_FILTER_BANKS);
     filters2.add(&Filter::accept_all()).unwrap(); // Receive all messages.
+
+    // Split the peripheral into transmitter and receiver parts.
     let mut rx = can2.take_rx(filters2).unwrap();
+    let mut tx = can2.take_tx().unwrap();
 
     // Sync to the bus and start normal operation.
     block!(can2.enable()).ok();

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -45,7 +45,10 @@ fn main() -> ! {
     // Because the filter banks are part of CAN1 we first need to enable CAN1
     // and split the filters between the peripherals to use them for CAN2.
     let mut can1 = Can::new(dp.CAN1, &mut rcc.apb1);
-    let (_filters1, mut filters2) = can1.split_filters().unwrap();
+
+    // Split the filters at index 0: No filters for CAN1 (unused), 28 filters
+    // for CAN2.
+    let (_filters1, mut filters2) = can1.split_filters(0).unwrap();
     filters2.add(Filter::accept_all()).unwrap(); // Receive all messages.
     let mut rx = can2.take_rx(filters2).unwrap();
 

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
     // Value was calculated with http://www.bittiming.can-wiki.info/
-    unsafe { can2.set_bit_timing(0x001c_0003) };
+    can2.set_bit_timing(0x001c_0003);
 
     // Get the transmitter part.
     let mut tx = can2.take_tx().unwrap();

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -6,7 +6,7 @@ use panic_halt as _;
 use cortex_m_rt::entry;
 use nb::block;
 use stm32f1xx_hal::{
-    can::{Can, Filter},
+    can::{Can, Filter, NUM_FILTER_BANKS},
     pac,
     prelude::*,
 };
@@ -49,6 +49,7 @@ fn main() -> ! {
     // Split the filters at index 0: No filters for CAN1 (unused), 28 filters
     // for CAN2.
     let (_filters1, mut filters2) = can1.split_filters(0).unwrap();
+    assert_eq!(filters2.num_available(), NUM_FILTER_BANKS);
     filters2.add(&Filter::accept_all()).unwrap(); // Receive all messages.
     let mut rx = can2.take_rx(filters2).unwrap();
 

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
     // Split the filters at index 0: No filters for CAN1 (unused), 28 filters
     // for CAN2.
     let (_filters1, mut filters2) = can1.split_filters(0).unwrap();
-    filters2.add(Filter::accept_all()).unwrap(); // Receive all messages.
+    filters2.add(&Filter::accept_all()).unwrap(); // Receive all messages.
     let mut rx = can2.take_rx(filters2).unwrap();
 
     // Sync to the bus and start normal operation.

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -5,7 +5,11 @@ use panic_halt as _;
 
 use cortex_m_rt::entry;
 use nb::block;
-use stm32f1xx_hal::{can::Can, pac, prelude::*};
+use stm32f1xx_hal::{
+    can::{Can, Filter},
+    pac,
+    prelude::*,
+};
 
 #[entry]
 fn main() -> ! {
@@ -40,7 +44,7 @@ fn main() -> ! {
     // and split the filters between the peripherals to use them for CAN2.
     let mut can1 = Can::new(dp.CAN1, &mut rcc.apb1);
     let (_filters1, mut filters2) = can1.split_filters().unwrap();
-    filters2.accept_all(); // Receive all messages.
+    filters2.add(Filter::accept_all()).unwrap(); // Receive all messages.
     let mut rx = can2.take_rx(filters2).unwrap();
 
     // Sync to the bus and start normal operation.

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -56,7 +56,8 @@ fn main() -> ! {
     // See the `can-rtfm` example for an echo implementation that adheres to
     // correct frame ordering based on the transfer id.
     loop {
-        let frame = block!(rx.receive()).unwrap();
-        block!(tx.transmit(&frame)).unwrap();
+        if let Ok(frame) = block!(rx.receive()) {
+            block!(tx.transmit(&frame)).unwrap();
+        }
     }
 }

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -32,9 +32,11 @@ fn main() -> ! {
     let mut can2 = Can::new(dp.CAN2, &mut rcc.apb1);
     can2.assign_pins((can_tx_pin, can_rx_pin), &mut afio.mapr);
 
-    // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
-    // Value was calculated with http://www.bittiming.can-wiki.info/
-    can2.set_bit_timing(0x001c_0003);
+    can2.configure(|config| {
+        // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
+        // Value was calculated with http://www.bittiming.can-wiki.info/
+        config.set_bit_timing(0x001c_0003);
+    });
 
     // Get the transmitter part.
     let mut tx = can2.take_tx().unwrap();

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -1,0 +1,56 @@
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+use nb::block;
+use stm32f1xx_hal::{can::Can, pac, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    // To meet CAN clock accuracy requirements an external crystal or ceramic
+    // resonator must be used.
+    rcc.cfgr.use_hse(8.mhz()).freeze(&mut flash.acr);
+
+    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+
+    // Select some pins for CAN2.
+    let can_rx_pin = gpiob.pb5.into_floating_input(&mut gpiob.crl);
+    let can_tx_pin = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
+    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+
+    let mut can2 = Can::new(dp.CAN2, &mut rcc.apb1);
+    can2.assign_pins((can_tx_pin, can_rx_pin), &mut afio.mapr);
+
+    // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
+    // Value was calculated with http://www.bittiming.can-wiki.info/
+    unsafe { can2.set_bit_timing(0x001c_0003) };
+
+    // Get the transmitter part.
+    let mut tx = can2.take_tx().unwrap();
+
+    // Filters are required to use the receiver part of CAN2.
+    // Because the filter banks are part of CAN1 we first need to enable CAN1
+    // and split the filters between the peripherals to use them for CAN2.
+    let mut can1 = Can::new(dp.CAN1, &mut rcc.apb1);
+    let (_filters1, mut filters2) = can1.split_filters().unwrap();
+    filters2.accept_all(); // Receive all messages.
+    let mut rx = can2.take_rx(filters2).unwrap();
+
+    // Sync to the bus and start normal operation.
+    block!(can2.enable()).ok();
+
+    // Echo back received packages in sequence.
+    // See the `can-rtfm` example for an echo implementation that adheres to
+    // correct frame ordering based on the transfer id.
+    loop {
+        let frame = block!(rx.receive()).unwrap();
+        block!(tx.transmit(&frame)).unwrap();
+    }
+}

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -21,7 +21,8 @@ fn main() -> ! {
     let mut rcc = dp.RCC.constrain();
 
     // To meet CAN clock accuracy requirements an external crystal or ceramic
-    // resonator must be used.
+    // resonator must be used. The blue pill has a 8MHz external crystal.
+    // Other boards might have a crystal with another frequency or none at all.
     rcc.cfgr.use_hse(8.mhz()).freeze(&mut flash.acr);
 
     let mut can2 = Can::new(dp.CAN2, &mut rcc.apb1);

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -6,7 +6,7 @@ use panic_halt as _;
 use cortex_m_rt::entry;
 use nb::block;
 use stm32f1xx_hal::{
-    can::{Can, Filter, Frame, NUM_FILTER_BANKS},
+    can::{Can, Filter, Frame},
     pac,
     prelude::*,
 };
@@ -40,25 +40,59 @@ fn main() -> ! {
     // Get the transmitter part.
     let mut tx = can.take_tx().unwrap();
 
-    // Receive all messages.
+    // Use advanced configurations for the first three filter banks.
     #[cfg(not(feature = "connectivity"))]
-    let mut filters = can.split_filters().unwrap();
+    let mut filters = can
+        .split_filters_advanced(0x0000_0006, 0xFFFF_FFFA, 0x0000_0007)
+        .unwrap();
     #[cfg(feature = "connectivity")]
-    let (mut filters, _) = can.split_filters(NUM_FILTER_BANKS / 2).unwrap();
-    filters.add(&Filter::accept_all()).unwrap();
+    let (mut filters, _) = can
+        .split_filters_advanced(0x0000_0006, 0xFFFF_FFFA, 0x0000_0007, 3)
+        .unwrap();
+
+    assert_eq!(filters.num_available(), 8);
+
+    // Matches 0, 1, 2
+    filters
+        .add_standard([
+            &Filter::new_standard(0).with_mask(!0b1),
+            &Filter::new_standard(0).with_mask(!0b10),
+        ])
+        .unwrap();
+
+    // Matches 4, 5
+    filters
+        .add_list([&Filter::new_standard(4), &Filter::new_standard(5)])
+        .unwrap();
+
+    // Matches 8, 9, 10, 11
+    filters
+        .add_standard_list([
+            &Filter::new_standard(8),
+            &Filter::new_standard(9),
+            &Filter::new_standard(10),
+            &Filter::new_standard(11),
+        ])
+        .unwrap();
+
     let mut rx = can.take_rx(filters).unwrap();
 
     // Sync to the bus and start normal operation.
     block!(can.enable()).ok();
 
-    // Send and receive messages with incrementing identifier.
-    for id in (0..0x7FF_u32).cycle() {
+    // Some messages shall pass the filters.
+    for &id in &[0, 1, 2, 4, 5, 8, 9, 10, 11] {
         let frame_tx = Frame::new_standard(id, &[id as u8]);
         block!(tx.transmit(&frame_tx)).unwrap();
-
         let frame_rx = block!(rx.receive()).unwrap();
-
         assert_eq!(frame_tx, frame_rx);
+    }
+
+    // Others must be filtered out.
+    for &id in &[3, 6, 7, 12] {
+        let frame_tx = Frame::new_standard(id, &[id as u8]);
+        block!(tx.transmit(&frame_tx)).unwrap();
+        assert!(rx.receive().is_err());
     }
 
     loop {}

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     let mut filters = can.split_filters().unwrap();
     #[cfg(feature = "connectivity")]
     let (mut filters, _) = can.split_filters(NUM_FILTER_BANKS / 2).unwrap();
-    filters.add(Filter::accept_all()).unwrap();
+    filters.add(&Filter::accept_all()).unwrap();
     let mut rx = can.take_rx(filters).unwrap();
 
     // Sync to the bus and start normal operation.

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -57,28 +57,23 @@ fn main() -> ! {
     // The order of the added filters is important: it must match configuration
     // of the `split_filters_advanced()` method.
 
-    // Matches 0, 1, 2
+    // 2x 11bit id + mask filter bank: Matches 0, 1, 2
     filters
-        .add_standard([
-            &Filter::new_standard(0).with_mask(!0b1),
-            &Filter::new_standard(0).with_mask(!0b10),
-        ])
+        .add(&Filter::new_standard(0).with_mask(!0b1))
+        .unwrap();
+    filters
+        .add(&Filter::new_standard(0).with_mask(!0b10))
         .unwrap();
 
-    // Matches 4, 5
-    filters
-        .add_list([&Filter::new_standard(4), &Filter::new_standard(5)])
-        .unwrap();
+    // 2x 29bit id filter bank: Matches 4, 5
+    filters.add(&Filter::new_standard(4)).unwrap();
+    filters.add(&Filter::new_standard(5)).unwrap();
 
-    // Matches 8, 9, 10, 11
-    filters
-        .add_standard_list([
-            &Filter::new_standard(8),
-            &Filter::new_standard(9),
-            &Filter::new_standard(10),
-            &Filter::new_standard(11),
-        ])
-        .unwrap();
+    // 4x 11bit id filter bank: Matches 8, 9, 10, 11
+    filters.add(&Filter::new_standard(8)).unwrap();
+    filters.add(&Filter::new_standard(9)).unwrap();
+    filters.add(&Filter::new_standard(10)).unwrap();
+    filters.add(&Filter::new_standard(11)).unwrap();
 
     // Split the peripheral into transmitter and receiver parts.
     let mut rx = can.take_rx(filters).unwrap();

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -58,8 +58,7 @@ fn main() -> ! {
 
         let frame_rx = block!(rx.receive()).unwrap();
 
-        assert_eq!(frame_tx, frame_rx); // Only compares the identifier.
-        assert_eq!(frame_tx.data(), frame_rx.data());
+        assert_eq!(frame_tx, frame_rx);
     }
 
     loop {}

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -6,7 +6,7 @@ use panic_halt as _;
 use cortex_m_rt::entry;
 use nb::block;
 use stm32f1xx_hal::{
-    can::{Can, Filter, Frame},
+    can::{Can, Filter, Frame, NUM_FILTER_BANKS},
     pac,
     prelude::*,
 };
@@ -44,7 +44,7 @@ fn main() -> ! {
     #[cfg(not(feature = "connectivity"))]
     let mut filters = can.split_filters().unwrap();
     #[cfg(feature = "connectivity")]
-    let (mut filters, _) = can.split_filters().unwrap();
+    let (mut filters, _) = can.split_filters(NUM_FILTER_BANKS / 2).unwrap();
     filters.add(Filter::accept_all()).unwrap();
     let mut rx = can.take_rx(filters).unwrap();
 

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -1,0 +1,66 @@
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+use nb::block;
+use stm32f1xx_hal::{
+    can::{Can, Filter, Frame},
+    pac,
+    prelude::*,
+};
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    // To meet CAN clock accuracy requirements an external crystal or ceramic
+    // resonator must be used.
+    rcc.cfgr.use_hse(8.mhz()).freeze(&mut flash.acr);
+
+    #[cfg(not(feature = "connectivity"))]
+    let mut can = Can::new(dp.CAN1, &mut rcc.apb1, dp.USB);
+
+    #[cfg(feature = "connectivity")]
+    let mut can = Can::new(dp.CAN1, &mut rcc.apb1);
+
+    // Use loopback mode: No pins need to be assigned to peripheral.
+    can.configure(|config| {
+        // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
+        // Value was calculated with http://www.bittiming.can-wiki.info/
+        config.set_bit_timing(0x001c_0003);
+        config.set_loopback(true);
+        config.set_silent(true);
+    });
+
+    // Get the transmitter part.
+    let mut tx = can.take_tx().unwrap();
+
+    // Receive all messages.
+    #[cfg(not(feature = "connectivity"))]
+    let mut filters = can.split_filters().unwrap();
+    #[cfg(feature = "connectivity")]
+    let (mut filters, _) = can.split_filters().unwrap();
+    filters.add(Filter::accept_all()).unwrap();
+    let mut rx = can.take_rx(filters).unwrap();
+
+    // Sync to the bus and start normal operation.
+    block!(can.enable()).ok();
+
+    // Send and receive messages with incrementing identifier.
+    for id in (0..0x7FF_u32).cycle() {
+        let frame_tx = Frame::new_standard(id, &[id as u8]);
+        block!(tx.transmit(&frame_tx)).unwrap();
+
+        let frame_rx = block!(rx.receive()).unwrap();
+
+        assert_eq!(frame_tx, frame_rx); // Only compares the identifier.
+        assert_eq!(frame_tx.data(), frame_rx.data());
+    }
+
+    loop {}
+}

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();
 
-    // To meet CAN clock accuracy requirements an external crystal or ceramic
+    // To meet CAN clock accuracy requirements, an external crystal or ceramic
     // resonator must be used.
     rcc.cfgr.use_hse(8.mhz()).freeze(&mut flash.acr);
 

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -74,7 +74,7 @@ const APP: () = {
 
         // APB1 (PCLK1): 36MHz, Bit rate: 125kBit/s, Sample Point 87.5%
         // Value was calculated with http://www.bittiming.can-wiki.info/
-        unsafe { can2.set_bit_timing(0x001c0011) };
+        can2.set_bit_timing(0x001c0011);
         can2.enable().ok();
 
         let mut can_tx = can2.take_tx().unwrap();

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -88,13 +88,13 @@ const APP: () = {
         let (_, mut filters) = can1.split_filters(0).unwrap();
 
         // To share load between FIFOs use one filter for standard messages and another
-        // for extended messages. Accept all IDs by setting the mask to 0. Only accept
-        // data frames (no remote frames).
+        // for extended messages. Accept all IDs by setting the mask to 0. Explicitly
+        // allow to receive remote frames.
         filters
-            .add(Filter::new_standard(0).with_mask(0).with_rtr(false))
+            .add(&Filter::new_standard(0).with_mask(0).allow_remote())
             .unwrap();
         filters
-            .add(Filter::new_extended(0).with_mask(0).with_rtr(false))
+            .add(&Filter::new_extended(0).with_mask(0).allow_remote())
             .unwrap();
 
         let mut can_rx = can2.take_rx(filters).unwrap();

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -85,7 +85,7 @@ const APP: () = {
         CanFramePool::grow(CAN_POOL_MEMORY);
 
         let mut can1 = Can::new(cx.device.CAN1, &mut rcc.apb1);
-        let (_, mut filters) = can1.split_filters().unwrap();
+        let (_, mut filters) = can1.split_filters(0).unwrap();
 
         // To share load between FIFOs use one filter for standard messages and another
         // for extended messages. Accept all IDs by setting the mask to 0. Only accept

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -1,0 +1,160 @@
+//! Interrupt driven CAN transmitter with RTFM.
+//!
+//! CAN frames are allocated from a static memory pool and stored in a priority
+//! queue (min heap) for transmisison. To start transmission the CAN TX
+//! interrupt has to be triggered manually once. With each successful
+//! transmission the interrupt is reentered and more data is fetched from the
+//! queue.
+#![no_main]
+#![no_std]
+
+use heapless::{
+    binary_heap::{BinaryHeap, Min},
+    consts::*,
+    pool,
+    pool::{
+        singleton::{Box, Pool},
+        Init,
+    },
+};
+use panic_halt as _;
+use rtfm::app;
+use stm32f1xx_hal::{
+    can::{Can, Frame, Tx},
+    pac::{Interrupt, CAN2},
+    prelude::*,
+};
+
+pool!(CanFramePool: Frame);
+
+fn alloc_frame(id: u32, data: &[u8]) -> Box<CanFramePool, Init> {
+    let frame_box = CanFramePool::alloc().unwrap();
+    frame_box.init(Frame::new_standard(id, data))
+}
+
+#[app(device = stm32f1xx_hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        can_tx: Tx<CAN2>,
+        can_tx_queue: BinaryHeap<Box<CanFramePool>, U8, Min>,
+        tx_count: usize,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> init::LateResources {
+        static mut CAN_POOL_MEMORY: [u8; 256] = [0; 256];
+
+        let mut flash = cx.device.FLASH.constrain();
+        let mut rcc = cx.device.RCC.constrain();
+
+        let _clocks = rcc.cfgr.use_hse(8.mhz()).freeze(&mut flash.acr);
+
+        let mut gpiob = cx.device.GPIOB.split(&mut rcc.apb2);
+        let mut afio = cx.device.AFIO.constrain(&mut rcc.apb2);
+
+        let canrx = gpiob.pb5.into_floating_input(&mut gpiob.crl);
+        let cantx = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
+        let mut can = Can::new(
+            cx.device.CAN2,
+            (cantx, canrx),
+            &mut afio.mapr,
+            &mut rcc.apb1,
+        );
+        // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
+        // Value was calculated with http://www.bittiming.can-wiki.info/
+        unsafe { can.set_bit_timing(0x001c_0003) };
+        can.enable_tx_interrupt();
+        can.enable().ok();
+
+        let can_tx = can.take_tx().unwrap();
+        let can_tx_queue = BinaryHeap::new();
+        CanFramePool::grow(CAN_POOL_MEMORY);
+
+        init::LateResources {
+            can_tx,
+            can_tx_queue,
+            tx_count: 0,
+        }
+    }
+
+    #[idle(resources = [can_tx_queue, tx_count])]
+    fn idle(mut cx: idle::Context) -> ! {
+        static mut HIGH_PRIORITY_MESSAGES_PENDING: bool = true;
+
+        // Enqueue some messages. Higher ID means lower priority.
+        cx.resources.can_tx_queue.lock(|tx_queue| {
+            tx_queue.push(alloc_frame(9, &[0, 1, 2, 4])).unwrap();
+            tx_queue.push(alloc_frame(9, &[0, 1, 2, 4])).unwrap();
+            tx_queue.push(alloc_frame(8, &[0, 1, 2, 4])).unwrap();
+            tx_queue.push(alloc_frame(8, &[0, 1, 2, 4])).unwrap();
+            tx_queue.push(alloc_frame(7, &[0, 1, 2, 4])).unwrap();
+            tx_queue.push(alloc_frame(7, &[0, 1, 2, 4])).unwrap();
+        });
+
+        // Manually trigger the tx interrupt to start the transmission.
+        rtfm::pend(Interrupt::CAN2_TX);
+
+        loop {
+            let tx_count = cx.resources.tx_count.lock(|tx_count| *tx_count);
+
+            // Add some higher priority messages when 3 messages have been sent.
+            if *HIGH_PRIORITY_MESSAGES_PENDING && tx_count >= 3 {
+                *HIGH_PRIORITY_MESSAGES_PENDING = false;
+
+                cx.resources.can_tx_queue.lock(|tx_queue| {
+                    tx_queue.push(alloc_frame(3, &[0, 1, 2, 4])).unwrap();
+                    tx_queue.push(alloc_frame(2, &[0, 1, 2, 4])).unwrap();
+                    tx_queue.push(alloc_frame(1, &[0, 1, 2, 4])).unwrap();
+                });
+            }
+            cortex_m::asm::wfi();
+        }
+
+        // Expected bus traffic:
+        //
+        // 1. ID: 7 DATA: 00 01 02 04
+        // 2. ID: 7 DATA: 00 01 02 04
+        // 3. ID: 8 DATA: 00 01 02 04
+        // 4. ID: 1 DATA: 00 01 02 04
+        // 5. ID: 2 DATA: 00 01 02 04
+        // 6. ID: 3 DATA: 00 01 02 04
+        // 7. ID: 8 DATA: 00 01 02 04
+        // 8. ID: 9 DATA: 00 01 02 04
+        // 9. ID: 9 DATA: 00 01 02 04
+        //
+        // The output can look different if there are other nodes on the bus that send
+        // higher priority messages at the same time.
+    }
+
+    // This ISR is triggered by each finished frame transmission.
+    #[task(binds = CAN2_TX, resources = [can_tx, can_tx_queue, tx_count])]
+    fn can2_tx(cx: can2_tx::Context) {
+        let tx = cx.resources.can_tx;
+        let tx_queue = cx.resources.can_tx_queue;
+
+        tx.clear_interrupt_flags();
+
+        // There is now a free mailbox. Send the next frame if there is still someting
+        // in the queue.
+        while let Some(frame) = tx_queue.peek() {
+            match tx.transmit(&frame) {
+                Ok(None) => {
+                    tx_queue.pop();
+                    *cx.resources.tx_count += 1;
+                }
+                Ok(pending_frame) => {
+                    // A lower priority frame was replaced with our high priority frame.
+                    // Put the low priority frame back in the transmit queue.
+                    tx_queue.pop();
+                    if let Some(frame) = pending_frame {
+                        tx_queue
+                            .push(CanFramePool::alloc().unwrap().init(frame))
+                            .unwrap();
+                    }
+                }
+                Err(nb::Error::WouldBlock) => break,
+                _ => unreachable!(),
+            }
+        }
+    }
+};

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -72,9 +72,11 @@ const APP: () = {
         let mut can2 = Can::new(cx.device.CAN2, &mut rcc.apb1);
         can2.assign_pins((can_tx_pin, can_rx_pin), &mut afio.mapr);
 
-        // APB1 (PCLK1): 36MHz, Bit rate: 125kBit/s, Sample Point 87.5%
-        // Value was calculated with http://www.bittiming.can-wiki.info/
-        can2.set_bit_timing(0x001c0011);
+        can2.configure(|config| {
+            // APB1 (PCLK1): 36MHz, Bit rate: 125kBit/s, Sample Point 87.5%
+            // Value was calculated with http://www.bittiming.can-wiki.info/
+            config.set_bit_timing(0x001c0011);
+        });
 
         let mut can_tx = can2.take_tx().unwrap();
         can_tx.enable_interrupt();

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -51,8 +51,6 @@ const APP: () = {
     fn init(cx: init::Context) -> init::LateResources {
         static mut CAN_POOL_MEMORY: [u8; 256] = [0; 256];
 
-        unsafe { cx.core.SCB.vtor.write(0x0800_0000) };
-
         let mut flash = cx.device.FLASH.constrain();
         let mut rcc = cx.device.RCC.constrain();
 

--- a/examples/can-rtfm.rs
+++ b/examples/can-rtfm.rs
@@ -35,7 +35,7 @@ pool!(
 
 fn alloc_frame(id: Id, data: &[u8]) -> Box<CanFramePool, Init> {
     let frame_box = CanFramePool::alloc().unwrap();
-    frame_box.init(Frame::new(id, data))
+    frame_box.init(Frame::new(id, data).unwrap())
 }
 
 #[app(device = stm32f1xx_hal::pac, peripherals = true)]
@@ -90,10 +90,10 @@ const APP: () = {
         #[cfg(feature = "connectivity")]
         let (mut filters, _) = can.split_filters(0).unwrap();
         filters
-            .add(&Filter::new_standard(0).with_mask(0).allow_remote())
+            .add(&Filter::new(Id::Standard(0)).with_mask(0).allow_remote())
             .unwrap();
         filters
-            .add(&Filter::new_extended(0).with_mask(0).allow_remote())
+            .add(&Filter::new(Id::Extended(0)).with_mask(0).allow_remote())
             .unwrap();
 
         let mut can_rx = can.take_rx(filters).unwrap();
@@ -123,25 +123,25 @@ const APP: () = {
         // Enqueue some messages. Higher ID means lower priority.
         tx_queue.lock(|tx_queue| {
             tx_queue
-                .push(alloc_frame(Id::new_standard(9), &[0, 1, 2, 4]))
+                .push(alloc_frame(Id::Standard(9), &[0, 1, 2, 4]))
                 .unwrap();
             tx_queue
-                .push(alloc_frame(Id::new_standard(9), &[0, 1, 2, 4]))
+                .push(alloc_frame(Id::Standard(9), &[0, 1, 2, 4]))
                 .unwrap();
             tx_queue
-                .push(alloc_frame(Id::new_standard(8), &[0, 1, 2, 4]))
+                .push(alloc_frame(Id::Standard(8), &[0, 1, 2, 4]))
                 .unwrap();
 
             // Extended frames have lower priority than standard frames.
             tx_queue
-                .push(alloc_frame(Id::new_extended(8), &[0, 1, 2, 4]))
+                .push(alloc_frame(Id::Extended(8), &[0, 1, 2, 4]))
                 .unwrap();
             tx_queue
-                .push(alloc_frame(Id::new_extended(7), &[0, 1, 2, 4]))
+                .push(alloc_frame(Id::Extended(7), &[0, 1, 2, 4]))
                 .unwrap();
 
             tx_queue
-                .push(alloc_frame(Id::new_standard(7), &[0, 1, 2, 4]))
+                .push(alloc_frame(Id::Standard(7), &[0, 1, 2, 4]))
                 .unwrap();
         });
 
@@ -155,13 +155,13 @@ const APP: () = {
             if tx_count >= 3 {
                 tx_queue.lock(|tx_queue| {
                     tx_queue
-                        .push(alloc_frame(Id::new_standard(3), &[0, 1, 2, 4]))
+                        .push(alloc_frame(Id::Standard(3), &[0, 1, 2, 4]))
                         .unwrap();
                     tx_queue
-                        .push(alloc_frame(Id::new_standard(2), &[0, 1, 2, 4]))
+                        .push(alloc_frame(Id::Standard(2), &[0, 1, 2, 4]))
                         .unwrap();
                     tx_queue
-                        .push(alloc_frame(Id::new_standard(1), &[0, 1, 2, 4]))
+                        .push(alloc_frame(Id::Standard(1), &[0, 1, 2, 4]))
                         .unwrap();
                 });
                 break;

--- a/src/can.rs
+++ b/src/can.rs
@@ -87,8 +87,12 @@ impl Id {
 
     /// Sets the remote transmission (RTR) flag. This marks the identifier as
     /// being part of a remote frame.
-    fn with_rtr(self) -> Id {
-        Self(self.0 | Self::RTR_MASK)
+    fn with_rtr(self, rtr: bool) -> Id {
+        if rtr {
+            Self(self.0 | Self::RTR_MASK)
+        } else {
+            Self(self.0 & !Self::RTR_MASK)
+        }
     }
 
     /// Returns the identifier.
@@ -167,9 +171,12 @@ impl Frame {
         Self::new(Id::new_extended(id), data)
     }
 
-    /// Marks this frame as a remote frame.
-    pub fn set_remote(&mut self) -> &mut Self {
-        self.id = self.id.with_rtr();
+    /// Sets the remote transmission (RTR) flag. Marks the frame as a remote frame.
+    ///
+    /// Remote frames do not contain any data, even if the frame was created with a
+    /// non-empty data buffer.
+    pub fn with_rtr(&mut self, rtr: bool) -> &mut Self {
+        self.id = self.id.with_rtr(rtr);
         self.dlc = 0;
         self
     }
@@ -550,7 +557,8 @@ impl Filter {
         self
     }
 
-    /// Select if only remote (`rtr = true`) frames or only data (`rtr = false`) shall be received.
+    /// Select if only remote (`rtr = true`) frames or only data (`rtr = false`)
+    /// shall be received.
     pub fn with_rtr(mut self, rtr: bool) -> Self {
         if rtr {
             self.id |= Id::RTR_MASK;

--- a/src/can.rs
+++ b/src/can.rs
@@ -355,6 +355,12 @@ impl<Instance> Tx<Instance>
 where
     Instance: traits::Instance,
 {
+    /// Puts a CAN frame in a free transmit mailbox for transmission on the bus.
+    ///
+    /// Frames are transmitted to the bus based on their priority (identifier).
+    /// Transmit order is preserved for frames with identical identifiers.
+    /// If all transmit mailboxes are full a higher priority frame replaces the
+    /// lowest priority frame which is returned as `Ok(Some(frame))`.
     pub fn transmit(&mut self, frame: &Frame) -> nb::Result<Option<Frame>, Infallible> {
         let can = unsafe { &*Instance::REGISTERS };
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -1,0 +1,151 @@
+//! # Controller Area Network (CAN) Interface
+//!
+//! ## Alternate function remapping
+//!
+//! TX: Alternate Push-Pull Output
+//! RX: Input Floating Input
+//!
+//! ### CAN1
+//!
+//! | Function | NoRemap | Remap |
+//! |----------|---------|-------|
+//! | TX       | PA12    | PB9   |
+//! | RX       | PA11    | PB8   |
+//!
+//! ### CAN2
+//!
+//! | Function | NoRemap | Remap |
+//! |----------|---------|-------|
+//! | TX       | PB6     | PB13  |
+//! | RX       | PB5     | PB12  |
+
+/// Identifier of a CAN message.
+///
+/// Can be either a standard identifier (11bit, Range: 0..0x3FF)
+/// or a extendended identifier (29bit , Range: 0..0x1FFFFFFF).
+#[derive(Clone, Copy)]
+pub struct Id(u32);
+
+impl Id {
+    const STANDARD_SHIFT: u32 = 21; // 11 valid bits. Mask: 0xFFE0_0000
+    const EXTENDED_SHIFT: u32 = 3; // 29 valid bits. Mask: 0xFFFF_FFF8
+    const EID_MASK: u32 = 0x0000_0004;
+    const RTR_MASK: u32 = 0x0000_0002;
+
+    /// Creates a new standard identifier (11bit, Range: 0..0x7FF)
+    ///
+    /// Ids outside the allowed range are silently truncated.
+    pub fn new_standard(id: u32) -> Self {
+        assert!(id < 0x7FF);
+        Self(id << Self::STANDARD_SHIFT)
+    }
+
+    /// Creates a new extendended identifier (29bit , Range: 0..0x1FFFFFFF).
+    ///
+    /// Ids outside the allowed range are silently truncated.
+    pub fn new_extended(id: u32) -> Id {
+        assert!(id < 0x1FFF_FFFF);
+        Self(id << Self::EXTENDED_SHIFT | Self::EID_MASK)
+    }
+
+    /// Sets the remote transmission (RTR) flag. This marks the identifier as
+    /// being part of a remote frame.
+    fn with_rtr(&self) -> Id {
+        Self(self.0 | Self::RTR_MASK)
+    }
+
+    /// Returns the identifier.
+    ///
+    /// It is up to the user to check if it is an standard or extended id.
+    pub fn id(&self) -> u32 {
+        if self.is_extended() {
+            self.0 >> Self::EXTENDED_SHIFT
+        } else {
+            self.0 >> Self::STANDARD_SHIFT
+        }
+    }
+
+    /// Returns `true` if the identifier is an extended identifier.
+    pub fn is_extended(&self) -> bool {
+        self.0 & Self::EID_MASK != 0
+    }
+
+    /// Returns `true` if the identifier is a standard identifier.
+    pub fn is_standard(&self) -> bool {
+        !self.is_extended()
+    }
+
+    /// Returns `true` if the identifer is part of a remote frame (RTR bit set).
+    fn rtr(&self) -> bool {
+        self.0 & Self::RTR_MASK != 0
+    }
+}
+
+/// A CAN data or remote frame.
+pub struct Frame {
+    id: Id,
+    dlc: usize,
+    data: [u8; 8],
+}
+
+impl Frame {
+    /// Creates a new data frame.
+    pub fn new(id: Id, data: &[u8]) -> Self {
+        assert!(!id.rtr());
+
+        let mut frame = Self {
+            id,
+            dlc: data.len(),
+            data: [0; 8],
+        };
+        frame.data[0..data.len()].copy_from_slice(data);
+        frame
+    }
+
+    /// Creates ane new frame with a standard identifier.
+    pub fn new_standard(id: u32, data: &[u8]) -> Self {
+        Self::new(Id::new_standard(id), data)
+    }
+
+    /// Creates ane new frame with an extended identifier.
+    pub fn new_extended(id: u32, data: &[u8]) -> Self {
+        Self::new(Id::new_extended(id), data)
+    }
+
+    /// Marks this frame as a remote frame.
+    pub fn set_remote(&mut self) -> &mut Self {
+        self.id = self.id.with_rtr();
+        self.dlc = 0;
+        self
+    }
+
+    /// Returns true if this `Frame` is a extended frame
+    pub fn is_extended(&self) -> bool {
+        self.id.is_extended()
+    }
+
+    /// Returns true if this `Frame` is a standard frame
+    pub fn is_standard(&self) -> bool {
+        self.id.is_standard()
+    }
+
+    /// Returns true if this `Frame` is a remote frame
+    pub fn is_remote_frame(&self) -> bool {
+        self.id.rtr()
+    }
+
+    /// Returns true if this `Frame` is a data frame
+    pub fn is_data_frame(&self) -> bool {
+        !self.is_remote_frame()
+    }
+
+    /// Returns the frame identifier.
+    pub fn id(&self) -> u32 {
+        self.id.id()
+    }
+
+    // Returns the frame data.
+    pub fn data(&self) -> &[u8] {
+        &self.data[0..self.dlc]
+    }
+}

--- a/src/can.rs
+++ b/src/can.rs
@@ -27,11 +27,11 @@ use crate::gpio::{
     gpiob::{PB8, PB9},
     Alternate, Floating, Input, PushPull,
 };
-use crate::pac::CAN1;
 #[cfg(feature = "connectivity")]
 use crate::pac::CAN2;
 #[cfg(not(feature = "connectivity"))]
 use crate::pac::USB;
+use crate::pac::{can1::TX, CAN1};
 use crate::rcc::sealed::RccBus;
 use core::{
     convert::{Infallible, TryInto},
@@ -42,7 +42,7 @@ use core::{
 ///
 /// Can be either a standard identifier (11bit, Range: 0..0x3FF)
 /// or a extendended identifier (29bit , Range: 0..0x1FFFFFFF).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug)]
 pub struct Id(u32);
 
 impl Id {
@@ -65,10 +65,6 @@ impl Id {
     pub fn new_extended(id: u32) -> Id {
         assert!(id < 0x1FFF_FFFF);
         Self(id << Self::EXTENDED_SHIFT | Self::EID_MASK)
-    }
-
-    fn from_register(reg_bits: u32) -> Id {
-        Self(reg_bits & 0xFFFF_FFFE)
     }
 
     /// Sets the remote transmission (RTR) flag. This marks the identifier as
@@ -362,73 +358,90 @@ where
     pub fn transmit(&mut self, frame: &Frame) -> nb::Result<Option<Frame>, Infallible> {
         let can = unsafe { &*Instance::REGISTERS };
 
+        // Get the index of free mailbox or of one with the lowest priority.
         let tsr = can.tsr.read();
-
-        // Get a free mailbox or the one with the lowest priority.
         let idx = tsr.code().bits() as usize;
-        let tx = &can.tx[idx];
+        let mb = unsafe { &can.tx.get_unchecked(idx) };
 
-        // Check for a free mailbox.
-        if tsr.tme0().bit_is_set() || tsr.tme1().bit_is_set() || tsr.tme2().bit_is_set() {
-            Self::write_tx_mailbox(tx, frame);
-            return Ok(None);
-        }
-
-        // Read the pending frame's id to check its priority.
-        let tir = tx.tir.read();
-        if tir.txrq().bit_is_clear() {
-            // All pending frames where transmitted in the meantime and all
-            // mailboxes are free. This can only happen when a higher priority
-            // interrupt routine is running preemtively. Otherwise this routine
-            // always executes faster than a pending frames can be sent.
-            Self::write_tx_mailbox(tx, frame);
-            return Ok(None);
-        }
-
-        // Check priority by comparing the identifiers including the EID and RTR
-        // bits: Standard frames have a higher priority than extended frames and
-        // data frames have a higher priority than remote frames.
-        if frame.id < Id::from_register(tir.bits()) {
-            // The new frame has a higher priority (lower identifier value).
-
-            // Abort the pending transfer.
-            can.tsr.write(|w| unsafe { w.bits(abort_mask(idx)) });
-
-            // Wait for the transfer to be finished either because it was
-            // aborted or because it was successfull in the meantime.
-            let aborted = loop {
-                let tsr = can.tsr.read().bits();
-                if tsr & abort_mask(idx) == 0 {
-                    break tsr & ok_mask(idx) == 0;
-                }
-            };
-
-            if !aborted {
-                // An abort was requested while the frame was already being sent
-                // on the bus. The transfer finished successfully and all
-                // mailboxes are free. This can happen for small prescaler
-                // values (e.g. 1MBit/s bit timing with a source clock of 8MHz)
-                // or when a higher priority ISR runs.
-                Self::write_tx_mailbox(tx, frame);
-                return Ok(None);
-            }
-
-            // Read the prending frame.
-            let tir = tx.tir.read();
-            let mut pending_frame = Frame {
-                id: Id(tir.bits()),
-                dlc: tx.tdtr.read().dlc().bits() as usize,
-                data: [0; 8],
-            };
-            pending_frame.data[0..4].copy_from_slice(&tx.tdlr.read().bits().to_ne_bytes());
-            pending_frame.data[4..8].copy_from_slice(&tx.tdhr.read().bits().to_ne_bytes());
-
-            Self::write_tx_mailbox(tx, frame);
-            Ok(Some(pending_frame))
+        let empty_flags = (tsr.bits() >> 26) & 0b111;
+        let pending_frame = if empty_flags == 0b111 {
+            // All mailboxes are available: Send frame without performing any checks.
+            None
         } else {
-            // All mailboxes filled with messages of higher priority.
-            Err(nb::Error::WouldBlock)
+            // High priority frames are transmitted first by the mailbox system.
+            // Frames with identical identifier shall be transmitted in FIFO order.
+            // The controller schedules pending frames of same priority based on the
+            // mailbox index instead. As a workaround check all pending mailboxes
+            // and only accept higher priority frames.
+            Self::check_priority(&can.tx[0], frame.id)?;
+            Self::check_priority(&can.tx[1], frame.id)?;
+            Self::check_priority(&can.tx[2], frame.id)?;
+
+            if empty_flags != 0b000 {
+                // There was a free mailbox.
+                None
+            } else {
+                // No free mailbox is available. This can only happen when three frames with
+                // descending priority were requested for transmission and all of them are
+                // blocked by bus traffic with even higher priority.
+                // To prevent a priority inversion abort and replace the lowest priority frame.
+                if Self::abort(idx) {
+                    // Read back the pending frame.
+                    let mut pending_frame = Frame {
+                        id: Id(mb.tir.read().bits()),
+                        dlc: mb.tdtr.read().dlc().bits() as usize,
+                        data: [0; 8],
+                    };
+                    pending_frame.data[0..4].copy_from_slice(&mb.tdlr.read().bits().to_ne_bytes());
+                    pending_frame.data[4..8].copy_from_slice(&mb.tdhr.read().bits().to_ne_bytes());
+
+                    Some(pending_frame)
+                } else {
+                    // Abort request failed because the frame was already sent (or being sent) on
+                    // the bus. All mailboxes are now free. This can happen for small prescaler
+                    // values (e.g. 1MBit/s bit timing with a source clock of 8MHz) or when an ISR
+                    // has preemted the execution.
+                    None
+                }
+            }
+        };
+
+        Self::write_tx_mailbox(mb, frame);
+        Ok(pending_frame)
+    }
+
+    /// Tries to abort a pending frame. Returns `true` when aborted.
+    fn abort(idx: usize) -> bool {
+        let can = unsafe { &*Instance::REGISTERS };
+
+        can.tsr.write(|w| unsafe { w.bits(abort_mask(idx)) });
+
+        // Wait for the abort request to be finished.
+        loop {
+            let tsr = can.tsr.read().bits();
+            if tsr & abort_mask(idx) == 0 {
+                break tsr & ok_mask(idx) == 0;
+            }
         }
+    }
+
+    /// Returns `Ok` when the mailbox is free or has a lower priority than
+    /// identifier than `id`.
+    fn check_priority(mb: &TX, id: Id) -> nb::Result<(), Infallible> {
+        // Read the pending frame's id to check its priority.
+        let tir = mb.tir.read();
+
+        // Check the priority by comparing the identifiers including the EID and RTR
+        // bits: Standard frames have a higher priority than extended frames and data
+        // frames have a higher priority than remote frames.
+        // Also make sure the frame has not finished transmission in the meantime.
+        if tir.txrq().bit_is_set() && id.0 >= tir.bits() & 0xFFFF_FFFE {
+            // There's a mailbox whose priority is higher or equal
+            // the priority of the new frame.
+            return Err(nb::Error::WouldBlock);
+        }
+
+        Ok(())
     }
 
     fn write_tx_mailbox(tx_mb: &crate::pac::can1::TX, frame: &Frame) {

--- a/src/can.rs
+++ b/src/can.rs
@@ -197,7 +197,7 @@ impl Frame {
         self.id
     }
 
-    // Returns the frame data.
+    /// Returns the frame data (0..8 bytes in length).
     pub fn data(&self) -> &[u8] {
         &self.data[0..self.dlc]
     }
@@ -390,6 +390,10 @@ where
         self.tx.take()
     }
 
+    /// Returns the receiver interface.
+    ///
+    /// Takes ownership of filters which must be otained by `Can::split_filters()`.
+    /// Only the first calls returns a valid receiver. Subsequent calls return `None`.
     pub fn take_rx(&mut self, _filters: Filters<Instance>) -> Option<Rx<Instance>> {
         self.rx.take()
     }
@@ -397,6 +401,8 @@ where
 
 impl Can<CAN1> {
     /// Returns the filter part of the CAN peripheral.
+    ///
+    /// Filters are required for the receiver to accept any messages at all.
     #[cfg(not(feature = "connectivity"))]
     pub fn split_filters(&mut self) -> Option<Filters<CAN1>> {
         self.split_filters_internal()?;
@@ -404,6 +410,8 @@ impl Can<CAN1> {
     }
 
     /// Returns the filter part of the CAN peripheral.
+    ///
+    /// Filters are required for the receiver to accept any messages at all.
     #[cfg(feature = "connectivity")]
     pub fn split_filters(&mut self) -> Option<(Filters<CAN1>, Filters<CAN2>)> {
         self.split_filters_internal()?;
@@ -437,6 +445,7 @@ impl Can<CAN1> {
     }
 }
 
+/// Interface to the filter banks of a CAN peripheral.
 pub struct Filters<Instance>(PhantomData<Instance>);
 
 impl<Instance> Filters<Instance>
@@ -456,7 +465,7 @@ where
     }
 }
 
-/// Interface to the CAN transmitter.
+/// Interface to the CAN transmitter part.
 pub struct Tx<Instance> {
     _can: PhantomData<Instance>,
 }
@@ -603,7 +612,7 @@ where
     }
 }
 
-/// Interface to a CAN receiver.
+/// Interface to the CAN receiver part.
 pub struct Rx<Instance> {
     _can: PhantomData<Instance>,
 }

--- a/src/can.rs
+++ b/src/can.rs
@@ -372,37 +372,8 @@ where
         self.tx.take()
     }
 
-    /// Enables the transmit interrupt CANn_TX.
-    ///
-    /// The interrupt flags must be cleared with `Tx::clear_interrupt_flags()`.
-    pub fn enable_tx_interrupt(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        can.ier.modify(|_, w| w.tmeie().set_bit());
-    }
-
-    /// Disables the transmit interrupt.
-    pub fn disable_tx_interrupt(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        can.ier.modify(|_, w| w.tmeie().clear_bit());
-    }
-
     pub fn take_rx(&mut self, _filters: Filters<Instance>) -> Option<Rx<Instance>> {
         self.rx.take()
-    }
-
-    /// Enables the receive interrupts CANn_RX0 and CANn_RX1.
-    ///
-    /// Make sure to register interrupt handlers for both.
-    /// The interrupt flags are cleared by reading frames with `RX::receive()`.
-    pub fn enable_rx_interrupts(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        can.ier.modify(|_, w| w.fmpie1().set_bit().fmpie0().set_bit());
-    }
-
-    /// Disables the receive interrupts.
-    pub fn disable_rx_interrupts(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        can.ier.modify(|_, w| w.fmpie1().clear_bit().fmpie0().clear_bit());
     }
 }
 
@@ -592,6 +563,20 @@ where
             .write(|w| unsafe { w.bits(frame.id.0).txrq().set_bit() });
     }
 
+    /// Enables the transmit interrupt CANn_TX.
+    ///
+    /// The interrupt flags must be cleared with `Tx::clear_interrupt_flags()`.
+    pub fn enable_interrupt(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        bb::set(&can.ier, 0); // TMEIE
+    }
+
+    /// Disables the transmit interrupt.
+    pub fn disable_interrupt(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        bb::clear(&can.ier, 0); // TMEIE
+    }
+
     /// Clears the request complete flag for all mailboxes.
     pub fn clear_interrupt_flags(&mut self) {
         let can = unsafe { &*Instance::REGISTERS };
@@ -636,5 +621,22 @@ where
         rfr.write(|w| w.rfom().set_bit());
 
         Ok(frame)
+    }
+
+    /// Enables the receive interrupts CANn_RX0 and CANn_RX1.
+    ///
+    /// Make sure to register interrupt handlers for both.
+    /// The interrupt flags are cleared by reading frames with `Rx::receive()`.
+    pub fn enable_interrupts(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        bb::set(&can.ier, 1); // FMPIE0
+        bb::set(&can.ier, 4); // FMPIE1
+    }
+
+    /// Disables the receive interrupts.
+    pub fn disable_interrupts(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        bb::clear(&can.ier, 1); // FMPIE0
+        bb::clear(&can.ier, 4); // FMPIE1
     }
 }

--- a/src/can.rs
+++ b/src/can.rs
@@ -369,6 +369,20 @@ where
     pub fn take_tx(&mut self) -> Option<Tx<Instance>> {
         self.tx.take()
     }
+
+    /// Enables the transmit interrupt.
+    ///
+    /// The interrupt flags must be cleared with `Tx::clear_interrupt_flags()`.
+    pub fn enable_tx_interrupt(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        can.ier.modify(|_, w| w.tmeie().set_bit());
+    }
+
+    /// Disables the transmit interrupt.
+    pub fn disable_tx_interrupt(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        can.ier.modify(|_, w| w.tmeie().clear_bit());
+    }
 }
 
 /// Interface to the CAN transmitter.
@@ -494,5 +508,12 @@ where
         tx_mb
             .tir
             .write(|w| unsafe { w.bits(frame.id.0).txrq().set_bit() });
+    }
+
+    /// Clears the request complete flag for all mailboxes.
+    pub fn clear_interrupt_flags(&mut self) {
+        let can = unsafe { &*Instance::REGISTERS };
+        can.tsr
+            .write(|w| w.rqcp2().set_bit().rqcp1().set_bit().rqcp0().set_bit());
     }
 }

--- a/src/can.rs
+++ b/src/can.rs
@@ -423,7 +423,7 @@ impl Can<CAN1> {
     #[cfg(not(feature = "connectivity"))]
     pub fn split_filters(&mut self) -> Option<Filters<CAN1>> {
         self.split_filters_internal()?;
-        Some(Filters(PhantomData))
+        Some(Filters::new())
     }
 
     /// Returns the filter part of the CAN peripheral.
@@ -545,7 +545,7 @@ where
             let filter_bank = &can.fb[idx];
             filter_bank.fr1.write(|w| unsafe { w.bits(filter.id) });
             filter_bank.fr2.write(|w| unsafe { w.bits(filter.mask) });
-            bb::set(&can.fa1r, idx as u8);  // Enable filter
+            bb::set(&can.fa1r, idx as u8); // Enable filter
             self.count += 1;
             Ok(())
         } else {

--- a/src/can.rs
+++ b/src/can.rs
@@ -69,14 +69,14 @@ impl Id {
 
     /// Sets the remote transmission (RTR) flag. This marks the identifier as
     /// being part of a remote frame.
-    fn with_rtr(&self) -> Id {
+    fn with_rtr(self) -> Id {
         Self(self.0 | Self::RTR_MASK)
     }
 
     /// Returns the identifier.
     ///
     /// It is up to the user to check if it is an standard or extended id.
-    pub fn id(&self) -> u32 {
+    pub fn id(self) -> u32 {
         if self.is_extended() {
             self.0 >> Self::EXTENDED_SHIFT
         } else {
@@ -85,17 +85,17 @@ impl Id {
     }
 
     /// Returns `true` if the identifier is an extended identifier.
-    pub fn is_extended(&self) -> bool {
+    pub fn is_extended(self) -> bool {
         self.0 & Self::EID_MASK != 0
     }
 
     /// Returns `true` if the identifier is a standard identifier.
-    pub fn is_standard(&self) -> bool {
+    pub fn is_standard(self) -> bool {
         !self.is_extended()
     }
 
     /// Returns `true` if the identifer is part of a remote frame (RTR bit set).
-    fn rtr(&self) -> bool {
+    fn rtr(self) -> bool {
         self.0 & Self::RTR_MASK != 0
     }
 }
@@ -287,9 +287,11 @@ where
 
     /// Configures the bit timings.
     ///
-    /// Use http://www.bittiming.can-wiki.info/ to calculate a safe parameter
-    /// value. Puts the peripheral in sleep mode. `Can::enable()` must be called
-    /// afterwards to start reception and transmission.
+    /// Puts the peripheral in sleep mode. `Can::enable()` must be called afterwards
+    /// to start reception and transmission.
+    ///
+    /// # Safety
+    /// Use http://www.bittiming.can-wiki.info/ to calculate a safe parameter value.
     pub unsafe fn set_bit_timing(&mut self, btr: u32) {
         let can = &*Instance::REGISTERS;
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -212,6 +212,7 @@ impl Frame {
     }
 }
 
+// Ordering is based on the ID and can be used to sort frames by priority.
 impl Ord for Frame {
     fn cmp(&self, other: &Self) -> Ordering {
         self.id().cmp(&other.id())
@@ -224,9 +225,10 @@ impl PartialOrd for Frame {
     }
 }
 
+// The Equality traits compare the identifier and the data.
 impl PartialEq for Frame {
     fn eq(&self, other: &Self) -> bool {
-        self.id() == other.id()
+        self.id() == other.id() && self.data[0..self.dlc] == other.data[0..other.dlc]
     }
 }
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -338,18 +338,16 @@ where
 
     /// Configures the bit timings.
     ///
+    /// Use http://www.bittiming.can-wiki.info/ to calculate the `btr` parameter.
     /// Puts the peripheral in sleep mode. `Can::enable()` must be called afterwards
     /// to start reception and transmission.
-    ///
-    /// # Safety
-    /// Use http://www.bittiming.can-wiki.info/ to calculate a safe parameter value.
-    pub unsafe fn set_bit_timing(&mut self, btr: u32) {
-        let can = &*Instance::REGISTERS;
+    pub fn set_bit_timing(&mut self, btr: u32) {
+        let can = unsafe { &*Instance::REGISTERS };
 
         can.mcr
             .modify(|_, w| w.sleep().clear_bit().inrq().set_bit());
         while can.msr.read().inak().bit_is_clear() {}
-        can.btr.write(|w| w.bits(btr));
+        can.btr.write(|w| unsafe { w.bits(btr) });
         self.sleep();
     }
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -181,6 +181,26 @@ impl Frame {
     }
 }
 
+impl core::cmp::Ord for Frame {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.id().cmp(&other.id())
+    }
+}
+
+impl core::cmp::PartialOrd for Frame {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl core::cmp::PartialEq for Frame {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl core::cmp::Eq for Frame {}
+
 // Seal the traits so that they cannot be implemented outside side this crate.
 mod traits {
     pub trait Instance: crate::rcc::Enable {

--- a/src/can.rs
+++ b/src/can.rs
@@ -170,13 +170,13 @@ impl Frame {
         Self::new(Id::new_extended(id), data)
     }
 
-    /// Sets the remote transmission (RTR) flag. Marks the frame as a remote frame.
+    /// Marks the frame as a remote frame with configurable data length code (DLC).
     ///
     /// Remote frames do not contain any data, even if the frame was created with a
     /// non-empty data buffer.
-    pub fn with_rtr(&mut self, rtr: bool) -> &mut Self {
-        self.id = self.id.with_rtr(rtr);
-        self.dlc = 0;
+    pub fn with_rtr(&mut self, dlc: usize) -> &mut Self {
+        self.id = self.id.with_rtr(true);
+        self.dlc = dlc;
         self
     }
 
@@ -205,9 +205,21 @@ impl Frame {
         self.id
     }
 
+    /// Returns the data length code (DLC) which is in the range 0..8.
+    ///
+    /// For data frames the DLC value always matches the lenght of the data.
+    /// Remote frames no not carry any data, yet the DLC can be greater than 0.
+    pub fn dlc(&self) -> usize {
+        self.dlc
+    }
+
     /// Returns the frame data (0..8 bytes in length).
     pub fn data(&self) -> &[u8] {
-        &self.data[0..self.dlc]
+        if self.is_data_frame() {
+            &self.data[0..self.dlc]
+        } else {
+            &[]
+        }
     }
 }
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -66,7 +66,7 @@ impl Id {
 
     /// Creates a new standard identifier (11bit, Range: 0..0x7FF)
     ///
-    /// IDs outside the allowed range are silently truncated.
+    /// Panics for IDs outside the allowed range.
     pub fn new_standard(id: u32) -> Self {
         assert!(id < 0x7FF);
         Self(id << Self::STANDARD_SHIFT)
@@ -74,7 +74,7 @@ impl Id {
 
     /// Creates a new extendended identifier (29bit , Range: 0..0x1FFFFFFF).
     ///
-    /// IDs outside the allowed range are silently truncated.
+    /// Panics for IDs outside the allowed range.
     pub fn new_extended(id: u32) -> Id {
         assert!(id < 0x1FFF_FFFF);
         Self(id << Self::EXTENDED_SHIFT | Self::IDE_MASK)
@@ -207,7 +207,7 @@ impl Frame {
 
     /// Returns the data length code (DLC) which is in the range 0..8.
     ///
-    /// For data frames the DLC value always matches the lenght of the data.
+    /// For data frames the DLC value always matches the length of the data.
     /// Remote frames no not carry any data, yet the DLC can be greater than 0.
     pub fn dlc(&self) -> usize {
         self.dlc
@@ -522,7 +522,8 @@ impl Can<CAN1> {
     /// `fm1r` in combination with `fs1r` sets the filter bank layout. The correct
     /// `Filters::add_*()` function must be used.
     /// `ffa1r` selects the FIFO the filter uses to store accepted messages.
-    /// More details can be found in the reference manual of the device.
+    /// More details can be found in  the reference manual (Section 24.7.4
+    /// Identifier filtering, Filter bank scale and mode configuration).
     #[cfg(not(feature = "connectivity"))]
     pub fn split_filters_advanced(
         &mut self,
@@ -813,7 +814,7 @@ where
     /// Puts a CAN frame in a free transmit mailbox for transmission on the bus.
     ///
     /// Frames are transmitted to the bus based on their priority (identifier).
-    /// Transmit order is preserved for frames with of identifiers.
+    /// Transmit order is preserved for frames with identical identifiers.
     /// If all transmit mailboxes are full, a higher priority frame replaces the
     /// lowest priority frame, which is returned as `Ok(Some(frame))`.
     pub fn transmit(&mut self, frame: &Frame) -> nb::Result<Option<Frame>, Infallible> {

--- a/src/can.rs
+++ b/src/can.rs
@@ -284,9 +284,9 @@ impl traits::Pins for (PB9<Alternate<PushPull>>, PB8<Input<Floating>>) {
 
     fn remap(mapr: &mut MAPR) {
         #[cfg(not(feature = "connectivity"))]
-        mapr.modify_mapr(|_, w| unsafe { w.can_remap().bits(0x10) });
+        mapr.modify_mapr(|_, w| unsafe { w.can_remap().bits(0b10) });
         #[cfg(feature = "connectivity")]
-        mapr.modify_mapr(|_, w| unsafe { w.can1_remap().bits(0x10) });
+        mapr.modify_mapr(|_, w| unsafe { w.can1_remap().bits(0b10) });
     }
 }
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -454,8 +454,10 @@ where
     ///
     /// Call `Can::enable()` in the ISR when the automatic wake-up is not enabled.
     pub fn enable_wakeup_interrupt(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        bb::set(&can.ier, 16); // WKUIE
+        unsafe {
+            let can = &*Instance::REGISTERS;
+            bb::set(&can.ier, 16); // WKUIE
+        }
     }
 
     /// Clears all state-change interrupt flags.
@@ -722,7 +724,7 @@ where
         }
 
         // Disable the filter bank so it can be modified.
-        bb::clear(&can.fa1r, idx as u8);
+        unsafe { bb::clear(&can.fa1r, idx as u8) };
 
         let filter_bank = &can.fb[idx];
         let fr1 = filter_bank.fr1.read().bits();
@@ -774,7 +776,7 @@ where
 
         filter_bank.fr1.write(|w| unsafe { w.bits(fr1) });
         filter_bank.fr2.write(|w| unsafe { w.bits(fr2) });
-        bb::set(&can.fa1r, idx as u8); // Enable the filter bank
+        unsafe { bb::set(&can.fa1r, idx as u8) }; // Enable the filter bank
         Ok(())
     }
 
@@ -785,7 +787,7 @@ where
         assert!(self.start_idx + self.count <= self.stop_idx);
         for i in self.start_idx..(self.start_idx + self.count) {
             // Bitbanding required because the filters are shared between CAN1 and CAN2
-            bb::clear(&can.fa1r, i as u8);
+            unsafe { bb::clear(&can.fa1r, i as u8) };
         }
         self.count = 0;
     }
@@ -941,14 +943,18 @@ where
     ///
     /// The interrupt flags must be cleared with `Tx::clear_interrupt_flags()`.
     pub fn enable_interrupt(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        bb::set(&can.ier, 0); // TMEIE
+        unsafe {
+            let can = &*Instance::REGISTERS;
+            bb::set(&can.ier, 0); // TMEIE
+        }
     }
 
     /// Disables the transmit interrupt.
     pub fn disable_interrupt(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        bb::clear(&can.ier, 0); // TMEIE
+        unsafe {
+            let can = &*Instance::REGISTERS;
+            bb::clear(&can.ier, 0); // TMEIE
+        }
     }
 
     /// Clears the request complete flag for all mailboxes.
@@ -1017,15 +1023,19 @@ where
     /// Make sure to register interrupt handlers for both.
     /// The interrupt flags are cleared by reading frames with `Rx::receive()`.
     pub fn enable_interrupts(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        bb::set(&can.ier, 1); // FMPIE0
-        bb::set(&can.ier, 4); // FMPIE1
+        unsafe {
+            let can = &*Instance::REGISTERS;
+            bb::set(&can.ier, 1); // FMPIE0
+            bb::set(&can.ier, 4); // FMPIE1
+        }
     }
 
     /// Disables the receive interrupts.
     pub fn disable_interrupts(&mut self) {
-        let can = unsafe { &*Instance::REGISTERS };
-        bb::clear(&can.ier, 1); // FMPIE0
-        bb::clear(&can.ier, 4); // FMPIE1
+        unsafe {
+            let can = &*Instance::REGISTERS;
+            bb::clear(&can.ier, 1); // FMPIE0
+            bb::clear(&can.ier, 4); // FMPIE1
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,11 @@ pub mod afio;
 pub mod backup_domain;
 #[cfg(feature = "device-selected")]
 pub mod bb;
+#[cfg(all(
+    feature = "device-selected",
+    any(feature = "stm32f103", feature = "connectivity")
+))]
+pub mod can;
 #[cfg(feature = "device-selected")]
 pub mod crc;
 #[cfg(feature = "device-selected")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,10 +144,7 @@ pub mod afio;
 pub mod backup_domain;
 #[cfg(feature = "device-selected")]
 pub mod bb;
-#[cfg(all(
-    feature = "device-selected",
-    any(feature = "stm32f103", feature = "connectivity")
-))]
+#[cfg(all(feature = "device-selected", feature = "has-can"))]
 pub mod can;
 #[cfg(feature = "device-selected")]
 pub mod crc;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -650,7 +650,6 @@ bus! {
 }
 #[cfg(feature = "connectivity")]
 bus! {
-    ADC2 => (APB2, adc2en, adc2rst),
     CAN1 => (APB1, can1en, can1rst),
     CAN2 => (APB1, can2en, can2rst),
 }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -651,6 +651,8 @@ bus! {
 #[cfg(feature = "connectivity")]
 bus! {
     ADC2 => (APB2, adc2en, adc2rst),
+    CAN1 => (APB1, can1en, can1rst),
+    CAN2 => (APB1, can2en, can2rst),
 }
 #[cfg(all(feature = "stm32f103", feature = "high",))]
 bus! {


### PR DESCRIPTION
This implementation is based on the experienced I collected when I picked up #101.
In comparison to the previous PR this is a more high-level approach.
My objective was to implement the minimal possible interfaces to support most use cases of the CAN peripheral.

## Design Decisions

### Separate `assign_pins()`
A common pattern is to pass pins in the constructor of a peripheral API. This API takes a different two step approach where the constructor only enables the clock and takes ownership of the CAN pac peripheral.
A second call to `assign_pins()` is required to route the peripheral to the pins.
It is needed for two special cases:
1. There are two can peripherals CAN1 and CAN2 for some devices (stm32f105/107). The CAN1 clock must be enabled to use the CAN2 receiver. If CAN1 is only used as clock source it should not take ownership of any pins.
2. Silent / Loop-back modes: For self test purposes the peripheral can operate without pins (not implemented yet)

Possible edge case: The user properly configures the CAN pins without assigning them. The CAN peripheral works but does not own the pins.

### Combined RX FIFOs
Both FIFOs are tightly coupled because they share acceptance filters: If a filter matches the incoming message it is put into just one of the FIFOs. In the common case where all messages shall be received FIFO1 remains completely unused because all messages are routed to FIFO0.
In my eyes splitting them introduces a leaky abstraction because they cannot really operate independently.

There is one interrupt for each FIFO. The downside of the combined approach is that both interrupts must be handled correctly as shown in the `can-rtfm` example.

### Combined Transmit Mailboxes
Required to prevent the inherent priority inversion problem. The problem is described well in the [UAVCAN Specification](https://uavcan.org/specification)  v1.0-alpha Section 4.2.4.3.
This implementation is based on [UAVCAN code](https://github.com/UAVCAN/libcanard/blob/8ee343c4edae0e0e4e1c040852aa3d8430f7bf76/drivers/stm32/canard_stm32.c#L281). In addition lower priority frames can be swapped out to higher priority frames.

### ~~Unsafe~~ bit-timing configuration
http://www.bittiming.can-wiki.info/ exists, works well and is convenient. It may be possible to do the same calculations in a const-fn. Not sure if it is worth the effort.

## Testing
I tested the examples on a “18 in 1 Universal CAN Filter” Aliexpress board.
That’s the cheapest was to get a MCU with two CAN interfaces. For more details see [this](https://dangerouspayload.com/2020/03/10/hacking-a-mileage-manipulator-can-bus-filter-device/) blog post.

## TODO
- [x] Filter support
- [x] Support loop-back and silent modes
- [x] Improve error handling: Overrun and error counters
- [x] Improve wakeup and bus-off management
