### PR TITLE
Better Circular DMA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Replace DMA buffer types with `Deref` ans `Unpin`
+
 ## [v0.6.1] - 2020-06-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ version = "0.2.2"
 version = "0.2.3"
 features = ["unproven"]
 
+[dependencies.stable_deref_trait]
+default-features = false
+version = "1.1"
+
 [dependencies.stm32-usbd]
 version = "0.5.0"
 features = ["ram_access_1x16"]

--- a/examples/serial-dma-circ-len.rs
+++ b/examples/serial-dma-circ-len.rs
@@ -1,0 +1,99 @@
+//! Serial interface circular DMA RX transfer test
+
+#![deny(unsafe_code)]
+#![no_std]
+#![no_main]
+
+use panic_semihosting as _;
+
+use cortex_m::{asm, singleton};
+use cortex_m_semihosting::{hprint, hprintln};
+
+use cortex_m_rt::entry;
+use stm32f1xx_hal::{
+    dma::CircReadDmaLen,
+    pac,
+    prelude::*,
+    serial::{Config, Serial},
+};
+
+#[entry]
+fn main() -> ! {
+    let p = pac::Peripherals::take().unwrap();
+
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut afio = p.AFIO.constrain(&mut rcc.apb2);
+    let channels = p.DMA1.split(&mut rcc.ahb);
+
+    let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
+    // let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+
+    // USART1
+    let tx = gpioa.pa9.into_alternate_push_pull(&mut gpioa.crh);
+    let rx = gpioa.pa10;
+
+    // USART1
+    // let tx = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
+    // let rx = gpiob.pb7;
+
+    // USART2
+    // let tx = gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl);
+    // let rx = gpioa.pa3;
+
+    // USART3
+    // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
+    // let rx = gpiob.pb11;
+
+    let serial = Serial::usart1(
+        p.USART1,
+        (tx, rx),
+        &mut afio.mapr,
+        Config::default().baudrate(9_600.bps()),
+        clocks,
+        &mut rcc.apb2,
+    );
+
+    hprintln!("waiting for 5 bytes").unwrap();
+
+    let rx = serial.split().1.with_dma(channels.5);
+    // increase to reasonable size (e.g. 64, 128 etc.) for actual applications
+    let buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
+
+    let mut circ_buffer = rx.circ_read_len(buf);
+
+    // wait until we have 5 bytes
+    while circ_buffer.len() < 5 {}
+
+    let mut dat = [0 as u8; 4];
+    assert!(circ_buffer.read(&mut dat[..]) == 4);
+
+    hprintln!("[{}, {}, {}, {}]", dat[0], dat[1], dat[2], dat[3]).unwrap();
+
+    // try to read again, now only one byte is returned
+    hprintln!("read {}", circ_buffer.read(&mut dat)).unwrap();
+
+    hprintln!("[{}]", dat[0]).unwrap();
+
+    // wait for the buffer to have 4 bytes again
+    while circ_buffer.len() < 4 {}
+
+    // all four bytes should be read in one go
+    assert!(circ_buffer.read(&mut dat) == 4);
+
+    hprintln!("[{}, {}, {}, {}]", dat[0], dat[1], dat[2], dat[3]).unwrap();
+
+    loop {
+        let read = circ_buffer.read(&mut dat);
+
+        if read > 0 {
+            for c in &dat[..read]{
+                hprint!("{}", *c as char).unwrap();
+            }
+            hprintln!("").unwrap();
+        }
+    }
+}

--- a/examples/serial-dma-circ-len.rs
+++ b/examples/serial-dma-circ-len.rs
@@ -6,7 +6,7 @@
 
 use panic_semihosting as _;
 
-use cortex_m::{asm, singleton};
+use cortex_m::{singleton};
 use cortex_m_semihosting::{hprint, hprintln};
 
 use cortex_m_rt::entry;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -51,7 +51,7 @@ use stable_deref_trait::StableDeref;
 use embedded_hal::serial::Write;
 
 use crate::afio::MAPR;
-use crate::dma::{dma1, CircBuffer, RxDma, Transfer, TxDma, R, W};
+use crate::dma::{dma1, CircBuffer, CircBufferLen, Priority, RxDma, Transfer, TxDma, R, W};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::gpioc::{PC10, PC11};
@@ -585,6 +585,17 @@ macro_rules! serialdma {
                         payload,
                         channel,
                     )
+                }
+            }
+
+            impl<B> crate::dma::CircReadDmaLen<B, u8> for $rxdma where B: as_slice::AsMutSlice<Element=u8> {
+                fn circ_read_len(self, buffer: &'static mut B) -> CircBufferLen<u8, Self>{
+                    let buffer = buffer.as_mut_slice();
+                    let paddr = unsafe { &(*$USARTX::ptr()).dr as *const _ as u32 };
+
+                    let mut buf = CircBufferLen::new(buffer, self);
+                    unsafe { buf.setup(paddr, Priority::MEDIUM) };
+                    buf
                 }
             }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -41,7 +41,7 @@ use crate::pac::{SPI1, SPI2};
 
 use crate::afio::MAPR;
 use crate::dma::dma1::{C3, C5};
-use crate::dma::{Static, Transfer, TransferPayload, Transmit, TxDma, R};
+use crate::dma::{Transfer, TransferPayload, Transmit, TxDma, R};
 use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
@@ -53,6 +53,7 @@ use crate::time::Hertz;
 use core::sync::atomic::{self, Ordering};
 
 use as_slice::AsSlice;
+use stable_deref_trait::StableDeref;
 
 /// SPI error
 #[derive(Debug)]
@@ -450,14 +451,14 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<A, B, REMAP, PIN> crate::dma::WriteDma<A, B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
+        impl<B, REMAP, PIN> crate::dma::WriteDma<B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
         where
-            A: AsSlice<Element = u8>,
-            B: Static<A>,
+            B: StableDeref + core::ops::Deref + 'static,
+            B::Target: as_slice::AsSlice<Element = u8> + Unpin,
         {
             fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
                 {
-                    let buffer = buffer.borrow().as_slice();
+                    let buffer = buffer.as_slice();
                     self.channel.set_peripheral_address(
                         unsafe { &(*$SPIi::ptr()).dr as *const _ as u32 },
                         false,


### PR DESCRIPTION
This is my initial draft on PR on issue #242.

The example `serial-dma-circ-len.rs` shows how to use it in more detail, but the most important changes are demonstrate in the following snippet:

```rust
    let mut circ_buffer = rx.circ_read_len(buf);

    // wait until we have 5 bytes
    while circ_buffer.len() < 5 {}

    let mut dat = [0 as u8; 4];
    assert!(circ_buffer.read(&mut dat[..]) == 4);
```

One thing I have noticed is that currently a lot of the responsibility in setting up DMA is coded in the using module (e.g. in the `serial` module.  I've introduced a `setup` function, so that it happens within the DMA module, and the setup within the serial module looks like:

```rust
                fn circ_read_len(self, buffer: &'static mut B) -> CircBufferLen<u8, Self>{
                    let buffer = buffer.as_mut_slice();
                    let paddr = unsafe { &(*$USARTX::ptr()).dr as *const _ as u32 };

                    let mut buf = CircBufferLen::new(buffer, self);
                    unsafe { buf.setup(paddr, Priority::MEDIUM) };
                    buf
                }
```

I would recommend that `CircBufferLen` be renamed `CircBuffer` and the olde `CircBuffer` behaviour renamed into e.g. `CircBufferHalves`.

I have only implemented this for the serial module so far.