### PR TITLE
Improve SPI, RCC and AFIO documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Use `Deref` for I2C generic implementations instead of macros
+- Deprecate `Spi::free` and rename it to `Spi::release`
+- Improve `SPI` documentation
 
 ## [v0.6.0] - 2020-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `Deref` for I2C generic implementations instead of macros
 - Deprecate `Spi::free` and rename it to `Spi::release`
 - Improve `SPI` documentation
+- Improve `RCC` and `AFIO` register documentation
 
 ## [v0.6.0] - 2020-06-06
 

--- a/src/afio.rs
+++ b/src/afio.rs
@@ -33,6 +33,15 @@ impl AfioExt for AFIO {
     }
 }
 
+/// HAL wrapper around the AFIO registers
+///
+/// Aquired by calling [constrain](trait.AfioExt.html#constrain) on the [AFIO
+/// registers](../pac/struct.AFIO.html)
+///
+/// ```rust
+/// let p = pac::Peripherals::take().unwrap();
+/// let mut rcc = p.RCC.constrain();
+/// let mut afio = p.AFIO.constrain(&mut rcc.apb2);
 pub struct Parts {
     pub evcr: EVCR,
     pub mapr: MAPR,
@@ -53,6 +62,16 @@ impl EVCR {
     }
 }
 
