### PR TITLE
Add GPIOF/GPIOG support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - LSB/MSB bit format selection for `SPI`
 - Support for CAN peripherals with the `bxcan` crate
 - Add DAC, UART4, UART5 clock in RCC for the f103 high density line
+- Add GPIOF/GPIOG support for high/xl density lines
 
 ### Fixed
 - Fix > 2 byte i2c reads

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1228,6 +1228,16 @@ macro_rules! impl_pxx {
     }
 }
 
+#[cfg(not(any(feature = "xl", feature = "high")))]
+impl_pxx! {
+    (gpioa::PAx),
+    (gpiob::PBx),
+    (gpioc::PCx),
+    (gpiod::PDx),
+    (gpioe::PEx)
+}
+
+#[cfg(any(feature = "xl", feature = "high"))]
 impl_pxx! {
     (gpioa::PAx),
     (gpiob::PBx),
@@ -1333,6 +1343,7 @@ gpio!(GPIOE, gpioe, gpioa, PEx, 4, [
     PE15: (pe15, 15, Input<Floating>, CRH, exticr4),
 ]);
 
+#[cfg(any(feature = "xl", feature = "high"))]
 gpio!(GPIOF, gpiof, gpioa, PFx, 5, [
     PF0:  (pf0, 0, Input<Floating>, CRL, exticr1),
     PF1:  (pf1, 1, Input<Floating>, CRL, exticr1),
@@ -1352,6 +1363,7 @@ gpio!(GPIOF, gpiof, gpioa, PFx, 5, [
     PF15: (pf15, 15, Input<Floating>, CRH, exticr4),
 ]);
 
+#[cfg(any(feature = "xl", feature = "high"))]
 gpio!(GPIOG, gpiog, gpioa, PGx, 6, [
     PG0:  (pg0, 0, Input<Floating>, CRL, exticr1),
     PG1:  (pg1, 1, Input<Floating>, CRL, exticr1),

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1233,7 +1233,9 @@ impl_pxx! {
     (gpiob::PBx),
     (gpioc::PCx),
     (gpiod::PDx),
-    (gpioe::PEx)
+    (gpioe::PEx),
+    (gpiof::PFx),
+    (gpiog::PGx)
 }
 
 gpio!(GPIOA, gpioa, gpioa, PAx, 0, [
@@ -1329,4 +1331,42 @@ gpio!(GPIOE, gpioe, gpioa, PEx, 4, [
     PE13: (pe13, 13, Input<Floating>, CRH, exticr4),
     PE14: (pe14, 14, Input<Floating>, CRH, exticr4),
     PE15: (pe15, 15, Input<Floating>, CRH, exticr4),
+]);
+
+gpio!(GPIOF, gpiof, gpioa, PFx, 5, [
+    PF0:  (pf0, 0, Input<Floating>, CRL, exticr1),
+    PF1:  (pf1, 1, Input<Floating>, CRL, exticr1),
+    PF2:  (pf2, 2, Input<Floating>, CRL, exticr1),
+    PF3:  (pf3, 3, Input<Floating>, CRL, exticr1),
+    PF4:  (pf4, 4, Input<Floating>, CRL, exticr2),
+    PF5:  (pf5, 5, Input<Floating>, CRL, exticr2),
+    PF6:  (pf6, 6, Input<Floating>, CRL, exticr2),
+    PF7:  (pf7, 7, Input<Floating>, CRL, exticr2),
+    PF8:  (pf8, 8, Input<Floating>, CRH, exticr3),
+    PF9:  (pf9, 9, Input<Floating>, CRH, exticr3),
+    PF10: (pf10, 10, Input<Floating>, CRH, exticr3),
+    PF11: (pf11, 11, Input<Floating>, CRH, exticr3),
+    PF12: (pf12, 12, Input<Floating>, CRH, exticr4),
+    PF13: (pf13, 13, Input<Floating>, CRH, exticr4),
+    PF14: (pf14, 14, Input<Floating>, CRH, exticr4),
+    PF15: (pf15, 15, Input<Floating>, CRH, exticr4),
+]);
+
+gpio!(GPIOG, gpiog, gpioa, PGx, 6, [
+    PG0:  (pg0, 0, Input<Floating>, CRL, exticr1),
+    PG1:  (pg1, 1, Input<Floating>, CRL, exticr1),
+    PG2:  (pg2, 2, Input<Floating>, CRL, exticr1),
+    PG3:  (pg3, 3, Input<Floating>, CRL, exticr1),
+    PG4:  (pg4, 4, Input<Floating>, CRL, exticr2),
+    PG5:  (pg5, 5, Input<Floating>, CRL, exticr2),
+    PG6:  (pg6, 6, Input<Floating>, CRL, exticr2),
+    PG7:  (pg7, 7, Input<Floating>, CRL, exticr2),
+    PG8:  (pg8, 8, Input<Floating>, CRH, exticr3),
+    PG9:  (pg9, 9, Input<Floating>, CRH, exticr3),
+    PG10: (pg10, 10, Input<Floating>, CRH, exticr3),
+    PG11: (pg11, 11, Input<Floating>, CRH, exticr3),
+    PG12: (pg12, 12, Input<Floating>, CRH, exticr4),
+    PG13: (pg13, 13, Input<Floating>, CRH, exticr4),
+    PG14: (pg14, 14, Input<Floating>, CRH, exticr4),
+    PG15: (pg15, 15, Input<Floating>, CRH, exticr4),
 ]);

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -669,6 +669,8 @@ bus! {
     GPIOC => (APB2, iopcen, iopcrst),
     GPIOD => (APB2, iopden, iopdrst),
     GPIOE => (APB2, iopeen, ioperst),
+    GPIOF => (APB2, iopfen, iopfrst),
+    GPIOG => (APB2, iopgen, iopgrst),
     I2C1 => (APB1, i2c1en, i2c1rst),
     I2C2 => (APB1, i2c2en, i2c2rst),
     SPI1 => (APB2, spi1en, spi1rst),

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -669,8 +669,6 @@ bus! {
     GPIOC => (APB2, iopcen, iopcrst),
     GPIOD => (APB2, iopden, iopdrst),
     GPIOE => (APB2, iopeen, ioperst),
-    GPIOF => (APB2, iopfen, iopfrst),
-    GPIOG => (APB2, iopgen, iopgrst),
     I2C1 => (APB1, i2c1en, i2c1rst),
     I2C2 => (APB1, i2c2en, i2c2rst),
     SPI1 => (APB2, spi1en, spi1rst),
@@ -679,6 +677,12 @@ bus! {
     USART2 => (APB1, usart2en, usart2rst),
     USART3 => (APB1, usart3en, usart3rst),
     WWDG => (APB1, wwdgen, wwdgrst),
+}
+
+#[cfg(any(feature = "xl", feature = "high"))]
+bus! {
+    GPIOF => (APB2, iopfen, iopfrst),
+    GPIOG => (APB2, iopgen, iopgrst),
 }
 
 #[cfg(any(feature = "high", feature = "connectivity"))]


### PR DESCRIPTION
Related issue #288

Seems like high/xl density lines of different device series have pin count 80/112. 
So it's probably good enough to feature-gate like that.