### PR TITLE
Use modify instead of write for clearing sr1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Remove `RemapStruct`s. [#462] [#506] [#509]
 - Use independent `Spi` and `SpiSlave` structures instead of `OP` generic [#462]
 - Take `&Clocks` instead of `Clocks` [#498]
-- Temporary replace `stm32f1` with `stm32f1-staging` [#503]
+- Temporary replace `stm32f1` with `stm32f1-staging` v0.17.1 [#503]
 - `Spi` now takes `Option<PIN>` for `SCK`, `MISO`, `MOSI` [#514]
 - move `Qei` mod inside `pwm_input` mod [#516]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 edition = "2021"
 rust-version = "1.59"
 
-authors = ["Jorge Aparicio <jorge@japaric.io>", "Daniel Egger <daniel@eggers-club.de>"]
+authors = [
+    "Jorge Aparicio <jorge@japaric.io>",
+    "Daniel Egger <daniel@eggers-club.de>",
+]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL for the STM32F1xx family of microcontrollers"
 keywords = ["arm", "cortex-m", "stm32", "hal"]
@@ -33,7 +36,7 @@ vcell = "0.1.3"
 
 [dependencies.stm32f1]
 package = "stm32f1-staging"
-version = "0.16.0"
+version = "0.17.1"
 features = ["atomics"]
 
 [dependencies.embedded-hal-02]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -256,7 +256,7 @@ macro_rules! adc_hal {
 
                 #[inline(always)]
                 pub fn set_external_trigger(&mut self, trigger: crate::pac::$adc::cr2::EXTSEL) {
-                    self.rb.cr2().modify(|_, w| w.extsel().variant(trigger))
+                    self.rb.cr2().modify(|_, w| w.extsel().variant(trigger));
                 }
 
                 fn power_up(&mut self) {
@@ -336,7 +336,7 @@ macro_rules! adc_hal {
                         16 => self.rb.smpr1().modify(|_, w| w.smp16().set(sample_time)),
                         17 => self.rb.smpr1().modify(|_, w| w.smp17().set(sample_time)),
                         _ => unreachable!(),
-                    }
+                    };
                 }
 
                 fn set_regular_sequence (&mut self, channels: &[u8]) {

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -30,7 +30,7 @@ impl Crc {
     }
 
     pub fn write(&mut self, val: u32) {
-        self.crc.dr().write(|w| w.dr().set(val))
+        self.crc.dr().write(|w| w.dr().set(val));
     }
 
     pub fn reset(&self) {

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -165,14 +165,14 @@ impl<DMA: DmaExt, const C: u8> Ch<DMA, C> {
         match event {
             Event::HalfTransfer => self.ch().cr().modify(|_, w| w.htie().set_bit()),
             Event::TransferComplete => self.ch().cr().modify(|_, w| w.tcie().set_bit()),
-        }
+        };
     }
 
     pub fn unlisten(&mut self, event: Event) {
         match event {
             Event::HalfTransfer => self.ch().cr().modify(|_, w| w.htie().clear_bit()),
             Event::TransferComplete => self.ch().cr().modify(|_, w| w.tcie().clear_bit()),
-        }
+        };
     }
 
     pub fn ch(&mut self) -> &pac::dma1::CH {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -532,14 +532,14 @@ impl<const P: char, const N: u8, MODE> Pin<P, N, MODE> {
     fn _set_high(&mut self) {
         // NOTE(unsafe) atomic write to a stateless register
         let gpio = unsafe { &(*gpiox::<P>()) };
-        gpio.bsrr().write(|w| w.bs(N).set_bit())
+        gpio.bsrr().write(|w| w.bs(N).set_bit());
     }
 
     #[inline(always)]
     fn _set_low(&mut self) {
         // NOTE(unsafe) atomic write to a stateless register
         let gpio = unsafe { &(*gpiox::<P>()) };
-        gpio.bsrr().write(|w| w.br(N).set_bit())
+        gpio.bsrr().write(|w| w.br(N).set_bit());
     }
 
     #[inline(always)]
@@ -966,7 +966,7 @@ where
                 } else {
                     w.br(N).set_bit()
                 }
-            })
+            });
         }
 
         match N {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -271,6 +271,9 @@ impl<I2C: Instance> I2c<I2C> {
 
     /// Generate START condition
     fn send_start(&mut self) {
+        // Clear all pending error bits
+        // NOTE(unsafe): Writing 0 clears the r/w bits and has no effect on the r bits
+        self.i2c.sr1().write(|w| unsafe { w.bits(0) });
         self.i2c.cr1().modify(|_, w| w.start().set_bit());
     }
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -213,7 +213,7 @@ impl CFGR {
                 } else {
                     0b010
                 })
-            })
+            });
         }
 
         let rcc = unsafe { &*RCC::ptr() };

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -128,7 +128,7 @@ impl Rtc<RtcClkLse> {
             w.rtcen().set_bit();
             // Set the source of the RTC to LSE
             w.rtcsel().lse()
-        })
+        });
     }
 }
 
