### PR TITLE
Add missing SPI3 remap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - MonoTimer now takes ownership of the DCB register
 - SPI objects now have a `FrameSize` type field
 - Bit banding functions (`bb::*`) are now correctly marked as unsafe
+- Add missing remap to `spi3` constructor. Requires a new `mapr` argument.
 
 ### Added
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -214,6 +214,7 @@ impl<REMAP, PINS> Spi<SPI3, REMAP, PINS, u8> {
     pub fn spi3<F, POS>(
         spi: SPI3,
         pins: PINS,
+        mapr: &mut MAPR,
         mode: Mode,
         freq: F,
         clocks: Clocks,
@@ -224,6 +225,7 @@ impl<REMAP, PINS> Spi<SPI3, REMAP, PINS, u8> {
         REMAP: Remap<Periph = SPI3>,
         PINS: Pins<REMAP, POS>,
     {
+        mapr.modify_mapr(|_, w| w.spi3_remap().bit(REMAP::REMAP));
         Spi::<SPI3, _, _, u8>::_spi(spi, pins, mode, freq.into(), clocks, apb)
     }
 }


### PR DESCRIPTION
This is necessary in order for SPI3 to function correctly.

Note that this is a breaking change, as it requires access to `MAPR` via
a new argument. This has been added as the third argument to match the
`spi1` constructor.

Tested successfully on an F107.