### PR TITLE
USB-SERIAL_NOTES: add note to inform user to build in release mode

### DIFF
--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -1,11 +1,11 @@
 //! CDC-ACM serial port example using polling in a busy loop.
 //! Target board: Blue Pill
-///
-/// Note:
-/// When building this since this is a larger program,
-/// one would need to build it using release profile
-/// since debug profiles generates artifacts that
-/// cause FLASH overflow errors due to their size
+//!
+//! Note:
+//! When building this since this is a larger program,
+//! one would need to build it using release profile
+//! since debug profiles generates artifacts that
+//! cause FLASH overflow errors due to their size
 #![no_std]
 #![no_main]
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -1,5 +1,11 @@
 //! CDC-ACM serial port example using polling in a busy loop.
 //! Target board: Blue Pill
+///
+/// Note:
+/// When building this since this is a larger program,
+/// one would need to build it using release profile
+/// since debug profiles generates artifacts that
+/// cause FLASH overflow errors due to their size
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
Fixes #286 

## Changes Proposed 
- [x] Add note on why one needs to build the example using the release profile

