### PR TITLE
Spi with 16bit framesize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 MonoTimer now takes ownership of the DCB register
 
+### Added
+
+- Add 16 bit dataframe size for `SPI`
+
 ### Fixed
 
 - Fix MonoTimer not working in debug mode. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
-MonoTimer now takes ownership of the DCB register
+- MonoTimer now takes ownership of the DCB register
+- SPI objects now have a `FrameSize` type field
 
 ### Added
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -231,7 +231,7 @@ pub type SpiRegisterBlock = crate::pac::spi1::RegisterBlock;
 pub trait SpiReadWrite<T> {
     fn read_data_reg(&mut self) -> T;
     fn write_data_reg(&mut self, data: T);
-    fn write_fast(&mut self, words: &[T]) -> Result<(), Error>;
+    fn spi_write(&mut self, words: &[T]) -> Result<(), Error>;
 }
 
 impl<SPI, REMAP, PINS, FrameSize> SpiReadWrite<FrameSize> for Spi<SPI, REMAP, PINS, FrameSize>
@@ -254,7 +254,7 @@ where
     // of RM0008 Rev 20. This is more than twice as fast as the
     // default Write<> implementation (which reads and drops each
     // received value)
-    fn write_fast(&mut self, words: &[FrameSize]) -> Result<(), Error> {
+    fn spi_write(&mut self, words: &[FrameSize]) -> Result<(), Error> {
         // Write each word when the tx buffer is empty
         for word in words {
             loop {
@@ -481,7 +481,7 @@ where
     // default Write<> implementation (which reads and drops each
     // received value)
     fn write(&mut self, words: &[u8]) -> Result<(), Error> {
-        self.write_fast(words)
+        self.spi_write(words)
     }
 }
 
@@ -492,7 +492,7 @@ where
     type Error = Error;
 
     fn write(&mut self, words: &[u16]) -> Result<(), Error> {
-        self.write_fast(words)
+        self.spi_write(words)
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -414,6 +414,18 @@ where
         }
     }
 
+    pub fn frame_size_8bit(self) -> Spi<SPI, REMAP, PINS, u8>{
+        self.spi.cr1.modify(|_, w| w.spe().clear_bit());
+        self.spi.cr1.modify(|_, w| w.dff().clear_bit());
+        self.spi.cr1.modify(|_, w| w.spe().set_bit());
+        Spi{
+            spi: self.spi,
+            pins: self.pins,
+            _remap: PhantomData,
+            _framesize: PhantomData,
+        }
+    }
+
     #[deprecated(since = "0.6.0", note = "Please use release instead")]
     pub fn free(self) -> (SPI, PINS) {
         self.release()

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -150,7 +150,7 @@ remap!(Spi3Remap, SPI3, true, PC10, PC11, PC12);
 
 impl<REMAP, PINS> Spi<SPI1, REMAP, PINS, u8> {
     /**
-      Constructs an SPI instance using SPI1.
+      Constructs an SPI instance using SPI1 in 8bit dataframe mode.
 
       The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
 
@@ -177,7 +177,7 @@ impl<REMAP, PINS> Spi<SPI1, REMAP, PINS, u8> {
 
 impl<REMAP, PINS> Spi<SPI2, REMAP, PINS, u8> {
     /**
-      Constructs an SPI instance using SPI2.
+      Constructs an SPI instance using SPI2 in 8bit dataframe mode.
 
       The pin parameter tuple (sck, miso, mosi) should be `(PB13, PB14, PB15)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
 
@@ -203,7 +203,7 @@ impl<REMAP, PINS> Spi<SPI2, REMAP, PINS, u8> {
 #[cfg(any(feature = "high", feature = "connectivity"))]
 impl<REMAP, PINS> Spi<SPI3, REMAP, PINS, u8> {
     /**
-      Constructs an SPI instance using SPI3.
+      Constructs an SPI instance using SPI3 in 8bit dataframe mode.
 
       The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
 
@@ -237,7 +237,7 @@ pub trait SpiReadWrite<T> {
 impl<SPI, REMAP, PINS, FrameSize> SpiReadWrite<FrameSize> for Spi<SPI, REMAP, PINS, FrameSize>
 where
     SPI: Deref<Target = SpiRegisterBlock>,
-    FrameSize: Copy
+    FrameSize: Copy,
 {
     fn read_data_reg(&mut self) -> FrameSize {
         // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
@@ -298,9 +298,8 @@ where
 impl<SPI, REMAP, PINS, FrameSize> Spi<SPI, REMAP, PINS, FrameSize>
 where
     SPI: Deref<Target = SpiRegisterBlock>,
-    FrameSize: Copy
+    FrameSize: Copy,
 {
-
     #[deprecated(since = "0.6.0", note = "Please use release instead")]
     pub fn free(self) -> (SPI, PINS) {
         self.release()
@@ -311,7 +310,7 @@ where
 }
 
 impl<SPI, REMAP, PINS> Spi<SPI, REMAP, PINS, u8>
-where 
+where
     SPI: Deref<Target = SpiRegisterBlock> + Enable + Reset,
     SPI::Bus: GetBusFreq,
 {
@@ -386,11 +385,12 @@ where
             _framesize: PhantomData,
         }
     }
-    pub fn frame_size_16bit(self) -> Spi<SPI, REMAP, PINS, u16>{
+    /// Converts from 8bit dataframe to 16bit.
+    pub fn frame_size_16bit(self) -> Spi<SPI, REMAP, PINS, u16> {
         self.spi.cr1.modify(|_, w| w.spe().clear_bit());
         self.spi.cr1.modify(|_, w| w.dff().set_bit());
         self.spi.cr1.modify(|_, w| w.spe().set_bit());
-        Spi{
+        Spi {
             spi: self.spi,
             pins: self.pins,
             _remap: PhantomData,
@@ -403,11 +403,12 @@ impl<SPI, REMAP, PINS> Spi<SPI, REMAP, PINS, u16>
 where
     SPI: Deref<Target = SpiRegisterBlock>,
 {
-    pub fn frame_size_8bit(self) -> Spi<SPI, REMAP, PINS, u8>{
+    /// Converts from 16bit dataframe to 8bit.
+    pub fn frame_size_8bit(self) -> Spi<SPI, REMAP, PINS, u8> {
         self.spi.cr1.modify(|_, w| w.spe().clear_bit());
         self.spi.cr1.modify(|_, w| w.dff().clear_bit());
         self.spi.cr1.modify(|_, w| w.spe().set_bit());
-        Spi{
+        Spi {
             spi: self.spi,
             pins: self.pins,
             _remap: PhantomData,
@@ -416,10 +417,11 @@ where
     }
 }
 
-impl<SPI, REMAP, PINS, FrameSize> crate::hal::spi::FullDuplex<FrameSize> for Spi<SPI, REMAP, PINS, FrameSize>
+impl<SPI, REMAP, PINS, FrameSize> crate::hal::spi::FullDuplex<FrameSize>
+    for Spi<SPI, REMAP, PINS, FrameSize>
 where
     SPI: Deref<Target = SpiRegisterBlock>,
-    FrameSize: Copy
+    FrameSize: Copy,
 {
     type Error = Error;
 
@@ -460,9 +462,11 @@ where
     }
 }
 
-impl<SPI, REMAP, PINS, FrameSize> crate::hal::blocking::spi::transfer::Default<FrameSize> for Spi<SPI, REMAP, PINS, FrameSize> where
+impl<SPI, REMAP, PINS, FrameSize> crate::hal::blocking::spi::transfer::Default<FrameSize>
+    for Spi<SPI, REMAP, PINS, FrameSize>
+where
     SPI: Deref<Target = SpiRegisterBlock>,
-    FrameSize: Copy
+    FrameSize: Copy,
 {
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -148,17 +148,6 @@ remap!(Spi3NoRemap, SPI3, false, PB3, PB4, PB5);
 #[cfg(feature = "connectivity")]
 remap!(Spi3Remap, SPI3, true, PC10, PC11, PC12);
 
-// pub trait DataFrameSize<T> {}
-
-// impl DataFrameSize<u8> for SPI1 {}
-// impl DataFrameSize<u16> for SPI1 {}
-// impl DataFrameSize<u8> for SPI2 {}
-// impl DataFrameSize<u16> for SPI2 {}
-// #[cfg(any(feature = "high", feature = "connectivity"))]
-// impl DataFrameSize<u8> for SPI3 {}
-// #[cfg(any(feature = "high", feature = "connectivity"))]
-// impl DataFrameSize<u16> for SPI3 {}
-
 impl<REMAP, PINS> Spi<SPI1, REMAP, PINS, u8> {
     /**
       Constructs an SPI instance using SPI1.


### PR DESCRIPTION
This is an attempt to implement [issue #256](https://github.com/stm32-rs/stm32f1xx-hal/issues/256).

This adds a `PhantomData` tag to the `Spi` objects, allowing them to be typed as `u8` or `u16` to indicate their data frame size. The existing constructor creates a `Spi<..., u8>` object with no change in syntax to not break the existing API. To convert between dataframe modes you must call `frame_size_8bit()` or `frame_size_16bit()` which consumes the old type and hands back the new one.

Example usage:
```
    let spi8 = spi::Spi::spi2(dp.SPI2, (sclk, miso, mosi), spi_mode, 100.khz(), clocks, &mut rcc.apb1);
    let spi16 = spi.frame_size_16bit();
```

So far there is no way to initialise directly into 16bit data frame mode. I couldn't think of an elegant way without breaking the current API, and didn't like the idea of just having `spi::Spi::spi2_16b_mode(dp.SPI1...`, so I'd love suggestions.

I'd love some feedback on my implementation as I am quite new to rust!