### PR TITLE
Add DMA RX and RX/TX support to SPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for CAN peripherals with the `bxcan` crate
 - Add DAC, UART4, UART5 clock in RCC for the f103 high density line
 - `start_raw` function and `arr`, `bsc` getters for more fine grained
-  control over the timer.
+  control over the timer
+- Added RxTxDma support support to the DMA infrastructure
+- Added DMA receive support for `SPI`
 
 ### Fixed
 - Fix > 2 byte i2c reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   control over the timer
 - Added RxTxDma support support to the DMA infrastructure
 - Added DMA receive support for `SPI`
+- Added `release` functions to SPI DMA
 
 ### Fixed
 - Fix > 2 byte i2c reads
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Use `cortex-m-rtic` instead of `cortex-m-rtfm` in the examples
+- Enable SPI DMA in `with_tx_dma`, not in `SpiTxDma::start`
 
 ## [v0.7.0]- 2020-10-17
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,6 +4,7 @@ pub use crate::crc::CrcExt as _stm32_hal_crc_CrcExt;
 pub use crate::dma::CircReadDma as _stm32_hal_dma_CircReadDma;
 pub use crate::dma::DmaExt as _stm32_hal_dma_DmaExt;
 pub use crate::dma::ReadDma as _stm32_hal_dma_ReadDma;
