### PR TITLE
Use CamelCase for gpio::Edge enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+- Rename `gpio::Edge::{RISING, FALLING, RISING_FALLING}` to `Rising`, `Falling`, `RisingFalling`, respectively
+
 ### Added
 
 - LSB/MSB bit format selection for `SPI`

--- a/examples/exti.rs
+++ b/examples/exti.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         let int_pin = unsafe { &mut *INT_PIN.as_mut_ptr() };
         *int_pin = gpioa.pa7.into_floating_input(&mut gpioa.crl);
         int_pin.make_interrupt_source(&mut afio);
-        int_pin.trigger_on_edge(&p.EXTI, Edge::RISING_FALLING);
+        int_pin.trigger_on_edge(&p.EXTI, Edge::RisingFalling);
         int_pin.enable_interrupt(&p.EXTI);
     } // initialization ends here
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -155,14 +155,11 @@ pub enum State {
     Low,
 }
 
-// Using SCREAMING_SNAKE_CASE to be consistent with other HALs
-// see 59b2740 and #125 for motivation
-#[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq)]
 pub enum Edge {
-    RISING,
-    FALLING,
-    RISING_FALLING,
+    Rising,
+    Falling,
+    RisingFalling,
 }
 
 /// External Interrupt Pin
@@ -395,15 +392,15 @@ macro_rules! gpio {
                 /// Generate interrupt on rising edge, falling edge or both
                 fn trigger_on_edge(&mut self, exti: &EXTI, edge: Edge) {
                     match edge {
-                        Edge::RISING => {
+                        Edge::Rising => {
                             exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::FALLING => {
+                        Edge::Falling => {
                             exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::RISING_FALLING => {
+                        Edge::RisingFalling => {
                             exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         }
@@ -912,15 +909,15 @@ macro_rules! gpio {
                     /// Generate interrupt on rising edge, falling edge or both
                     fn trigger_on_edge(&mut self, exti: &EXTI, edge: Edge) {
                         match edge {
-                            Edge::RISING => {
+                            Edge::Rising => {
                                 exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::FALLING => {
+                            Edge::Falling => {
                                 exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::RISING_FALLING => {
+                            Edge::RisingFalling => {
                                 exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                             }


### PR DESCRIPTION
ref: [h7xx](https://github.com/stm32-rs/stm32h7xx-hal/pull/179), [l4xx](https://github.com/stm32-rs/stm32l4xx-hal/pull/187), [f4xx](https://github.com/stm32-rs/stm32f4xx-hal/pull/250), [f7xx](https://github.com/stm32-rs/stm32f7xx-hal/pull/111)
