### PR TITLE
Improve DMA ergonomics when working with generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Replace DMA buffer types with `Deref` ans `Unpin`
+
 ## [v0.6.1] - 2020-06-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ version = "0.2.2"
 version = "0.2.3"
 features = ["unproven"]
 
+[dependencies.stable_deref_trait]
+default-features = false
+version = "1.1"
+
 [dependencies.stm32-usbd]
 version = "0.5.0"
 features = ["ram_access_1x16"]

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -506,7 +506,7 @@ where
 pub trait WriteDma<B, TS>: Transmit
 where
     B: core::ops::Deref + 'static,
-    B::Target: as_slice::AsSlice<Element=TS> + Unpin,
+    B::Target: as_slice::AsSlice<Element = TS> + Unpin,
     B: StableDeref,
     Self: core::marker::Sized,
 {

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -4,6 +4,8 @@
 use core::marker::PhantomData;
 use core::ops;
 
+use stable_deref_trait::StableDeref;
+
 use crate::rcc::AHB;
 
 #[derive(Debug)]
@@ -505,6 +507,7 @@ pub trait WriteDma<B, TS>: Transmit
 where
     B: core::ops::Deref + 'static,
     B::Target: as_slice::AsSlice<Element=TS> + Unpin,
+    B: StableDeref,
     Self: core::marker::Sized,
 {
     fn write(self, buffer: B) -> Transfer<R, B, Self>;

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -70,6 +70,11 @@ pub trait TransferPayload {
     fn stop(&mut self);
 }
 
+pub trait Transferable<BUFFER, DMA> {
+    fn is_done(&self) -> bool;
+    fn wait(self) -> (BUFFER, DMA);
+}
+
 pub struct Transfer<MODE, BUFFER, PAYLOAD> {
     _mode: PhantomData<MODE>,
     buffer: BUFFER,
@@ -128,7 +133,7 @@ macro_rules! dma {
 
                 use crate::pac::{$DMAX, dma1};
 
-                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferPayload};
+                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferPayload, Transferable};
                 use crate::rcc::{AHB, Enable};
 
                 pub struct Channels((), $(pub $CX),+);
@@ -294,15 +299,15 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> Transferable<BUFFER, RxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
                     where
                         RxDma<PAYLOAD, $CX>: TransferPayload,
                     {
-                        pub fn is_done(&self) -> bool {
+                        fn is_done(&self) -> bool {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
+                        fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
                             atomic::compiler_fence(Ordering::Acquire);
@@ -320,15 +325,15 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> Transferable<BUFFER, TxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
                     where
                         TxDma<PAYLOAD, $CX>: TransferPayload,
                     {
-                        pub fn is_done(&self) -> bool {
+                        fn is_done(&self) -> bool {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
+                        fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
                             atomic::compiler_fence(Ordering::Acquire);
@@ -496,10 +501,10 @@ where
     fn read(self, buffer: &'static mut B) -> Transfer<W, &'static mut B, Self>;
 }
 
-pub trait WriteDma<A, B, TS>: Transmit
+pub trait WriteDma<B, TS>: Transmit
 where
-    A: as_slice::AsSlice<Element = TS>,
-    B: Static<A>,
+    B: core::ops::Deref + 'static,
+    B::Target: as_slice::AsSlice<Element=TS> + Unpin,
     Self: core::marker::Sized,
 {
     fn write(self, buffer: B) -> Transfer<R, B, Self>;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -44,10 +44,13 @@ use core::sync::atomic::{self, Ordering};
 
 use crate::pac::{USART1, USART2, USART3};
 use core::convert::Infallible;
+
+use as_slice::AsSlice;
+
 use embedded_hal::serial::Write;
 
 use crate::afio::MAPR;
-use crate::dma::{dma1, CircBuffer, RxDma, Static, Transfer, TxDma, R, W};
+use crate::dma::{dma1, CircBuffer, RxDma, Transfer, TxDma, R, W};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::gpioc::{PC10, PC11};
@@ -637,12 +640,16 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<A, B> crate::dma::WriteDma<A, B, u8> for $txdma where A: as_slice::AsSlice<Element=u8>, B: Static<A> {
+            impl<B> crate::dma::WriteDma<B, u8> for $txdma
+            where
+                B: core::ops::Deref + 'static,
+                B::Target: AsSlice<Element = u8> + Unpin,
+            {
                 fn write(mut self, buffer: B
                 ) -> Transfer<R, B, Self>
                 {
                     {
-                        let buffer = buffer.borrow().as_slice();
+                        let buffer = (*buffer).as_slice();
 
                         self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -46,6 +46,7 @@ use crate::pac::{USART1, USART2, USART3};
 use core::convert::Infallible;
 
 use as_slice::AsSlice;
+use stable_deref_trait::StableDeref;
 
 use embedded_hal::serial::Write;
 
@@ -642,7 +643,7 @@ macro_rules! serialdma {
 
             impl<B> crate::dma::WriteDma<B, u8> for $txdma
             where
-                B: core::ops::Deref + 'static,
+                B: StableDeref + core::ops::Deref + 'static,
                 B::Target: AsSlice<Element = u8> + Unpin,
             {
                 fn write(mut self, buffer: B

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -41,7 +41,7 @@ use crate::pac::{SPI1, SPI2};
 
 use crate::afio::MAPR;
 use crate::dma::dma1::{C3, C5};
-use crate::dma::{Static, Transfer, TransferPayload, Transmit, TxDma, R};
+use crate::dma::{Transfer, TransferPayload, Transmit, TxDma, R};
 use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
@@ -450,14 +450,14 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<A, B, REMAP, PIN> crate::dma::WriteDma<A, B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
+        impl<B, REMAP, PIN> crate::dma::WriteDma<B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
         where
-            A: AsSlice<Element = u8>,
-            B: Static<A>,
+            B: core::ops::Deref + 'static,
+            B::Target: as_slice::AsSlice<Element = u8> + Unpin,
         {
             fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
                 {
-                    let buffer = buffer.borrow().as_slice();
+                    let buffer = buffer.as_slice();
                     self.channel.set_peripheral_address(
                         unsafe { &(*$SPIi::ptr()).dr as *const _ as u32 },
                         false,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -53,6 +53,7 @@ use crate::time::Hertz;
 use core::sync::atomic::{self, Ordering};
 
 use as_slice::AsSlice;
+use stable_deref_trait::StableDeref;
 
 /// SPI error
 #[derive(Debug)]
@@ -452,7 +453,7 @@ macro_rules! spi_dma {
 
         impl<B, REMAP, PIN> crate::dma::WriteDma<B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
         where
-            B: core::ops::Deref + 'static,
+            B: StableDeref + core::ops::Deref + 'static,
             B::Target: as_slice::AsSlice<Element = u8> + Unpin,
         {
             fn write(mut self, buffer: B) -> Transfer<R, B, Self> {


### PR DESCRIPTION
I found our current DMA API to be quite difficult to work with in external crates because of the `A, B` thingy. This replaces the buffer types with the ones used in the embeddonomicon https://docs.rust-embedded.org/embedonomicon/dma.html

As  far as I can tell, this is safe, but I may very well be missing something.

Because of the way that `Transfer` is implemented, I found no way to specify a generic TxDma which has a `wait` method. To fix that, I added the `Transferable` trait.

Example usage of all of this can be found at https://gitlab.com/TheZoq2/ws2812-spi-dma/-/blob/master/src/lib.rs

DNM because the same treatment has to be given to RxDma, but I just want to make sure I don't do anything stupid before going through with that.