### PR TITLE
Fix period retrival for timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix period retrival for timers
+
 ## [v0.6.0] - 2020-06-06
 
 ### Breaking changes

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -371,7 +371,7 @@ macro_rules! hal {
                 fn get_period(&self) -> Self::Time {
                     let clk = self.clk;
                     let psc: u16 = unsafe{(*$TIMX::ptr()).psc.read().psc().bits()};
-                    let arr: u16 = unsafe{(*$TIMX::ptr()).psc.read().psc().bits()};
+                    let arr: u16 = unsafe{(*$TIMX::ptr()).arr.read().arr().bits()};
 
                     // Length in ms of an internal clock pulse
                     (clk.0 / u32(psc * arr)).hz()


### PR DESCRIPTION
Fix `get_period` for timers