### PR TITLE
various i2c fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix > 2 byte i2c reads
+- Send stop after acknowledge errors on i2c
+- Fix i2c interactions after errors
+
 ## [v0.7.0]- 2020-10-17
 
 ### Breaking changes

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -533,6 +533,7 @@ where
                 self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
             }
             buffer_len => {
+                self.nb.i2c.cr1.modify(|_, w| w.ack().set_bit());
                 self.nb.i2c.sr1.read();
                 self.nb.i2c.sr2.read();
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -220,12 +220,16 @@ macro_rules! wait_for_flag {
         let sr1 = $i2c.sr1.read();
 
         if sr1.berr().bit_is_set() {
+            $i2c.sr1.write(|w| w.berr().clear_bit());
             Err(Other(Error::Bus))
         } else if sr1.arlo().bit_is_set() {
+            $i2c.sr1.write(|w| w.arlo().clear_bit());
             Err(Other(Error::Arbitration))
         } else if sr1.af().bit_is_set() {
+            $i2c.sr1.write(|w| w.af().clear_bit());
             Err(Other(Error::Acknowledge))
         } else if sr1.ovr().bit_is_set() {
+            $i2c.sr1.write(|w| w.ovr().clear_bit());
             Err(Other(Error::Overrun))
         } else if sr1.$flag().bit_is_set() {
             Ok(())


### PR DESCRIPTION
Fixes required to work with an AM2320 sensor; This sensor doesn't acknowledge the first i2c message sent to it, but it triggers it to wake up. This caused the i2c state to stay in an error state and the bus not to go idle.  This is fixed in the first two patches

Later on a multi (>2) byte read is necessary  to actually get the data; However the data didn't get properly acknowledged, fixed in the last patch.