### PR TITLE
More documentation links

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -2,12 +2,15 @@
 //!
 //! The GPIO pins are organised into groups of 16 pins which can be accessed through the
 //! `gpioa`, `gpiob`... modules. To get access to the pins, you first need to convert them into a
-//! HAL designed struct from the `pac` struct using the `spilit` function.
+//! HAL designed struct from the `pac` struct using the [split](trait.GpioExt.html#tymethod.split) function.
 //! ```rust
 //! // Acquire the GPIOC peripheral
 //! // NOTE: `dp` is the device peripherals from the `PAC` crate
 //! let mut gpioa = dp.GPIOA.split(&mut rcc.apb2);
 //! ```
+//!
+//! See the documentation for [rcc::APB2](../rcc/struct.APB2.html) for details about the input parameter to
+//! `split`.
 //!
 //! This gives you a struct containing two control registers `crl` and `crh`, and all the pins
 //! `px0..px15`. These structs are what you use to interract with the pins to change their modes,

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -36,6 +36,14 @@ impl RccExt for RCC {
 }
 
 /// Constrained RCC peripheral
+///
+/// Aquired by calling the [constrain](../trait.RccExt.html#tymethod.constrain) method
+/// on the Rcc struct from the `PAC`
+///
+/// ```rust
+/// let dp = pac::Peripherals::take().unwrap();
+/// let mut rcc = dp.RCC.constrain();
+/// ```
 pub struct Rcc {
     /// AMBA High-performance Bus (AHB) registers
     pub ahb: AHB,


### PR DESCRIPTION
Like my previous documentation improvement PR, this one adds a few more links where I think that it might be hard to find out where parameters come from, or how to aquire certain structs.

I'll probably do a few more commits as I find them, so don't merge quite yet