### PR TITLE
Remove generic RCC buses from public API

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -9,7 +9,7 @@ use crate::gpio::gpiob::{PB10, PB11, PB6, PB7, PB8, PB9};
 use crate::gpio::{Alternate, OpenDrain};
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 use crate::pac::{DWT, I2C1, I2C2};
-use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset};
+use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset, APB1};
 use crate::time::Hertz;
 use nb::Error::{Other, WouldBlock};
 use nb::{Error as NbError, Result as NbResult};
@@ -113,7 +113,7 @@ impl<PINS> I2c<I2C1, PINS> {
         mapr: &mut MAPR,
         mode: Mode,
         clocks: Clocks,
-        apb: &mut <I2C1 as RccBus>::Bus,
+        apb: &mut APB1,
     ) -> Self
     where
         PINS: Pins<I2C1>,
@@ -131,7 +131,7 @@ impl<PINS> BlockingI2c<I2C1, PINS> {
         mapr: &mut MAPR,
         mode: Mode,
         clocks: Clocks,
-        apb: &mut <I2C1 as RccBus>::Bus,
+        apb: &mut APB1,
         start_timeout_us: u32,
         start_retries: u8,
         addr_timeout_us: u32,
@@ -157,13 +157,7 @@ impl<PINS> BlockingI2c<I2C1, PINS> {
 
 impl<PINS> I2c<I2C2, PINS> {
     /// Creates a generic I2C2 object on pins PB10 and PB11 using the embedded-hal `BlockingI2c` trait.
-    pub fn i2c2(
-        i2c: I2C2,
-        pins: PINS,
-        mode: Mode,
-        clocks: Clocks,
-        apb: &mut <I2C2 as RccBus>::Bus,
-    ) -> Self
+    pub fn i2c2(i2c: I2C2, pins: PINS, mode: Mode, clocks: Clocks, apb: &mut APB1) -> Self
     where
         PINS: Pins<I2C2>,
     {
@@ -178,7 +172,7 @@ impl<PINS> BlockingI2c<I2C2, PINS> {
         pins: PINS,
         mode: Mode,
         clocks: Clocks,
-        apb: &mut <I2C2 as RccBus>::Bus,
+        apb: &mut APB1,
         start_timeout_us: u32,
         start_retries: u8,
         addr_timeout_us: u32,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -53,7 +53,7 @@ use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::gpioc::{PC10, PC11};
 use crate::gpio::gpiod::{PD5, PD6, PD8, PD9};
 use crate::gpio::{Alternate, Floating, Input, PushPull};
-use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset};
+use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::{Bps, U32Ext};
 
 /// Interrupt event
@@ -263,6 +263,7 @@ macro_rules! hal {
             $usartX_remap:ident,
             $bit:ident,
             $closure:expr,
+            $APBx:ident,
         ),
     )+) => {
         $(
@@ -292,7 +293,7 @@ macro_rules! hal {
                     mapr: &mut MAPR,
                     config: Config,
                     clocks: Clocks,
-                    apb: &mut <$USARTX as RccBus>::Bus,
+                    apb: &mut $APBx,
                 ) -> Self
                 where
                     PINS: Pins<$USARTX>,
@@ -473,6 +474,7 @@ hal! {
         usart1_remap,
         bit,
         |remap| remap == 1,
+        APB2,
     ),
     /// # USART2 functions
     USART2: (
@@ -480,6 +482,7 @@ hal! {
         usart2_remap,
         bit,
         |remap| remap == 1,
+        APB1,
     ),
     /// # USART3 functions
     USART3: (
@@ -487,6 +490,7 @@ hal! {
         usart3_remap,
         bits,
         |remap| remap,
+        APB1,
     ),
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -46,7 +46,7 @@ use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
 use crate::gpio::{Alternate, Floating, Input, PushPull};
-use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset};
+use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 
 use core::sync::atomic::{self, Ordering};
@@ -154,7 +154,7 @@ impl<REMAP, PINS> Spi<SPI1, REMAP, PINS> {
         mode: Mode,
         freq: F,
         clocks: Clocks,
-        apb: &mut <SPI1 as RccBus>::Bus,
+        apb: &mut APB2,
     ) -> Self
     where
         F: Into<Hertz>,
@@ -173,7 +173,7 @@ impl<REMAP, PINS> Spi<SPI2, REMAP, PINS> {
         mode: Mode,
         freq: F,
         clocks: Clocks,
-        apb: &mut <SPI2 as RccBus>::Bus,
+        apb: &mut APB1,
     ) -> Self
     where
         F: Into<Hertz>,
@@ -192,7 +192,7 @@ impl<REMAP, PINS> Spi<SPI3, REMAP, PINS> {
         mode: Mode,
         freq: F,
         clocks: Clocks,
-        apb: &mut <SPI3 as RccBus>::Bus,
+        apb: &mut APB1,
     ) -> Self
     where
         F: Into<Hertz>,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -67,7 +67,7 @@ use crate::pac::{DBGMCU as DBG, TIM2, TIM3};
 #[cfg(feature = "stm32f100")]
 use crate::pac::{TIM15, TIM16, TIM17};
 
-use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset};
+use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use cast::{u16, u32, u64};
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
@@ -256,11 +256,11 @@ impl CountDown for CountDownTimer<SYST> {
 impl Periodic for CountDownTimer<SYST> {}
 
 macro_rules! hal {
-    ($($TIMX:ident: ($timX:ident, $dbg_timX_stop:ident$(,$master_timbase:ident)*),)+) => {
+    ($($TIMX:ident: ($timX:ident, $APBx:ident, $dbg_timX_stop:ident$(,$master_timbase:ident)*),)+) => {
         $(
             impl Timer<$TIMX> {
                 /// Initialize timer
-                pub fn $timX(tim: $TIMX, clocks: &Clocks, apb: &mut <$TIMX as RccBus>::Bus) -> Self {
+                pub fn $timX(tim: $TIMX, clocks: &Clocks, apb: &mut $APBx) -> Self {
                     // enable and reset peripheral to a clean slate state
                     $TIMX::enable(apb);
                     $TIMX::reset(apb);
@@ -419,18 +419,18 @@ fn compute_arr_presc(freq: u32, clock: u32) -> (u16, u16) {
 }
 
 hal! {
-    TIM2: (tim2, dbg_tim2_stop, tim2),
-    TIM3: (tim3, dbg_tim3_stop, tim2),
+    TIM2: (tim2, APB1, dbg_tim2_stop, tim2),
+    TIM3: (tim3, APB1, dbg_tim3_stop, tim2),
 }
 
 #[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 hal! {
-    TIM1: (tim1, dbg_tim1_stop, tim1),
+    TIM1: (tim1, APB2, dbg_tim1_stop, tim1),
 }
 
 #[cfg(any(feature = "stm32f100", feature = "high", feature = "connectivity",))]
 hal! {
-    TIM6: (tim6, dbg_tim6_stop, tim6),
+    TIM6: (tim6, APB1, dbg_tim6_stop, tim6),
 }
 
 #[cfg(any(
@@ -438,29 +438,29 @@ hal! {
     any(feature = "stm32f100", feature = "connectivity",)
 ))]
 hal! {
-    TIM7: (tim7, dbg_tim7_stop, tim6),
+    TIM7: (tim7, APB1, dbg_tim7_stop, tim6),
 }
 
 #[cfg(feature = "stm32f100")]
 hal! {
-    TIM15: (tim15, dbg_tim15_stop),
-    TIM16: (tim16, dbg_tim16_stop),
-    TIM17: (tim17, dbg_tim17_stop),
+    TIM15: (tim15, APB2, dbg_tim15_stop),
+    TIM16: (tim16, APB2, dbg_tim16_stop),
+    TIM17: (tim17, APB2, dbg_tim17_stop),
 }
 
 #[cfg(feature = "medium")]
 hal! {
-    TIM4: (tim4, dbg_tim4_stop, tim2),
+    TIM4: (tim4, APB1, dbg_tim4_stop, tim2),
 }
 
 #[cfg(any(feature = "high", feature = "connectivity"))]
 hal! {
-    TIM5: (tim5, dbg_tim5_stop, tim2),
+    TIM5: (tim5, APB1, dbg_tim5_stop, tim2),
 }
 
 #[cfg(all(feature = "stm32f103", feature = "high",))]
 hal! {
-    TIM8: (tim8, dbg_tim8_stop, tim1),
+    TIM8: (tim8, APB2, dbg_tim8_stop, tim1),
 }
 
 //TODO: restore these timers once stm32-rs has been updated

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -67,7 +67,9 @@ use crate::pac::{DBGMCU as DBG, TIM2, TIM3};
 #[cfg(feature = "stm32f100")]
 use crate::pac::{TIM15, TIM16, TIM17};
 
-use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
+#[cfg(not(feature = "stm32f101"))]
+use crate::rcc::APB2;
+use crate::rcc::{sealed::RccBus, Clocks, Enable, GetBusFreq, Reset, APB1};
 use cast::{u16, u32, u64};
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;


### PR DESCRIPTION
I never liked the RccBus generic stuff, as it made it impossible to tell which register to pass to the constructors of functions, `&mut <USART1 as RccBus>::Bus` isn't very helpful.

This PR goes back to explicit APB1 and APB2 in the constructors, but keeps the generic structs inside functions to still provide most of the benefit while improving doc readbility.

While this is a public API change, I don't believe it is breaking, as it still requires the exact same types to be passed to functions.

cc: @burrbull 