### PR TITLE
Improve blocking i2c ergonomics

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -129,7 +129,7 @@ pub struct BlockingTimeouts {
     pub start_attempts: u8,
     pub start_us: u32,
     pub addr_us: u32,
-    pub data_us: u32
+    pub data_us: u32,
 }
 
 impl Default for BlockingTimeouts {
@@ -148,16 +148,19 @@ impl Default for BlockingTimeouts {
 
 impl BlockingTimeouts {
     pub fn start_timeout_us(self, start_us: u32) -> Self {
-        Self {start_us, .. self}
+        Self { start_us, ..self }
     }
     pub fn addr_timeout_us(self, addr_us: u32) -> Self {
-        Self {addr_us, .. self}
+        Self { addr_us, ..self }
     }
     pub fn data_timeout_us(self, data_us: u32) -> Self {
-        Self {data_us, .. self}
+        Self { data_us, ..self }
     }
     pub fn start_attempts(self, start_attempts: u8) -> Self {
-        Self {start_attempts, .. self}
+        Self {
+            start_attempts,
+            ..self
+        }
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -168,9 +168,9 @@ impl<PINS> BlockingI2c<I2C1, PINS> {
         pins: PINS,
         mode: Mode,
         clocks: Clocks,
+        timeouts: BlockingTimeouts,
         mapr: &mut MAPR,
         apb: &mut <I2C1 as RccBus>::Bus,
-        timeouts: BlockingTimeouts
     ) -> Self
     where
         PINS: Pins<I2C1>,
@@ -213,8 +213,8 @@ impl<PINS> BlockingI2c<I2C2, PINS> {
         pins: PINS,
         mode: Mode,
         clocks: Clocks,
+        timeouts: BlockingTimeouts,
         apb: &mut <I2C2 as RccBus>::Bus,
-        timeouts: BlockingTimeouts
     ) -> Self
     where
         PINS: Pins<I2C2>,


### PR DESCRIPTION
Lumpio- in the community discord rightfully pointed out that our current blocking i2c struct takes a lot of unnamed parameters for initialisation. This replaces those unnamed parameter with a default-constructible struct, which allows either the builder pattern, or `Struct{fields, .. default()}` initialisation to be used.

I also renamed `retries` to `attempts` because I think retries is ambiguous. I interpret it as "how many extra tries should we make", but the implementation is "how many attempts should we make.

Finally, I moved the mapr reference requried for i2c1 to the end of the parameter list to the end, next to apb. This makes a lot more sense to me since most of our APIs takes those parameters last, and it's more compatible with i2c2