### PR TITLE
Change arm-none-eabi-gdb to gdb-multiarch

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.thumbv7m-none-eabi]
-runner = 'arm-none-eabi-gdb'
+runner = 'gdb'
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.thumbv7m-none-eabi]
-runner = 'gdb'
+runner = 'gdb-multiarch'
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mini](https://www.st.com/en/development-tools/stlink-v3mini.html) for programmin
 
 To program your microcontroller, you need to install:
 - [openocd](http://openocd.org/)
-- `gdb`
+- `gdb-multiarch` (on some platforms you may need to use `gdb-arm-none-eabi` instead, make sure to update `.cargo/config` to reflect this change)
 
 Finally, you need to install arm target support for the Rust compiler. To do
 so, run

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mini](https://www.st.com/en/development-tools/stlink-v3mini.html) for programmin
 
 To program your microcontroller, you need to install:
 - [openocd](http://openocd.org/)
-- `arm-none-eabi-gdb`
+- `gdb`
 
 Finally, you need to install arm target support for the Rust compiler. To do
 so, run


### PR DESCRIPTION
On Ubuntu from 18.04 it seems that `arm-none-eabi-gdb` is now replaced with `gdb-multiarch` and then `gdb` is used to perform debugging. https://rust-embedded.github.io/book/intro/install/linux.html seems to indicate this might not apply to all distributions though. A `gdb-multiarch` package does exist in the AUR (https://aur.archlinux.org/packages/gdb-multiarch/), and I'm unable to access the fedora website to check. 