@@ -202,7 +202,7 @@ impl Rtc<RtcClkLsi> {
             w.rtcen().set_bit();
             // Set the source of the RTC to LSI
             w.rtcsel().lsi()
-        })
+        });
     }
 }
 
@@ -280,7 +280,7 @@ impl Rtc<RtcClkHseDiv128> {
             w.rtcen().set_bit();
             // Set the source of the RTC to HSE/128
             w.rtcsel().hse()
-        })
+        });
     }
 }
 
@@ -365,22 +365,30 @@ impl<CS> Rtc<CS> {
 
     /// Enables triggering the RTC interrupt every time the RTC counter is increased
     pub fn listen_seconds(&mut self) {
-        self.perform_write(|s| s.regs.crh().modify(|_, w| w.secie().set_bit()))
+        self.perform_write(|s| {
+            s.regs.crh().modify(|_, w| w.secie().set_bit());
+        })
     }
 
     /// Disables the RTC second interrupt
     pub fn unlisten_seconds(&mut self) {
-        self.perform_write(|s| s.regs.crh().modify(|_, w| w.secie().clear_bit()))
+        self.perform_write(|s| {
+            s.regs.crh().modify(|_, w| w.secie().clear_bit());
+        })
     }
 
     /// Clears the RTC second interrupt flag
     pub fn clear_second_flag(&mut self) {
-        self.perform_write(|s| s.regs.crl().modify(|_, w| w.secf().clear_bit()))
+        self.perform_write(|s| {
+            s.regs.crl().modify(|_, w| w.secf().clear_bit());
+        })
     }
 
     /// Clears the RTC alarm interrupt flag
     pub fn clear_alarm_flag(&mut self) {
-        self.perform_write(|s| s.regs.crl().modify(|_, w| w.alrf().clear_bit()))
+        self.perform_write(|s| {
+            s.regs.crl().modify(|_, w| w.alrf().clear_bit());
+        })
     }
 
     /**

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -325,7 +325,7 @@ macro_rules! hal {
                 }
                 #[inline(always)]
                 unsafe fn set_auto_reload_unchecked(&mut self, arr: u32) {
-                    self.arr().write(|w| w.bits(arr))
+                    self.arr().write(|w| w.bits(arr));
                 }
                 #[inline(always)]
                 fn set_auto_reload(&mut self, arr: u32) -> Result<(), Error> {
@@ -445,7 +445,7 @@ macro_rules! with_pwm {
                 let tim = unsafe { &*<$TIM>::ptr() };
                 #[allow(unused_unsafe)]
                 if channel < Self::CH_NUMBER {
-                    tim.ccr(channel as usize).write(|w| unsafe { w.bits(value) })
+                    tim.ccr(channel as usize).write(|w| unsafe { w.bits(value) });
                 }
             }
 
@@ -493,7 +493,7 @@ macro_rules! with_pwm {
                 let tim = unsafe { &*<$TIM>::ptr() };
                 #[allow(unused_unsafe)]
                 if channel < Self::CH_NUMBER {
-                    tim.ccr(channel as usize).write(|w| unsafe { w.bits(value) })
+                    tim.ccr(channel as usize).write(|w| unsafe { w.bits(value) });
                 }
             }
 
@@ -539,7 +539,7 @@ macro_rules! with_pwm {
             #[inline(always)]
             fn set_cc_value(channel: u8, value: u32) {
                 let tim = unsafe { &*<$TIM>::ptr() };
-                tim.ccr(channel as usize).write(|w| unsafe { w.bits(value) })
+                tim.ccr(channel as usize).write(|w| unsafe { w.bits(value) });
             }
 
             #[inline(always)]


### PR DESCRIPTION
As per the discussion in #282 

This seems better, but it also leaves the possibility of some flags not being cleared if multiple flags are raised at the same time. Is that something that can even happen, and how should we deal with it then?

CC: @Disasm 
