### PR TITLE
Fix mono timer

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use core::ops;
-use cortex_m::peripheral::DWT;
+use cortex_m::peripheral::{DWT, DCB};
 
 use crate::rcc::Clocks;
 
@@ -234,7 +234,8 @@ pub struct MonoTimer {
 
 impl MonoTimer {
     /// Creates a new `Monotonic` timer
-    pub fn new(mut dwt: DWT, clocks: Clocks) -> Self {
+    pub fn new(mut dwt: DWT, mut dcb: DCB, clocks: Clocks) -> Self {
+        dcb.enable_trace();
         dwt.enable_cycle_counter();
 
         // now the CYCCNT counter can't be stopped or reset

--- a/src/time.rs
+++ b/src/time.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use core::ops;
-use cortex_m::peripheral::{DWT, DCB};
+use cortex_m::peripheral::{DCB, DWT};
 
 use crate::rcc::Clocks;
 
@@ -227,6 +227,11 @@ impl_arithmetic!(MegaHertz, u32);
 impl_arithmetic!(Bps, u32);
 
 /// A monotonic non-decreasing timer
+///
+/// This uses the timer in the debug watch trace peripheral. This means, that if the
+/// core is stopped, the timer does not count up. This may be relevant if you are using
+/// cortex_m_semihosting::hprintln for debugging in which case the timer will be stopped
+/// while printing
 #[derive(Clone, Copy)]
 pub struct MonoTimer {
     frequency: Hertz,


### PR DESCRIPTION
Closes #252 

Unfortunately this a breaking change as we now need to take the DCP peripheral when starting the mono timer.

I also added a note from one of the linked issues about `mono_timer` being stopped when hprintln is running.

For reference, here is a code sample that does not work currently, but does with this fix

```rust
#![deny(unsafe_code)]
#![no_main]
#![no_std]

use panic_halt as _;

use cortex_m_semihosting::hprintln;
use cortex_m_rt::entry;
use stm32f1xx_hal::{
    pac,
    prelude::*,
    serial::{Config, Serial},
};
use embedded_hal::digital::v2::OutputPin;

use core::fmt::Write;

#[entry]
fn main() -> ! {
    let mut cp = cortex_m::peripheral::Peripherals::take().unwrap();
    let p = pac::Peripherals::take().unwrap();

    let mut flash = p.FLASH.constrain();
    let mut rcc = p.RCC.constrain();
    let clocks = rcc.cfgr.freeze(&mut flash.acr);

    let mut afio = p.AFIO.constrain(&mut rcc.apb2);
    let mut gpioc = p.GPIOC.split(&mut rcc.apb2);

    let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);


    // Needed in order for MonoTimer to work properly
    // cp.DCB.enable_trace();

    let mut delay = stm32f1xx_hal::delay::Delay::new(cp.SYST, clocks);
    let mono_timer = stm32f1xx_hal::time::MonoTimer::new(cp.DWT, cp.DCB, clocks);

    let start = mono_timer.now();

    let mut led_state = false;
    let mut prev = start.elapsed();
    loop {
        // hprintln!("{}", new);
        let new = start.elapsed();
        if prev + mono_timer.frequency().0 < new {
            if led_state {
                led.set_high();
            }
            else {
                led.set_low();
            }
            led_state = !led_state;
            prev = new;
        }
    }
}
```