### PR TITLE
Dma Transfer

### DIFF
--- a/examples/adc-dma-rx.rs
+++ b/examples/adc-dma-rx.rs
@@ -35,14 +35,14 @@ fn main() -> ! {
     // Configure pa0 as an analog input
     let adc_ch0 = gpioa.pa0.into_analog(&mut gpioa.crl);
 
-    let adc_dma = adc1.with_dma(adc_ch0, dma_ch1);
-    let buf = singleton!(: [u16; 8] = [0; 8]).unwrap();
+    let mut adc_dma = adc1.with_dma(adc_ch0, dma_ch1);
+    let mut buf = singleton!(: [u16; 8] = [0; 8]).unwrap();
 
     // The read method consumes the buf and self, starts the adc and dma transfer and returns a
     // RxDma struct. The wait method consumes the RxDma struct, waits for the whole transfer to be
     // completed and then returns the updated buf and underlying adc_dma struct. For non blocking,
     // one can call the is_done method of RxDma and only call wait after that method returns true.
-    let (_buf, adc_dma) = adc_dma.read(buf).wait();
+    adc_dma.read(&mut buf).wait();
     asm::bkpt();
 
     // Consumes the AdcDma struct, restores adc configuration to previous state and returns the

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -55,10 +55,10 @@ fn main() -> ! {
         &mut rcc.apb2,
     );
 
-    let rx = serial.split().1.with_dma(channels.5);
-    let buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
+    let mut rx = serial.split().1.with_dma(channels.5);
+    let mut buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
 
-    let t = rx.read(buf);
+    let t = rx.read(&mut buf);
 
     while !t.is_done() {
         let _slice = t.peek();

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -55,10 +55,10 @@ fn main() -> ! {
         &mut rcc.apb2,
     );
 
-    let rx = serial.split().1.with_dma(channels.5);
-    let buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
+    let mut rx = serial.split().1.with_dma(channels.5);
+    let mut buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
 
-    let (_buf, _rx) = rx.read(buf).wait();
+    rx.read(&mut buf).wait();
 
     asm::bkpt();
 

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -55,17 +55,17 @@ fn main() -> ! {
         &mut rcc.apb2,
     );
 
-    let tx = serial.split().0.with_dma(channels.4);
+    let mut tx = serial.split().0.with_dma(channels.4);
 
-    let (_, tx) = tx.write(b"The quick brown fox").wait();
-
-    asm::bkpt();
-
-    let (_, tx) = tx.write(b" jumps").wait();
+    tx.write(&b"The quick brown fox").wait();
 
     asm::bkpt();
 
-    tx.write(b" over the lazy dog.").wait();
+    tx.write(&b" jumps").wait();
+
+    asm::bkpt();
+
+    tx.write(&b" over the lazy dog.").wait();
 
     asm::bkpt();
 

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -46,14 +46,13 @@ fn main() -> ! {
     let dma = dp.DMA1.split(&mut rcc.ahb);
 
     // Connect the SPI device to the DMA
-    let spi_dma = spi.with_tx_dma(dma.5);
+    let mut spi_dma = spi.with_tx_dma(dma.5);
 
     // Start a DMA transfer
-    let transfer = spi_dma.write(b"hello, world");
+    let transfer = spi_dma.write(&b"hello, world");
 
-    // Wait for it to finnish. The transfer takes ownership over the SPI device
-    // and the data being sent anb those things are returned by transfer.wait
-    let (_buffer, _spi_dma) = transfer.wait();
+    // Wait for it to finnish
+    transfer.wait();
 
     loop {}
 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -742,7 +742,7 @@ where
     Self: TransferPayload,
     B: StaticWriteBuffer<Word = u16>,
 {
-    fn read(mut self, mut buffer: B) -> TransferW<B, Self> {
+    fn read<'b, 'p>(&'p mut self, buffer: &'b mut B) -> TransferW<'b, 'p, B, Self> {
         // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
         // until the end of the transfer.
         let (ptr, len) = unsafe { buffer.static_write_buffer() };

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 use embedded_hal::adc::{Channel, OneShot};
 
-use crate::dma::{dma1::C1, CircBuffer, Receive, RxDma, Transfer, TransferPayload, W};
+use crate::dma::{dma1::C1, CircBuffer, Receive, RxDma, TransferPayload, TransferW};
 use crate::gpio::Analog;
 use crate::gpio::{gpioa, gpiob, gpioc};
 use crate::rcc::{Clocks, Enable, Reset, APB2};
@@ -742,7 +742,7 @@ where
     Self: TransferPayload,
     B: StaticWriteBuffer<Word = u16>,
 {
-    fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
+    fn read(mut self, mut buffer: B) -> TransferW<B, Self> {
         // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
         // until the end of the transfer.
         let (ptr, len) = unsafe { buffer.static_write_buffer() };
@@ -768,6 +768,6 @@ where
         });
         self.start();
 
-        Transfer::w(buffer, self)
+        TransferW::new(buffer, self)
     }
 }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1,10 +1,7 @@
 //! # Direct Memory Access
 #![allow(dead_code)]
 
-use core::{
-    marker::PhantomData,
-    sync::atomic::{compiler_fence, Ordering},
-};
+use core::sync::atomic::{compiler_fence, Ordering};
 use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 
 use crate::rcc::AHB;
@@ -59,43 +56,42 @@ pub trait TransferPayload {
     fn start(&mut self);
     fn stop(&mut self);
 }
-
-pub struct Transfer<MODE, BUFFER, PAYLOAD>
+/// Read transfer
+pub struct TransferR<BUFFER, PAYLOAD>
 where
     PAYLOAD: TransferPayload,
 {
-    _mode: PhantomData<MODE>,
+    buffer: BUFFER,
+    payload: PAYLOAD,
+}
+/// Write transfer
+pub struct TransferW<BUFFER, PAYLOAD>
+where
+    PAYLOAD: TransferPayload,
+{
     buffer: BUFFER,
     payload: PAYLOAD,
 }
 
-impl<BUFFER, PAYLOAD> Transfer<R, BUFFER, PAYLOAD>
+impl<BUFFER, PAYLOAD> TransferR<BUFFER, PAYLOAD>
 where
     PAYLOAD: TransferPayload,
 {
-    pub(crate) fn r(buffer: BUFFER, payload: PAYLOAD) -> Self {
-        Transfer {
-            _mode: PhantomData,
-            buffer,
-            payload,
-        }
+    pub(crate) fn new(buffer: BUFFER, payload: PAYLOAD) -> Self {
+        Self { buffer, payload }
     }
 }
 
-impl<BUFFER, PAYLOAD> Transfer<W, BUFFER, PAYLOAD>
+impl<BUFFER, PAYLOAD> TransferW<BUFFER, PAYLOAD>
 where
     PAYLOAD: TransferPayload,
 {
-    pub(crate) fn w(buffer: BUFFER, payload: PAYLOAD) -> Self {
-        Transfer {
-            _mode: PhantomData,
-            buffer,
-            payload,
-        }
+    pub(crate) fn new(buffer: BUFFER, payload: PAYLOAD) -> Self {
+        Self { buffer, payload }
     }
 }
 
-impl<MODE, BUFFER, PAYLOAD> Drop for Transfer<MODE, BUFFER, PAYLOAD>
+impl<BUFFER, PAYLOAD> Drop for TransferR<BUFFER, PAYLOAD>
 where
     PAYLOAD: TransferPayload,
 {
@@ -105,11 +101,15 @@ where
     }
 }
 
-/// Read transfer
-pub struct R;
-
-/// Write transfer
-pub struct W;
+impl<BUFFER, PAYLOAD> Drop for TransferW<BUFFER, PAYLOAD>
+where
+    PAYLOAD: TransferPayload,
+{
+    fn drop(&mut self) {
+        self.payload.stop();
+        compiler_fence(Ordering::SeqCst);
+    }
+}
 
 macro_rules! dma {
     ($($DMAX:ident: ($dmaX:ident, {
@@ -128,7 +128,7 @@ macro_rules! dma {
 
                 use crate::pac::{$DMAX, dma1};
 
-                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferPayload};
+                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, TransferR, TransferW , RxDma, TxDma, TransferPayload};
                 use crate::rcc::{AHB, Enable};
 
                 #[allow(clippy::manual_non_exhaustive)]
@@ -295,7 +295,7 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD> TransferW<BUFFER, RxDma<PAYLOAD, $CX>>
                     where
                         RxDma<PAYLOAD, $CX>: TransferPayload,
                     {
@@ -333,7 +333,7 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD> TransferR<BUFFER, TxDma<PAYLOAD, $CX>>
                     where
                         TxDma<PAYLOAD, $CX>: TransferPayload,
                     {
@@ -371,7 +371,7 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD> Transfer<W, BUFFER, RxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD> TransferW<BUFFER, RxDma<PAYLOAD, $CX>>
                     where
                         RxDma<PAYLOAD, $CX>: TransferPayload,
                     {
@@ -521,7 +521,7 @@ where
     B: StaticWriteBuffer<Word = RS>,
     Self: core::marker::Sized + TransferPayload,
 {
-    fn read(self, buffer: B) -> Transfer<W, B, Self>;
+    fn read(self, buffer: B) -> TransferW<B, Self>;
 }
 
 /// Trait for DMA writing from memory to peripheral.
@@ -530,5 +530,5 @@ where
     B: StaticReadBuffer<Word = TS>,
     Self: core::marker::Sized + TransferPayload,
 {
-    fn write(self, buffer: B) -> Transfer<R, B, Self>;
+    fn write(self, buffer: B) -> TransferR<B, Self>;
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -48,7 +48,7 @@ use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 use embedded_hal::serial::Write;
 
 use crate::afio::MAPR;
-use crate::dma::{dma1, CircBuffer, RxDma, Transfer, TxDma, R, W};
+use crate::dma::{dma1, CircBuffer, RxDma, TransferR, TransferW, TxDma};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::gpioc::{PC10, PC11};
@@ -619,7 +619,7 @@ macro_rules! serialdma {
             where
                 B: StaticWriteBuffer<Word = u8>,
             {
-                fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
+                fn read(mut self, mut buffer: B) -> TransferW<B, Self> {
                     // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
                     // until the end of the transfer.
                     let (ptr, len) = unsafe { buffer.static_write_buffer() };
@@ -638,7 +638,7 @@ macro_rules! serialdma {
                     });
                     self.start();
 
-                    Transfer::w(buffer, self)
+                    TransferW::new(buffer, self)
                 }
             }
 
@@ -646,7 +646,7 @@ macro_rules! serialdma {
             where
                 B: StaticReadBuffer<Word = u8>,
             {
-                fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
+                fn write(mut self, buffer: B) -> TransferR<B, Self> {
                     // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
                     // until the end of the transfer.
                     let (ptr, len) = unsafe { buffer.static_read_buffer() };
@@ -668,7 +668,7 @@ macro_rules! serialdma {
                     });
                     self.start();
 
-                    Transfer::r(buffer, self)
+                    TransferR::new(buffer, self)
                 }
             }
         )+

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -619,7 +619,7 @@ macro_rules! serialdma {
             where
                 B: StaticWriteBuffer<Word = u8>,
             {
-                fn read(mut self, mut buffer: B) -> TransferW<B, Self> {
+                fn read<'b, 'p>(&'p mut self, buffer: &'b mut B) -> TransferW<'b, 'p, B, Self> {
                     // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
                     // until the end of the transfer.
                     let (ptr, len) = unsafe { buffer.static_write_buffer() };
@@ -646,7 +646,7 @@ macro_rules! serialdma {
             where
                 B: StaticReadBuffer<Word = u8>,
             {
-                fn write(mut self, buffer: B) -> TransferR<B, Self> {
+                fn write<'b, 'p>(&'p mut self, buffer: &'b B) -> TransferR<'b, 'p, B, Self> {
                     // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
                     // until the end of the transfer.
                     let (ptr, len) = unsafe { buffer.static_read_buffer() };

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -543,7 +543,7 @@ macro_rules! spi_dma {
         where
             B: StaticReadBuffer<Word = u8>,
         {
-            fn write(mut self, buffer: B) -> TransferR<B, Self> {
+            fn write<'b, 'p>(&'p mut self, buffer: &'b B) -> TransferR<'b, 'p, B, Self> {
                 // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
                 // until the end of the transfer.
                 let (ptr, len) = unsafe { buffer.static_read_buffer() };

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -43,7 +43,7 @@ use crate::afio::MAPR;
 use crate::dma::dma1::{C3, C5};
 #[cfg(feature = "connectivity")]
 use crate::dma::dma2::C2;
-use crate::dma::{Transfer, TransferPayload, Transmit, TxDma, R};
+use crate::dma::{TransferPayload, TransferR, Transmit, TxDma};
 use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
@@ -543,7 +543,7 @@ macro_rules! spi_dma {
         where
             B: StaticReadBuffer<Word = u8>,
         {
-            fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
+            fn write(mut self, buffer: B) -> TransferR<B, Self> {
                 // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
                 // until the end of the transfer.
                 let (ptr, len) = unsafe { buffer.static_read_buffer() };
@@ -578,7 +578,7 @@ macro_rules! spi_dma {
                 });
                 self.start();
 
-                Transfer::r(buffer, self)
+                TransferR::new(buffer, self)
             }
         }
     };


### PR DESCRIPTION
As we now use `StableDeref` from `embedded-dma`, shall DMA still take owned values of buffer and peripheral?
Or we can change API to take `& mut PAYLOAD`?