### PR TITLE
Hide PAC aliases to declutter docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,10 +130,12 @@ pub use stm32f1::stm32f107 as pac;
 
 #[cfg(feature = "device-selected")]
 #[deprecated(since = "0.6.0", note = "please use `pac` instead")]
+#[doc(hidden)]
 pub use crate::pac as device;
 
 #[cfg(feature = "device-selected")]
 #[deprecated(since = "0.6.0", note = "please use `pac` instead")]
+#[doc(hidden)]
 pub use crate::pac as stm32;
 
 #[cfg(feature = "device-selected")]


### PR DESCRIPTION
Hides `stm32` and `device` from the docs so they don't clutter things too much. Temporary fix for #237 since we still have 75% of users on versions before the deprecation according to crates.io.
