### PR TITLE
Mark bit banding function unsafe (and some minor fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - MonoTimer now takes ownership of the DCB register
 - SPI objects now have a `FrameSize` type field
+- Bit banding functions (`bb::*`) are now correctly marked as unsafe
 
 ### Added
 
 - Add 16 bit dataframe size for `SPI`
 - Implement `timer::Cancel` trait for `CountDownTimer`
 - Changing Output pin slew rates through the OutputSpeed trait
-
-### Added
-
 - Add support for ADC continuous conversion
 - Add supoort for ADC discontinuous mode
 

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -2,15 +2,15 @@
 
 use core::ptr;
 
-pub fn clear<T>(register: *const T, bit: u8) {
+pub unsafe fn clear<T>(register: *const T, bit: u8) {
     write(register, bit, false);
 }
 
-pub fn set<T>(register: *const T, bit: u8) {
+pub unsafe fn set<T>(register: *const T, bit: u8) {
     write(register, bit, true);
 }
 
-pub fn write<T>(register: *const T, bit: u8, set: bool) {
+pub unsafe fn write<T>(register: *const T, bit: u8, set: bool) {
     let addr = register as usize;
 
     assert!(addr >= 0x4000_0000 && addr <= 0x4010_0000);
@@ -18,5 +18,5 @@ pub fn write<T>(register: *const T, bit: u8, set: bool) {
 
     let bit = bit as usize;
     let bb_addr = (0x4200_0000 + (addr - 0x4000_0000) * 32) + 4 * bit;
-    unsafe { ptr::write_volatile(bb_addr as *mut u32, if set { 1 } else { 0 }) }
+    ptr::write_volatile(bb_addr as *mut u32, if set { 1 } else { 0 })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! [README]: https://github.com/stm32-rs/stm32f1xx-hal/tree/v0.6.1
 
 #![no_std]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 // If no target specified, print error message.
 #[cfg(not(any(


### PR DESCRIPTION
Fixes #271 

I also fixed a lint warning that popped up while building on the latest nightly and removed the duplicate categories that are present in CHANGELOG.md

cc: @thalesfragoso 