+/// AF remap and debug I/O configuration register (MAPR)
+///
+/// Aquired through the [Parts](struct.Parts.html) struct.
+///
+/// ```rust
+/// let dp = pac::Peripherals::take().unwrap();
+/// let mut rcc = dp.RCC.constrain();
+/// let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+/// function_using_mapr(&mut afio.mapr);
+/// ```
 pub struct MAPR {
     _0: (),
     jtag_enabled: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,26 @@
 //! * C, D, E => `high` feature
 //! * F, G => `xl` feature
 //!
+//! ## Commonly used setup
+//! Almost all peripherals require references to some registers in `RCC` and `AFIO`. The following
+//! code shows how to set up those registers
+//!
+//! ```rust
+//! // Get access to the device specific peripherals from the peripheral access crate
+//! let dp = pac::Peripherals::take().unwrap();
+//!
+//! // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+//! // HAL structs
+//! let mut flash = dp.FLASH.constrain();
+//! let mut rcc = dp.RCC.constrain();
+//!
+//! // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
+//! // `clocks`
+//! let clocks = rcc.cfgr.freeze(&mut flash.acr);
+//!
+//! // Prepare the alternate function I/O registers
+//! let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+//! ```
 //!
 //! ## Usage examples
 //!

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -48,6 +48,14 @@ pub struct Rcc {
 }
 
 /// AMBA High-performance Bus (AHB) registers
+///
+/// Aquired through the `Rcc` registers:
+///
+/// ```rust
+/// let dp = pac::Peripherals::take().unwrap();
+/// let mut rcc = dp.RCC.constrain();
+/// function_that_uses_ahb(&mut rcc.ahb)
+/// ```
 pub struct AHB {
     _0: (),
 }
@@ -62,6 +70,14 @@ impl AHB {
 }
 
 /// Advanced Peripheral Bus 1 (APB1) registers
+///
+/// Aquired through the `Rcc` registers:
+///
+/// ```rust
+/// let dp = pac::Peripherals::take().unwrap();
+/// let mut rcc = dp.RCC.constrain();
+/// function_that_uses_apb1(&mut rcc.apb1)
+/// ```
 pub struct APB1 {
     _0: (),
 }
@@ -86,6 +102,14 @@ impl APB1 {
 }
 
 /// Advanced Peripheral Bus 2 (APB2) registers
+///
+/// Aquired through the `Rcc` registers:
+///
+/// ```rust
+/// let dp = pac::Peripherals::take().unwrap();
+/// let mut rcc = dp.RCC.constrain();
+/// function_that_uses_apb2(&mut rcc.apb2);
+/// ```
 pub struct APB2 {
     _0: (),
 }
@@ -104,6 +128,15 @@ impl APB2 {
 
 const HSI: u32 = 8_000_000; // Hz
 
+/// Clock configuration register (CFGR)
+///
+/// Used to configure the frequencies of the clocks present in the processor.
+///
+/// After setting all frequencies, call the [freeze](#method.freeze) function to
+/// apply the configuration.
+///
+/// **NOTE**: Currently, it is not guaranteed that the exact frequencies selected will be
+/// used, only frequencies close to it.
 pub struct CFGR {
     hse: Option<u32>,
     hclk: Option<u32>,
@@ -116,6 +149,7 @@ pub struct CFGR {
 impl CFGR {
     /// Uses HSE (external oscillator) instead of HSI (internal RC oscillator) as the clock source.
     /// Will result in a hang if an external oscillator is not connected or it fails to start.
+    /// The frequency specified must be the frequency of the external oscillator
     pub fn use_hse<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,
@@ -415,6 +449,16 @@ impl BKP {
 /// Frozen clock frequencies
 ///
 /// The existence of this value indicates that the clock configuration can no longer be changed
+///
+/// To acquire it, use the freeze function on the `rcc.cfgr` register. If desired, you can adjust
+/// the frequencies using the methods on [cfgr](struct.CFGR.html) before calling freeze.
+///
+/// ```rust
+/// let dp = pac::Peripherals::take().unwrap();
+/// let mut rcc = dp.RCC.constrain();
+///
+/// let clocks = rcc.cfgr.freeze(&mut flash.acr);
+/// ```
 #[derive(Clone, Copy)]
 pub struct Clocks {
     hclk: Hertz,

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -203,6 +203,19 @@ impl CFGR {
         self
     }
 
+    /// Applies the clock configuration and returns a `Clocks` struct that signifies that the
+    /// clocks are frozen, and contains the frequencies used. After this function is called,
+    /// the clocks can not change
+    ///
+    /// Usage:
+    ///
+    /// ```rust
+    /// let dp = pac::Peripherals::take().unwrap();
+    /// let mut flash = dp.FLASH.constrain();
+    /// let mut rcc = dp.RCC.constrain();
+    /// let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    /// ```
+
     pub fn freeze(self, acr: &mut ACR) -> Clocks {
         let pllsrcclk = self.hse.unwrap_or(HSI / 2);
 
@@ -456,6 +469,7 @@ impl BKP {
 /// ```rust
 /// let dp = pac::Peripherals::take().unwrap();
 /// let mut rcc = dp.RCC.constrain();
+/// let mut flash = dp.FLASH.constrain();
 ///
 /// let clocks = rcc.cfgr.freeze(&mut flash.acr);
 /// ```

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -303,8 +303,12 @@ where
         }
     }
 
+    #[deprecated(since = "0.6.0", note = "Please use release instead")]
     pub fn free(self) -> (SPI, PINS) {
         (self.spi, self.pins)
+    }
+    pub fn release(self) -> (SPI, PINS) {
+        self.free()
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,33 +1,34 @@
 /*!
   # Serial Peripheral Interface
+  To construct the SPI instances, use the `Spi::spiX` functions.
 
-  ## Alternate function remapping
+  The pin parameter is a tuple containing `(sck, miso, mosi)` which should be configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
 
-  ### SPI1
+  You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
 
-  | Function | Spi1NoRemap | Spi1Remap |
-  |:----:|:-----------:|:---------:|
-  | SCK  |     PA5     |    PB3   |
-  | MISO |     PA6     |    PB4   |
-  | MOSI |     PA7     |    PB5   |
+  - `SPI1` can use `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)`.
+  - `SPI2` can use `(PB13, PB14, PB15)`
+  - `SPI3` can use `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)`
 
-  ### SPI2
 
-  | Function | Spi2NoRemap |
-  |:----:|:-----------:|
-  | SCK  |     PB13     |
-  | MISO |     PB14     |
-  | MOSI |     PB15     |
+  ## Initialisation example
 
-  ### SPI3
+  ```rust
+    // Acquire the GPIOB peripheral
+    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
 
-  Available only on high density devices.
+    let pins = (
+        gpiob.pb13.into_alternate_push_pull(&mut gpiob.crh),
+        gpiob.pb14.into_floating_input(&mut gpiob.crh),
+        gpiob.pb15.into_alternate_push_pull(&mut gpiob.crh),
+    );
 
-  | Function | Spi3NoRemap | Spi3Remap |
-  |:----:|:-----------:|:---------:|
-  | SCK  |     PB3     |    PC10   |
-  | MISO |     PB4     |    PC11   |
-  | MOSI |     PB5     |    PC12   |
+    let spi_mode = Mode {
+        polarity: Polarity::IdleLow,
+        phase: Phase::CaptureOnFirstTransition,
+    };
+    let spi = Spi::spi2(dp.SPI2, pins, spi_mode, 100.khz(), clocks, &mut rcc.apb1);
+  ```
 */
 
 use core::ops::Deref;
@@ -147,6 +148,13 @@ remap!(Spi3NoRemap, SPI3, false, PB3, PB4, PB5);
 remap!(Spi3Remap, SPI3, true, PC10, PC11, PC12);
 
 impl<REMAP, PINS> Spi<SPI1, REMAP, PINS> {
+    /**
+      Constructs an SPI instance using SPI1.
+
+      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+
+      You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
+    */
     pub fn spi1<F, POS>(
         spi: SPI1,
         pins: PINS,
@@ -167,6 +175,13 @@ impl<REMAP, PINS> Spi<SPI1, REMAP, PINS> {
 }
 
 impl<REMAP, PINS> Spi<SPI2, REMAP, PINS> {
+    /**
+      Constructs an SPI instance using SPI1.
+
+      The pin parameter tuple (sck, miso, mosi) should be `(PB13, PB14, PB15)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+
+      You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
+    */
     pub fn spi2<F, POS>(
         spi: SPI2,
         pins: PINS,
@@ -186,6 +201,13 @@ impl<REMAP, PINS> Spi<SPI2, REMAP, PINS> {
 
 #[cfg(any(feature = "high", feature = "connectivity"))]
 impl<REMAP, PINS> Spi<SPI3, REMAP, PINS> {
+    /**
+      Constructs an SPI instance using SPI1.
+
+      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+
+      You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
+    */
     pub fn spi3<F, POS>(
         spi: SPI3,
         pins: PINS,


### PR DESCRIPTION
The lack of documentation for how to get a hold of the `Rcc` and `Afio` structs has bothered me for a while. This fixes that, along with adding some top level documentation to the SPI module