### PR TITLE
Remove deprecated PAC aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Remove deprecated `pac` aliases
+
 ## [v0.6.1] - 2020-06-25
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,14 +129,6 @@ pub use stm32f1::stm32f103 as pac;
 pub use stm32f1::stm32f107 as pac;
 
 #[cfg(feature = "device-selected")]
-#[deprecated(since = "0.6.0", note = "please use `pac` instead")]
-pub use crate::pac as device;
-
-#[cfg(feature = "device-selected")]
-#[deprecated(since = "0.6.0", note = "please use `pac` instead")]
-pub use crate::pac as stm32;
-
-#[cfg(feature = "device-selected")]
 pub mod adc;
 #[cfg(feature = "device-selected")]
 pub mod afio;


### PR DESCRIPTION
These were deprecated in v0.6.0 so we *can* remove them now. I'm not sure when its appropriate to do so though.

[crates.io statistics](https://crates.io/crates/stm32f1xx-hal) says we still have plenty of 0.5.3 downloads, so those people would never see the deprecation warning.

On the other hand, having 3 aliases for the same thing makes the docs.rs search quite a lot more cluttered (see below) so getting rid of it soon would be nice.

![image](https://user-images.githubusercontent.com/5312813/85757551-dd18bd80-b70f-11ea-8d06-09fa48d67f84.png)

Is it possible to do a "hard deprecation" where we export an empty module that gives a clear error message `use`d? That would fix the docs.rs breakage