### PR TITLE
Added support for SPI Alternate<OpenDrain> configuration on Mosi and Sck pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for OpenDrain pin configuration on SPI CLK and MOSI pins
+
 ## [v0.7.0]- 2020-10-17
 
 ### Breaking changes

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -50,7 +50,7 @@ use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::{Alternate, Floating, Input, PushPull};
+use crate::gpio::{Alternate, Floating, Input, PushPull, OpenDrain};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -50,7 +50,7 @@ use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::{Alternate, Floating, Input, PushPull, OpenDrain};
+use crate::gpio::{Alternate, Floating, Input, OpenDrain, PushPull};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -3,6 +3,8 @@
   To construct the SPI instances, use the `Spi::spiX` functions.
 
   The pin parameter is a tuple containing `(sck, miso, mosi)` which should be configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+  As some STM32F1xx chips have 5V tolerant SPI pins, it is also possible to configure Sck and Mosi outputs as `Alternate<PushPull>`. Then
+  a simple Pull-Up to 5V can be used to use SPI on a 5V bus without a level shifter.
 
   You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
 
@@ -135,8 +137,10 @@ macro_rules! remap {
             const REMAP: bool = $state;
         }
         impl Sck<$name> for $SCK<Alternate<PushPull>> {}
+        impl Sck<$name> for $SCK<Alternate<OpenDrain>> {}
         impl Miso<$name> for $MISO<Input<Floating>> {}
         impl Mosi<$name> for $MOSI<Alternate<PushPull>> {}
+        impl Mosi<$name> for $MOSI<Alternate<OpenDrain>> {}
     };
 }
 


### PR DESCRIPTION
This patch allows for OpenDrain configuration on SPI Sck and Mosi pins. This in turn makes it possible to use the SPI interface on 5V bus'es using a simple 5V pull-up (no level shifter).