### PR TITLE
SPI OpenDrain Alternate Pin support, and better SPI DMA example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Replace DMA buffer types with `Deref` ans `Unpin`
+
 ## [v0.6.1] - 2020-06-25
 
 ### Added

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -70,6 +70,11 @@ pub trait TransferPayload {
     fn stop(&mut self);
 }
 
+pub trait Transferable<BUFFER, DMA> {
+    fn is_done(&self) -> bool;
+    fn wait(self) -> (BUFFER, DMA);
+}
+
 pub struct Transfer<MODE, BUFFER, PAYLOAD> {
     _mode: PhantomData<MODE>,
     buffer: BUFFER,
@@ -128,7 +133,7 @@ macro_rules! dma {
 
                 use crate::pac::{$DMAX, dma1};
 
-                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferPayload};
+                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferPayload, Transferable};
                 use crate::rcc::{AHB, Enable};
 
                 pub struct Channels((), $(pub $CX),+);
@@ -294,15 +299,15 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> Transferable<BUFFER, RxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
                     where
                         RxDma<PAYLOAD, $CX>: TransferPayload,
                     {
-                        pub fn is_done(&self) -> bool {
+                        fn is_done(&self) -> bool {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
+                        fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
                             atomic::compiler_fence(Ordering::Acquire);
@@ -320,15 +325,15 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> Transferable<BUFFER, TxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
                     where
                         TxDma<PAYLOAD, $CX>: TransferPayload,
                     {
-                        pub fn is_done(&self) -> bool {
+                        fn is_done(&self) -> bool {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
+                        fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
                             atomic::compiler_fence(Ordering::Acquire);
@@ -496,10 +501,10 @@ where
     fn read(self, buffer: &'static mut B) -> Transfer<W, &'static mut B, Self>;
 }
 
-pub trait WriteDma<A, B, TS>: Transmit
+pub trait WriteDma<B, TS>: Transmit
 where
-    A: as_slice::AsSlice<Element = TS>,
-    B: Static<A>,
+    B: core::ops::Deref + 'static,
+    B::Target: as_slice::AsSlice<Element=TS> + Unpin,
     Self: core::marker::Sized,
 {
     fn write(self, buffer: B) -> Transfer<R, B, Self>;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -44,10 +44,13 @@ use core::sync::atomic::{self, Ordering};
 
 use crate::pac::{USART1, USART2, USART3};
 use core::convert::Infallible;
+
+use as_slice::AsSlice;
+
 use embedded_hal::serial::Write;
 
 use crate::afio::MAPR;
-use crate::dma::{dma1, CircBuffer, RxDma, Static, Transfer, TxDma, R, W};
+use crate::dma::{dma1, CircBuffer, RxDma, Transfer, TxDma, R, W};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::gpioc::{PC10, PC11};
@@ -637,12 +640,16 @@ macro_rules! serialdma {
                 }
             }
 
-            impl<A, B> crate::dma::WriteDma<A, B, u8> for $txdma where A: as_slice::AsSlice<Element=u8>, B: Static<A> {
+            impl<B> crate::dma::WriteDma<B, u8> for $txdma
+            where
+                B: core::ops::Deref + 'static,
+                B::Target: AsSlice<Element = u8> + Unpin,
+            {
                 fn write(mut self, buffer: B
                 ) -> Transfer<R, B, Self>
                 {
                     {
-                        let buffer = buffer.borrow().as_slice();
+                        let buffer = (*buffer).as_slice();
 
                         self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -41,7 +41,7 @@ use crate::pac::{SPI1, SPI2};
 
 use crate::afio::MAPR;
 use crate::dma::dma1::{C3, C5};
-use crate::dma::{Static, Transfer, TransferPayload, Transmit, TxDma, R};
+use crate::dma::{Transfer, TransferPayload, Transmit, TxDma, R};
 use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
@@ -450,14 +450,14 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<A, B, REMAP, PIN> crate::dma::WriteDma<A, B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
+        impl<B, REMAP, PIN> crate::dma::WriteDma<B, u8> for SpiTxDma<$SPIi, REMAP, PIN, $TCi>
         where
-            A: AsSlice<Element = u8>,
-            B: Static<A>,
+            B: core::ops::Deref + 'static,
+            B::Target: as_slice::AsSlice<Element = u8> + Unpin,
         {
             fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
                 {
-                    let buffer = buffer.borrow().as_slice();
+                    let buffer = buffer.as_slice();
                     self.channel.set_peripheral_address(
                         unsafe { &(*$SPIi::ptr()).dr as *const _ as u32 },
                         false,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -3,6 +3,8 @@
   To construct the SPI instances, use the `Spi::spiX` functions.
 
   The pin parameter is a tuple containing `(sck, miso, mosi)` which should be configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+  NOTE! As the SPI pins are 5V tolerant on many STM32F1xx devices, you may also configure the 'Alternate' (Output) pins as `Alternate<OpenDrain>`,
+  and then use pull-up resistors to access a 5V SPI bus without a level converter.
 
   You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
 
@@ -46,7 +48,7 @@ use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::{Alternate, Floating, Input, PushPull};
+use crate::gpio::{Alternate, Floating, Input, PushPull, OpenDrain};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 
@@ -134,8 +136,10 @@ macro_rules! remap {
             const REMAP: bool = $state;
         }
         impl Sck<$name> for $SCK<Alternate<PushPull>> {}
+        impl Sck<$name> for $SCK<Alternate<OpenDrain>> {}
         impl Miso<$name> for $MISO<Input<Floating>> {}
         impl Mosi<$name> for $MOSI<Alternate<PushPull>> {}
+        impl Mosi<$name> for $MOSI<Alternate<OpenDrain>> {}
     };
 }
 


### PR DESCRIPTION
This pull request adds support for configuring SPI Clock and Mosi pins as Alternate<OpenDrain>. This makes it possible to use external 5V Pull-Ups to interface 5V electronics without the need for any level converters (STM32F1xx have 5V tolerant SPI pins in many cases).
I also updated the SPI DMA example to showcase the following (not so obvious) additional use-cases:
- How to dynamically generate data into a buffer and transmit it (in stead of sending a constant string).
- How to pass an SpiTxDma instance to a function (or struct), which is a typical use case when creating drivers etc.
- How to return the Transfer instance from said function.
- How to send data multiple times; by returning buffer and spi_dma ownership.

Let me know if you spot any problems with these suggestions. Also be aware that I am somewhat of a noob in Rust, so this may very well be udder crap :-/ Thank you for your patience.