+pub use crate::dma::ReadWriteDma as _stm32_hal_dma_ReadWriteDma;
 pub use crate::dma::WriteDma as _stm32_hal_dma_WriteDma;
 pub use crate::flash::FlashExt as _stm32_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32_hal_gpio_GpioExt;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -552,7 +552,11 @@ pub type SpiRxTxDma<SPI, REMAP, PINS, RXCHANNEL, TXCHANNEL> =
     RxTxDma<Spi<SPI, REMAP, PINS, u8>, RXCHANNEL, TXCHANNEL>;
 
 macro_rules! spi_dma {
-    ($SPIi:ident, $RCi:ty, $TCi:ty) => {
+    ($SPIi:ident, $RCi:ty, $TCi:ty, $rxdma:ident, $txdma:ident, $rxtxdma:ident) => {
+        pub type $rxdma<REMAP, PINS> = SpiRxDma<$SPIi, REMAP, PINS, $RCi>;
+        pub type $txdma<REMAP, PINS> = SpiTxDma<$SPIi, REMAP, PINS, $TCi>;
+        pub type $rxtxdma<REMAP, PINS> = SpiRxTxDma<$SPIi, REMAP, PINS, $RCi, $TCi>;
+
         impl<REMAP, PINS> Transmit for SpiTxDma<$SPIi, REMAP, PINS, $TCi> {
             type TxChannel = $TCi;
             type ReceivedWord = u8;
@@ -835,7 +839,7 @@ macro_rules! spi_dma {
     };
 }
 
-spi_dma!(SPI1, dma1::C2, dma1::C3);
-spi_dma!(SPI2, dma1::C4, dma1::C5);
+spi_dma!(SPI1, dma1::C2, dma1::C3, Spi1RxDma, Spi1TxDma, Spi1RxTxDma);
+spi_dma!(SPI2, dma1::C4, dma1::C5, Spi2RxDma, Spi2TxDma, Spi2RxTxDma);
 #[cfg(feature = "connectivity")]
-spi_dma!(SPI3, dma2::C1, dma2::C2);
+spi_dma!(SPI3, dma2::C1, dma2::C2, Spi3RxDma, Spi3TxDma, Spi3RxTxDma);

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -546,14 +546,10 @@ where
 
 // DMA
 
-pub struct SpiPayload<SPI, REMAP, PINS> {
-    spi: Spi<SPI, REMAP, PINS, u8>,
-}
-
-pub type SpiTxDma<SPI, REMAP, PINS, CHANNEL> = TxDma<SpiPayload<SPI, REMAP, PINS>, CHANNEL>;
-pub type SpiRxDma<SPI, REMAP, PINS, CHANNEL> = RxDma<SpiPayload<SPI, REMAP, PINS>, CHANNEL>;
+pub type SpiTxDma<SPI, REMAP, PINS, CHANNEL> = TxDma<Spi<SPI, REMAP, PINS, u8>, CHANNEL>;
+pub type SpiRxDma<SPI, REMAP, PINS, CHANNEL> = RxDma<Spi<SPI, REMAP, PINS, u8>, CHANNEL>;
 pub type SpiRxTxDma<SPI, REMAP, PINS, RXCHANNEL, TXCHANNEL> =
-    RxTxDma<SpiPayload<SPI, REMAP, PINS>, RXCHANNEL, TXCHANNEL>;
+    RxTxDma<Spi<SPI, REMAP, PINS, u8>, RXCHANNEL, TXCHANNEL>;
 
 macro_rules! spi_dma {
     ($SPIi:ident, $RCi:ty, $TCi:ty) => {
@@ -580,13 +576,17 @@ macro_rules! spi_dma {
         impl<REMAP, PINS> Spi<$SPIi, REMAP, PINS, u8> {
             pub fn with_tx_dma(self, channel: $TCi) -> SpiTxDma<$SPIi, REMAP, PINS, $TCi> {
                 self.spi.cr2.modify(|_, w| w.txdmaen().set_bit());
-                let payload = SpiPayload { spi: self };
-                SpiTxDma { payload, channel }
+                SpiTxDma {
+                    payload: self,
+                    channel,
+                }
             }
             pub fn with_rx_dma(self, channel: $RCi) -> SpiRxDma<$SPIi, REMAP, PINS, $RCi> {
                 self.spi.cr2.modify(|_, w| w.rxdmaen().set_bit());
-                let payload = SpiPayload { spi: self };
-                SpiRxDma { payload, channel }
+                SpiRxDma {
+                    payload: self,
+                    channel,
+                }
             }
             pub fn with_rx_tx_dma(
                 self,
@@ -596,9 +596,8 @@ macro_rules! spi_dma {
                 self.spi
                     .cr2
                     .modify(|_, w| w.rxdmaen().set_bit().txdmaen().set_bit());
-                let payload = SpiPayload { spi: self };
                 SpiRxTxDma {
-                    payload,
+                    payload: self,
                     rxchannel,
                     txchannel,
                 }
@@ -608,16 +607,16 @@ macro_rules! spi_dma {
         impl<REMAP, PINS> SpiTxDma<$SPIi, REMAP, PINS, $TCi> {
             pub fn release(self) -> (Spi<$SPIi, REMAP, PINS, u8>, $TCi) {
                 let SpiTxDma { payload, channel } = self;
-                payload.spi.spi.cr2.modify(|_, w| w.txdmaen().clear_bit());
-                (payload.spi, channel)
+                payload.spi.cr2.modify(|_, w| w.txdmaen().clear_bit());
+                (payload, channel)
             }
         }
 
         impl<REMAP, PINS> SpiRxDma<$SPIi, REMAP, PINS, $RCi> {
             pub fn release(self) -> (Spi<$SPIi, REMAP, PINS, u8>, $RCi) {
                 let SpiRxDma { payload, channel } = self;
-                payload.spi.spi.cr2.modify(|_, w| w.rxdmaen().clear_bit());
-                (payload.spi, channel)
+                payload.spi.cr2.modify(|_, w| w.rxdmaen().clear_bit());
+                (payload, channel)
             }
         }
 
@@ -630,10 +629,9 @@ macro_rules! spi_dma {
                 } = self;
                 payload
                     .spi
-                    .spi
                     .cr2
                     .modify(|_, w| w.rxdmaen().clear_bit().txdmaen().clear_bit());
-                (payload.spi, rxchannel, txchannel)
+                (payload, rxchannel, txchannel)
             }
         }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -42,10 +42,10 @@ use crate::pac::SPI3;
 use crate::pac::{SPI1, SPI2};
 
 use crate::afio::MAPR;
-use crate::dma::dma1::{C3, C5};
+use crate::dma::dma1;
 #[cfg(feature = "connectivity")]
-use crate::dma::dma2::C2;
-use crate::dma::{Transfer, TransferPayload, Transmit, TxDma, R};
+use crate::dma::dma2;
+use crate::dma::{Receive, RxDma, RxTxDma, Transfer, TransferPayload, Transmit, TxDma, R, W};
 use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
@@ -55,7 +55,7 @@ use crate::rcc::{Clocks, Enable, GetBusFreq, Reset, APB1, APB2};
 use crate::time::Hertz;
 
 use core::sync::atomic::{self, Ordering};
-use embedded_dma::StaticReadBuffer;
+use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 
 /// SPI error
 #[derive(Debug)]
@@ -551,18 +551,52 @@ pub struct SpiPayload<SPI, REMAP, PINS> {
 }
 
 pub type SpiTxDma<SPI, REMAP, PINS, CHANNEL> = TxDma<SpiPayload<SPI, REMAP, PINS>, CHANNEL>;
+pub type SpiRxDma<SPI, REMAP, PINS, CHANNEL> = RxDma<SpiPayload<SPI, REMAP, PINS>, CHANNEL>;
+pub type SpiRxTxDma<SPI, REMAP, PINS, RXCHANNEL, TXCHANNEL> =
+    RxTxDma<SpiPayload<SPI, REMAP, PINS>, RXCHANNEL, TXCHANNEL>;
 
 macro_rules! spi_dma {
-    ($SPIi:ident, $TCi:ident) => {
+    ($SPIi:ident, $RCi:ty, $TCi:ty) => {
         impl<REMAP, PINS> Transmit for SpiTxDma<$SPIi, REMAP, PINS, $TCi> {
             type TxChannel = $TCi;
             type ReceivedWord = u8;
+        }
+
+        impl<REMAP, PINS> Receive for SpiRxDma<$SPIi, REMAP, PINS, $RCi> {
+            type RxChannel = $RCi;
+            type TransmittedWord = u8;
+        }
+
+        impl<REMAP, PINS> Transmit for SpiRxTxDma<$SPIi, REMAP, PINS, $RCi, $TCi> {
+            type TxChannel = $TCi;
+            type ReceivedWord = u8;
+        }
+
+        impl<REMAP, PINS> Receive for SpiRxTxDma<$SPIi, REMAP, PINS, $RCi, $TCi> {
+            type RxChannel = $RCi;
+            type TransmittedWord = u8;
         }
 
         impl<REMAP, PINS> Spi<$SPIi, REMAP, PINS, u8> {
             pub fn with_tx_dma(self, channel: $TCi) -> SpiTxDma<$SPIi, REMAP, PINS, $TCi> {
                 let payload = SpiPayload { spi: self };
                 SpiTxDma { payload, channel }
+            }
+            pub fn with_rx_dma(self, channel: $RCi) -> SpiRxDma<$SPIi, REMAP, PINS, $RCi> {
+                let payload = SpiPayload { spi: self };
+                SpiRxDma { payload, channel }
+            }
+            pub fn with_rx_tx_dma(
+                self,
+                rxchannel: $RCi,
+                txchannel: $TCi,
+            ) -> SpiRxTxDma<$SPIi, REMAP, PINS, $RCi, $TCi> {
+                let payload = SpiPayload { spi: self };
+                SpiRxTxDma {
+                    payload,
+                    rxchannel,
+                    txchannel,
+                }
             }
         }
 
@@ -582,6 +616,89 @@ macro_rules! spi_dma {
                     .cr2
                     .modify(|_, w| w.txdmaen().clear_bit());
                 self.channel.stop();
+            }
+        }
+
+        impl<REMAP, PINS> TransferPayload for SpiRxDma<$SPIi, REMAP, PINS, $RCi> {
+            fn start(&mut self) {
+                self.payload
+                    .spi
+                    .spi
+                    .cr2
+                    .modify(|_, w| w.rxdmaen().set_bit());
+                self.channel.start();
+            }
+            fn stop(&mut self) {
+                self.payload
+                    .spi
+                    .spi
+                    .cr2
+                    .modify(|_, w| w.rxdmaen().clear_bit());
+                self.channel.stop();
+            }
+        }
+
+        impl<REMAP, PINS> TransferPayload for SpiRxTxDma<$SPIi, REMAP, PINS, $RCi, $TCi> {
+            fn start(&mut self) {
+                self.payload
+                    .spi
+                    .spi
+                    .cr2
+                    .modify(|_, w| w.rxdmaen().set_bit().txdmaen().set_bit());
+                self.rxchannel.start();
+                self.txchannel.start();
+            }
+            fn stop(&mut self) {
+                self.payload
+                    .spi
+                    .spi
+                    .cr2
+                    .modify(|_, w| w.txdmaen().clear_bit().rxdmaen().clear_bit());
+                self.txchannel.stop();
+                self.rxchannel.stop();
+            }
+        }
+
+        impl<B, REMAP, PIN> crate::dma::ReadDma<B, u8> for SpiRxDma<$SPIi, REMAP, PIN, $RCi>
+        where
+            B: StaticWriteBuffer<Word = u8>,
+        {
+            fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (ptr, len) = unsafe { buffer.static_write_buffer() };
+                self.channel.set_peripheral_address(
+                    unsafe { &(*$SPIi::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.channel.set_memory_address(ptr as u32, true);
+                self.channel.set_transfer_length(len);
+
+                atomic::compiler_fence(Ordering::Release);
+                self.channel.ch().cr.modify(|_, w| {
+                    w
+                        // memory to memory mode disabled
+                        .mem2mem()
+                        .clear_bit()
+                        // medium channel priority level
+                        .pl()
+                        .medium()
+                        // 8-bit memory size
+                        .msize()
+                        .bits8()
+                        // 8-bit peripheral size
+                        .psize()
+                        .bits8()
+                        // circular mode disabled
+                        .circ()
+                        .clear_bit()
+                        // write to memory
+                        .dir()
+                        .clear_bit()
+                });
+                self.start();
+
+                Transfer::w(buffer, self)
             }
         }
 
@@ -627,10 +744,93 @@ macro_rules! spi_dma {
                 Transfer::r(buffer, self)
             }
         }
+
+        impl<RXB, TXB, REMAP, PIN> crate::dma::ReadWriteDma<RXB, TXB, u8>
+            for SpiRxTxDma<$SPIi, REMAP, PIN, $RCi, $TCi>
+        where
+            RXB: StaticWriteBuffer<Word = u8>,
+            TXB: StaticReadBuffer<Word = u8>,
+        {
+            fn read_write(
+                mut self,
+                mut rxbuffer: RXB,
+                txbuffer: TXB,
+            ) -> Transfer<W, (RXB, TXB), Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (rxptr, rxlen) = unsafe { rxbuffer.static_write_buffer() };
+                let (txptr, txlen) = unsafe { txbuffer.static_read_buffer() };
+
+                if rxlen != txlen {
+                    panic!("receive and send buffer lengths do not match!");
+                }
+
+                self.rxchannel.set_peripheral_address(
+                    unsafe { &(*$SPIi::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.rxchannel.set_memory_address(rxptr as u32, true);
+                self.rxchannel.set_transfer_length(rxlen);
+
+                self.txchannel.set_peripheral_address(
+                    unsafe { &(*$SPIi::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.txchannel.set_memory_address(txptr as u32, true);
+                self.txchannel.set_transfer_length(txlen);
+
+                atomic::compiler_fence(Ordering::Release);
+                self.rxchannel.ch().cr.modify(|_, w| {
+                    w
+                        // memory to memory mode disabled
+                        .mem2mem()
+                        .clear_bit()
+                        // medium channel priority level
+                        .pl()
+                        .medium()
+                        // 8-bit memory size
+                        .msize()
+                        .bits8()
+                        // 8-bit peripheral size
+                        .psize()
+                        .bits8()
+                        // circular mode disabled
+                        .circ()
+                        .clear_bit()
+                        // write to memory
+                        .dir()
+                        .clear_bit()
+                });
+                self.txchannel.ch().cr.modify(|_, w| {
+                    w
+                        // memory to memory mode disabled
+                        .mem2mem()
+                        .clear_bit()
+                        // medium channel priority level
+                        .pl()
+                        .medium()
+                        // 8-bit memory size
+                        .msize()
+                        .bits8()
+                        // 8-bit peripheral size
+                        .psize()
+                        .bits8()
+                        // circular mode disabled
+                        .circ()
+                        .clear_bit()
+                        // read from memory
+                        .dir()
+                        .set_bit()
+                });
+                self.start();
+
+                Transfer::w((rxbuffer, txbuffer), self)
+            }
+        }
     };
 }
 
-spi_dma!(SPI1, C3);
-spi_dma!(SPI2, C5);
+spi_dma!(SPI1, dma1::C2, dma1::C3);
+spi_dma!(SPI2, dma1::C4, dma1::C5);
 #[cfg(feature = "connectivity")]
-spi_dma!(SPI3, C2);
+spi_dma!(SPI3, dma2::C1, dma2::C2);


### PR DESCRIPTION
Implements #200

SPI is a bit different from most other DMA-supporting peripherals, since SPI in master mode cannot receive without transmitting simultaneously. After some discussion in the #rust-embedded irc channel, we came to the conclusion that `split()`ting the device (like with serial) does not make much sense, because sending and receiving are inherently tied to each other; that made it necessary to finish the implementation of the already-existing (but unused) `RxTxDma` struct from `dma.rs` and add required traits.

This PR does that and adds an RxTxDma implementation to the SPI module.

Because in slave mode, this might(?) be still possible to receive without transmitting, I left the `RxDma` implementations in, but I am yet unsure about this.

Please do tell me if you have any suggestions :).