### PR TITLE
Fix Flash erase verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Send stop after acknowledge errors on i2c
 - Fix i2c interactions after errors
 - Fix SPI3 alternate function remapping.
+- Fix flash erase verification
 
 ### Changed
 - Use `cortex-m-rtic` instead of `cortex-m-rtfm` in the examples

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -170,7 +170,7 @@ impl<'a> FlashWriter<'a> {
                 // 'start_offset' was.
                 let size = self.sector_sz.kbytes() as u32;
                 let start = start_offset & !(size - 1);
-                for idx in start..start + size {
+                for idx in (start..start + size).step_by(2) {
                     let write_address = (FLASH_START + idx as u32) as *const u16;
                     let verify: u16 = unsafe { core::ptr::read_volatile(write_address) };
                     if verify != 0xFFFF {


### PR DESCRIPTION
Needs step_by(2) to avoid accessing one extra byte on a next block, which will fail the verification if that byte is not 0xff. Also avoid unnecessary unaligned checks of u16 on odd addresses.

Update CHANGELOG.md

cast-0.2.4 is temporarily broken on 32-bit platforms - https://github.com/japaric/cast.rs/pull/27
