### PR TITLE
Timer additions: raw access to prescaler and auto-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - LSB/MSB bit format selection for `SPI`
 - Support for CAN peripherals with the `bxcan` crate
 - Add DAC, UART4, UART5 clock in RCC for the f103 high density line
+- `start_raw` function and `arr`, `bsc` getters for more fine grained
+  control over the timer.
 
 ### Fixed
 - Fix > 2 byte i2c reads

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -442,21 +442,8 @@ macro_rules! hal {
                 where
                     T: Into<Hertz>,
                 {
-                    // pause
-                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
-
                     let (psc, arr) = compute_arr_presc(timeout.into().0, self.clk.0);
-                    self.tim.psc.write(|w| w.psc().bits(psc) );
-
-                    // TODO: Remove this `allow` once this field is made safe for stm32f100
-                    #[allow(unused_unsafe)]
-                    self.tim.arr.write(|w| unsafe { w.arr().bits(arr) });
-
-                    // Trigger an update event to load the prescaler value to the clock
-                    self.reset();
-
-                    // start counter
-                    self.tim.cr1.modify(|_, w| w.cen().set_bit());
+                    self.restart_raw(psc, arr);
                 }
 
                 fn wait(&mut self) -> nb::Result<(), Void> {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -360,8 +360,6 @@ macro_rules! hal {
                     // pause
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
 
-                    let timer_clock = self.clk;
-
                     self.tim.psc.write(|w| w.psc().bits(psc) );
                     self.tim.arr.write(|w| w.arr().bits(arr) );
 
@@ -372,12 +370,15 @@ macro_rules! hal {
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }
 
-                pub fn clk(&mut self) -> u32
-                {
-                    self.clk.0
+                pub fn psc(&self) -> u16 {
+                    self.tim.psc.read().psc().bits()
                 }
 
-                pub fn cnt(&mut self) -> u16 {
+                pub fn arr(&self) -> u16 {
+                    self.tim.arr.read().arr().bits()
+                }
+
+                pub fn cnt(&self) -> u16 {
                     self.tim.cnt.read().cnt().bits()
                 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -363,7 +363,10 @@ macro_rules! hal {
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
 
                     self.tim.psc.write(|w| w.psc().bits(psc) );
-                    self.tim.arr.write(|w| w.arr().bits(arr) );
+
+                    // TODO: Remove this `allow` once this field is made safe for stm32f100
+                    #[allow(unused_unsafe)]
+                    self.tim.arr.write(|w| unsafe { w.arr().bits(arr) });
 
                     // Trigger an update event to load the prescaler value to the clock
                     self.reset();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -314,11 +314,12 @@ macro_rules! hal {
                     }
                 )?
 
+                /// Starts the timer in count down mode with user-defined prescaler and auto-reload register
                 pub fn start_raw(self, psc: u16, arr: u16) -> CountDownTimer<$TIMX>
                 {
                     let Self { tim, clk } = self;
                     let mut timer = CountDownTimer { tim, clk };
-                    timer.start_raw(psc, arr);
+                    timer.restart_raw(psc, arr);
                     timer
                 }
 
@@ -355,7 +356,8 @@ macro_rules! hal {
                     }
                 }
 
-                pub fn start_raw(&mut self, psc: u16, arr: u16)
+                /// Restarts the timer in count down mode with user-defined prescaler and auto-reload register
+                pub fn restart_raw(&mut self, psc: u16, arr: u16)
                 {
                     // pause
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
@@ -370,14 +372,17 @@ macro_rules! hal {
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }
 
+                /// Retrieves the content of the prescaler register. The real prescaler is this value + 1.
                 pub fn psc(&self) -> u16 {
                     self.tim.psc.read().psc().bits()
                 }
 
+                /// Retrieves the value of the auto-reload register.
                 pub fn arr(&self) -> u16 {
                     self.tim.arr.read().arr().bits()
                 }
 
+                /// Retrieves the current timer counter value.
                 pub fn cnt(&self) -> u16 {
                     self.tim.cnt.read().cnt().bits()
                 }


### PR DESCRIPTION
I frequently use timers for precise measurements, and unfortunately, `start_countdown` performs intransparent calculations which can introduce rounding errors.

This PR adds the capability to set and read the raw prescaler and auto-reload values, also we can now read the timer's count; this is useful when ARR is set to `0xFFFF`, i.e. the timer is just "free-running".