### PR TITLE
Re-implemented DMA Transferable Trait and added SPI DMA example which use pure abstract references

### DIFF
--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -11,6 +11,7 @@ use stm32f1xx_hal::{
     pac,
     prelude::*,
     spi::{Mode, Phase, Polarity, Spi},
+    dma::{TransferOperation}
 };
 
 #[entry]
@@ -49,7 +50,7 @@ fn main() -> ! {
     let spi_dma = spi.with_tx_dma(dma.5);
 
     // Start a DMA transfer
-    let transfer = spi_dma.write(b"hello, world");
+    let mut transfer = spi_dma.write(b"hello, world");
 
     // Wait for it to finnish. The transfer takes ownership over the SPI device
     // and the data being sent anb those things are returned by transfer.wait

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -64,16 +64,15 @@ pub trait TransferPayload {
 /// The Trait defines methods for checking if the operation is complete, or waiting for
 /// the operation to complete. The wait function is also used to return ownership of the
 /// transmission buffer and `TransferPayload` (An RxDma or TxDma wrapping a peripheral).
-pub trait Transferable<BUFFER, DMA>
-{
+pub trait Transferable<BUFFER, DMA> {
     /// Checks if a Transmission is complete
     fn is_done(&self) -> bool;
 
     /// Wait for transmission to complete
-    /// 
-    /// When the transmission is complete, the ownership of the buffer and the "Payload" 
+    ///
+    /// When the transmission is complete, the ownership of the buffer and the "Payload"
     /// (the instance that started the Transfer) is returned to the caller.
-    /// 
+    ///
     /// # Returns
     /// - Tuple containing the Transmitted buffer and the Payload (the instance initiating the transfer)
     fn wait(self) -> (BUFFER, DMA);

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -64,7 +64,7 @@ pub trait TransferPayload {
 /// The Trait defines methods for checking if the operation is complete, or waiting for
 /// the operation to complete. The wait function is also used to return ownership of the
 /// transmission buffer and `TransferPayload` (An RxDma or TxDma wrapping a peripheral).
-pub trait TransferOperation<BUFFER, DMA>
+pub trait Transferable<BUFFER, DMA>
 {
     /// Checks if a Transmission is complete
     fn is_done(&self) -> bool;
@@ -147,7 +147,7 @@ macro_rules! dma {
 
                 use crate::pac::{$DMAX, dma1};
 
-                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferOperation, TransferPayload};
+                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, Transferable, TransferPayload};
                 use crate::rcc::{AHB, Enable};
 
                 #[allow(clippy::manual_non_exhaustive)]
@@ -314,7 +314,7 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> TransferOperation<BUFFER, RxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> Transferable<BUFFER, RxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
                     where
                         RxDma<PAYLOAD, $CX>: TransferPayload,
                     {
@@ -352,7 +352,7 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> TransferOperation<BUFFER, TxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> Transferable<BUFFER, TxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
                     where
                         TxDma<PAYLOAD, $CX>: TransferPayload,
                     {

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -60,6 +60,25 @@ pub trait TransferPayload {
     fn stop(&mut self);
 }
 
+/// Trait implemented by `Transfer` to provide access to the DMA Transfer Operation.
+/// The Trait defines methods for checking if the operation is complete, or waiting for
+/// the operation to complete. The wait function is also used to return ownership of the
+/// transmission buffer and `TransferPayload` (An RxDma or TxDma wrapping a peripheral).
+pub trait TransferOperation<BUFFER, DMA>
+{
+    /// Checks if a Transmission is complete
+    fn is_done(&self) -> bool;
+
+    /// Wait for transmission to complete
+    /// 
+    /// When the transmission is complete, the ownership of the buffer and the "Payload" 
+    /// (the instance that started the Transfer) is returned to the caller.
+    /// 
+    /// # Returns
+    /// - Tuple containing the Transmitted buffer and the Payload (the instance initiating the transfer)
+    fn wait(self) -> (BUFFER, DMA);
+}
+
 pub struct Transfer<MODE, BUFFER, PAYLOAD>
 where
     PAYLOAD: TransferPayload,
@@ -128,7 +147,7 @@ macro_rules! dma {
 
                 use crate::pac::{$DMAX, dma1};
 
-                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferPayload};
+                use crate::dma::{CircBuffer, DmaExt, Error, Event, Half, Transfer, W, RxDma, TxDma, TransferOperation, TransferPayload};
                 use crate::rcc::{AHB, Enable};
 
                 #[allow(clippy::manual_non_exhaustive)]
@@ -295,15 +314,15 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> TransferOperation<BUFFER, RxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, RxDma<PAYLOAD, $CX>>
                     where
                         RxDma<PAYLOAD, $CX>: TransferPayload,
                     {
-                        pub fn is_done(&self) -> bool {
+                        fn is_done(&self) -> bool {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
+                        fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
                             atomic::compiler_fence(Ordering::Acquire);
@@ -333,15 +352,15 @@ macro_rules! dma {
                         }
                     }
 
-                    impl<BUFFER, PAYLOAD, MODE> Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
+                    impl<BUFFER, PAYLOAD, MODE> TransferOperation<BUFFER, TxDma<PAYLOAD, $CX>> for Transfer<MODE, BUFFER, TxDma<PAYLOAD, $CX>>
                     where
                         TxDma<PAYLOAD, $CX>: TransferPayload,
                     {
-                        pub fn is_done(&self) -> bool {
+                        fn is_done(&self) -> bool {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
+                        fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
                             atomic::compiler_fence(Ordering::Acquire);

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -50,7 +50,7 @@ use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::{Alternate, Floating, Input, PushPull};
+use crate::gpio::{Alternate, Floating, Input, PushPull, OpenDrain};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -50,7 +50,7 @@ use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::{Alternate, Floating, Input, PushPull, OpenDrain};
+use crate::gpio::{Alternate, Floating, Input, OpenDrain, PushPull};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -3,6 +3,8 @@
   To construct the SPI instances, use the `Spi::spiX` functions.
 
   The pin parameter is a tuple containing `(sck, miso, mosi)` which should be configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+  As some STM32F1xx chips have 5V tolerant SPI pins, it is also possible to configure Sck and Mosi outputs as `Alternate<PushPull>`. Then
+  a simple Pull-Up to 5V can be used to use SPI on a 5V bus without a level shifter.
 
   You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
 
@@ -135,8 +137,10 @@ macro_rules! remap {
             const REMAP: bool = $state;
         }
         impl Sck<$name> for $SCK<Alternate<PushPull>> {}
+        impl Sck<$name> for $SCK<Alternate<OpenDrain>> {}
         impl Miso<$name> for $MISO<Input<Floating>> {}
         impl Mosi<$name> for $MOSI<Alternate<PushPull>> {}
+        impl Mosi<$name> for $MOSI<Alternate<OpenDrain>> {}
     };
 }
 


### PR DESCRIPTION
For some reason the Transferable trait has been removed in 0.7.0. This seems to make it impossible to create functions which takes an abstract SPI DMA reference and transmit data via it. A real life use-case for this is in multipurpose drivers, which should work with any SPI peripheral and possibly share it with other drivers.
I've also improved the SPI-DMA example to showcase this exact use case. As a side perk, this will break if pure abstract referencing is ever broken. Thus hopefully insuring this feature is retained in the HAL for the Future.
NOTE! I really think this DMA scheme should be defined on a higher level, and be shared across all the HALs.
Also NOTE! I am very much a noob in Rust (though I have a long experience in MCU/Embedded development in C), so please go easy on me if this is udder crap :)