### PR TITLE
Use statically typed time consistently

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -129,7 +129,7 @@ pub struct BlockingTimeouts {
     pub start_attempts: u8,
     pub start_us: u32,
     pub addr_us: u32,
-    pub data_us: u32
+    pub data_us: u32,
 }
 
 impl Default for BlockingTimeouts {
@@ -148,16 +148,19 @@ impl Default for BlockingTimeouts {
 
 impl BlockingTimeouts {
     pub fn start_timeout_us(self, start_us: u32) -> Self {
-        Self {start_us, .. self}
+        Self { start_us, ..self }
     }
     pub fn addr_timeout_us(self, addr_us: u32) -> Self {
-        Self {addr_us, .. self}
+        Self { addr_us, ..self }
     }
     pub fn data_timeout_us(self, data_us: u32) -> Self {
-        Self {data_us, .. self}
+        Self { data_us, ..self }
     }
     pub fn start_attempts(self, start_attempts: u8) -> Self {
-        Self {start_attempts, .. self}
+        Self {
+            start_attempts,
+            ..self
+        }
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -168,9 +168,9 @@ impl<PINS> BlockingI2c<I2C1, PINS> {
         pins: PINS,
         mode: Mode,
         clocks: Clocks,
+        timeouts: BlockingTimeouts,
         mapr: &mut MAPR,
         apb: &mut <I2C1 as RccBus>::Bus,
-        timeouts: BlockingTimeouts
     ) -> Self
     where
         PINS: Pins<I2C1>,
@@ -213,8 +213,8 @@ impl<PINS> BlockingI2c<I2C2, PINS> {
         pins: PINS,
         mode: Mode,
         clocks: Clocks,
+        timeouts: BlockingTimeouts,
         apb: &mut <I2C2 as RccBus>::Bus,
-        timeouts: BlockingTimeouts
     ) -> Self
     where
         PINS: Pins<I2C2>,

--- a/src/time.rs
+++ b/src/time.rs
@@ -100,10 +100,10 @@ pub struct MegaHertz(pub u32);
 
 /// Time unit
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
-pub struct MilliSeconds(pub u32);
+pub struct Milliseconds(pub u32);
 
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
-pub struct MicroSeconds(pub u32);
+pub struct Microseconds(pub u32);
 
 /// Extension trait that adds convenience methods to the `u32` type
 pub trait U32Ext {
@@ -119,11 +119,11 @@ pub trait U32Ext {
     /// Wrap in `MegaHertz`
     fn mhz(self) -> MegaHertz;
 
-    /// Wrap in `MilliSeconds`
-    fn ms(self) -> MilliSeconds;
+    /// Wrap in `Milliseconds`
+    fn ms(self) -> Milliseconds;
 
-    /// Wrap in `MicroSeconds`
-    fn us(self) -> MicroSeconds;
+    /// Wrap in `Microseconds`
+    fn us(self) -> Microseconds;
 }
 
 impl U32Ext for u32 {
@@ -143,12 +143,12 @@ impl U32Ext for u32 {
         MegaHertz(self)
     }
 
-    fn ms(self) -> MilliSeconds {
-        MilliSeconds(self)
+    fn ms(self) -> Milliseconds {
+        Milliseconds(self)
     }
 
-    fn us(self) -> MicroSeconds {
-        MicroSeconds(self)
+    fn us(self) -> Microseconds {
+        Microseconds(self)
     }
 }
 
@@ -170,13 +170,13 @@ impl From<MegaHertz> for KiloHertz {
     }
 }
 
-impl Into<Hertz> for MilliSeconds {
+impl Into<Hertz> for Milliseconds {
     fn into(self) -> Hertz {
         Hertz(1_000 / self.0)
     }
 }
 
-impl Into<Hertz> for MicroSeconds {
+impl Into<Hertz> for Microseconds {
     fn into(self) -> Hertz {
         Hertz(1_000_000 / self.0)
     }


### PR DESCRIPTION
Closes #230 

Replaces the uses of `_ms` and `_us` postfix variables with `Microsecond` and `Millisecond` types. I also renamed the types to use a lowercase S which I believe is more correct. It's the way wikipedia spells it at least :) https://en.wikipedia.org/wiki/Microsecond

This is built on top of #229 as that was where a lot of the `us` occurrences were.