### PR TITLE
Blocking i2c without timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Implementation of blocking i2c without timeouts
 - `From<Into<Hertz>>` for `i2c::Mode`
 - `exti_rtic` example
 - Support for OpenDrain pin configuration on SPI CLK and MOSI pins

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -8,12 +8,10 @@ use crate::afio::MAPR;
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7, PB8, PB9};
 use crate::gpio::{Alternate, OpenDrain};
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
-use crate::pac::{DWT, I2C1, I2C2, RCC};
+use crate::pac::{self, DWT, I2C1, I2C2, RCC};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset};
 use crate::time::Hertz;
 use core::ops::Deref;
-use nb::Error::{Other, WouldBlock};
-use nb::{Error as NbError, Result as NbResult};
 
 pub mod blocking;
 pub use blocking::BlockingI2c;
@@ -113,11 +111,12 @@ pub struct I2c<I2C, PINS> {
     i2c: I2C,
     pins: PINS,
     mode: Mode,
-    pclk1: u32,
+    clk: Hertz,
+    start_retries: u8,
 }
 
 pub trait Instance:
-    crate::Sealed + Deref<Target = crate::pac::i2c1::RegisterBlock> + Enable + Reset + GetBusFreq
+    crate::Sealed + Deref<Target = pac::i2c1::RegisterBlock> + Enable + Reset + GetBusFreq
 {
 }
 
@@ -131,23 +130,30 @@ impl<PINS> I2c<I2C1, PINS> {
         pins: PINS,
         mapr: &mut MAPR,
         mode: M,
+        start_retries: u8,
         clocks: Clocks,
     ) -> Self
     where
         PINS: Pins<I2C1>,
     {
         mapr.modify_mapr(|_, w| w.i2c1_remap().bit(PINS::REMAP));
-        I2c::<I2C1, _>::_i2c(i2c, pins, mode, clocks)
+        I2c::<I2C1, _>::_i2c(i2c, pins, mode, start_retries, clocks)
     }
 }
 
 impl<PINS> I2c<I2C2, PINS> {
     /// Creates a generic I2C2 object on pins PB10 and PB11 using the embedded-hal `BlockingI2c` trait.
-    pub fn i2c2<M: Into<Mode>>(i2c: I2C2, pins: PINS, mode: M, clocks: Clocks) -> Self
+    pub fn i2c2<M: Into<Mode>>(
+        i2c: I2C2,
+        pins: PINS,
+        mode: M,
+        start_retries: u8,
+        clocks: Clocks,
+    ) -> Self
     where
         PINS: Pins<I2C2>,
     {
-        I2c::<I2C2, _>::_i2c(i2c, pins, mode, clocks)
+        I2c::<I2C2, _>::_i2c(i2c, pins, mode, start_retries, clocks)
     }
 }
 
@@ -156,13 +162,19 @@ where
     I2C: Instance,
 {
     /// Configures the I2C peripheral to work in master mode
-    fn _i2c<M: Into<Mode>>(i2c: I2C, pins: PINS, mode: M, clocks: Clocks) -> Self {
+    fn _i2c<M: Into<Mode>>(
+        i2c: I2C,
+        pins: PINS,
+        mode: M,
+        start_retries: u8,
+        clocks: Clocks,
+    ) -> Self {
         let mode = mode.into();
         let rcc = unsafe { &(*RCC::ptr()) };
         I2C::enable(rcc);
         I2C::reset(rcc);
 
-        let pclk1 = I2C::get_frequency(&clocks).0;
+        let clk = I2C::get_frequency(&clocks);
 
         assert!(mode.get_frequency().0 <= 400_000);
 
@@ -170,7 +182,8 @@ where
             i2c,
             pins,
             mode,
-            pclk1,
+            clk,
+            start_retries,
         };
         i2c.init();
         i2c
@@ -185,34 +198,34 @@ where
     /// according to the system frequency and I2C mode.
     fn init(&mut self) {
         let freq = self.mode.get_frequency();
-        let pclk1_mhz = (self.pclk1 / 1000000) as u16;
+        let clk_mhz = (self.clk.0 / 1000000) as u16;
 
         self.i2c
             .cr2
-            .write(|w| unsafe { w.freq().bits(pclk1_mhz as u8) });
+            .write(|w| unsafe { w.freq().bits(clk_mhz as u8) });
         self.i2c.cr1.write(|w| w.pe().clear_bit());
 
         match self.mode {
             Mode::Standard { .. } => {
                 self.i2c
                     .trise
-                    .write(|w| w.trise().bits((pclk1_mhz + 1) as u8));
+                    .write(|w| w.trise().bits((clk_mhz + 1) as u8));
                 self.i2c.ccr.write(|w| unsafe {
-                    w.ccr().bits(((self.pclk1 / (freq.0 * 2)) as u16).max(4))
+                    w.ccr().bits(((self.clk.0 / (freq.0 * 2)) as u16).max(4))
                 });
             }
             Mode::Fast { ref duty_cycle, .. } => {
                 self.i2c
                     .trise
-                    .write(|w| w.trise().bits((pclk1_mhz * 300 / 1000 + 1) as u8));
+                    .write(|w| w.trise().bits((clk_mhz * 300 / 1000 + 1) as u8));
 
                 self.i2c.ccr.write(|w| {
                     let (freq, duty) = match duty_cycle {
                         DutyCycle::Ratio2to1 => {
-                            (((self.pclk1 / (freq.0 * 3)) as u16).max(1), false)
+                            (((self.clk.0 / (freq.0 * 3)) as u16).max(1), false)
                         }
                         DutyCycle::Ratio16to9 => {
-                            (((self.pclk1 / (freq.0 * 25)) as u16).max(1), true)
+                            (((self.clk.0 / (freq.0 * 25)) as u16).max(1), true)
                         }
                     };
 
@@ -257,5 +270,215 @@ where
     #[deprecated(since = "0.7.1", note = "Please use release instead")]
     pub fn free(self) -> (I2C, PINS) {
         self.release()
+    }
+}
+
+impl<I2C, PINS> I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    fn check_and_clear_error_flags(&self) -> Result<pac::i2c1::sr1::R, Error> {
+        let sr1 = self.i2c.sr1.read();
+        if sr1.berr().bit_is_set() {
+            self.i2c.sr1.write(|w| w.berr().clear_bit());
+            Err(Error::Bus)
+        } else if sr1.arlo().bit_is_set() {
+            self.i2c.sr1.write(|w| w.arlo().clear_bit());
+            Err(Error::Arbitration)
+        } else if sr1.af().bit_is_set() {
+            self.i2c.sr1.write(|w| w.af().clear_bit());
+            Err(Error::Acknowledge)
+        } else if sr1.ovr().bit_is_set() {
+            self.i2c.sr1.write(|w| w.ovr().clear_bit());
+            Err(Error::Overrun)
+        } else {
+            Ok(sr1)
+        }
+    }
+
+    /// Check if STOP condition is generated
+    fn wait_for_stop(&mut self) {
+        while self.i2c.cr1.read().stop().is_stop() {}
+    }
+
+    fn send_start_and_wait(&mut self) -> Result<(), Error> {
+        // According to http://www.st.com/content/ccc/resource/technical/document/errata_sheet/f5/50/c9/46/56/db/4a/f6/CD00197763.pdf/files/CD00197763.pdf/jcr:content/translations/en.CD00197763.pdf
+        // 2.14.4 Wrong behavior of I2C peripheral in master mode after a misplaced STOP
+        let mut retries_left = self.start_retries.max(1);
+        loop {
+            retries_left -= 1;
+            self.send_start();
+            loop {
+                match self.check_and_clear_error_flags() {
+                    Ok(sr1) => {
+                        // Check if START condition is generated
+                        if sr1.sb().bit_is_set() {
+                            return Ok(());
+                        }
+                    }
+                    Err(e) => {
+                        if retries_left > 0 {
+                            self.reset();
+                            break;
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn send_addr_and_wait(&mut self, addr: u8, read: bool) -> Result<(), Error> {
+        self.i2c.sr1.read();
+        self.send_addr(addr, read);
+        loop {
+            match self.check_and_clear_error_flags() {
+                Ok(sr1) => {
+                    if sr1.addr().bit_is_set() {
+                        break Ok(());
+                    }
+                }
+                Err(e) => {
+                    if let Error::Acknowledge = e {
+                        self.send_stop();
+                    }
+                    break Err(e);
+                }
+            }
+        }
+    }
+
+    fn write_bytes_and_wait(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        self.i2c.sr1.read();
+        self.i2c.sr2.read();
+
+        self.i2c.dr.write(|w| w.dr().bits(bytes[0]));
+
+        for byte in &bytes[1..] {
+            while self.check_and_clear_error_flags()?.tx_e().bit_is_clear() {}
+            self.i2c.dr.write(|w| w.dr().bits(*byte));
+        }
+        while self.check_and_clear_error_flags()?.btf().bit_is_clear() {}
+
+        Ok(())
+    }
+
+    fn write_without_stop(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+        self.send_start_and_wait()?;
+        self.send_addr_and_wait(addr, false)?;
+
+        let ret = self.write_bytes_and_wait(bytes);
+        if ret == Err(Error::Acknowledge) {
+            self.send_stop();
+        }
+        ret
+    }
+}
+
+impl<I2C, PINS> Write for I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    type Error = Error;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.write_without_stop(addr, bytes)?;
+        self.send_stop();
+        self.wait_for_stop();
+
+        Ok(())
+    }
+}
+
+impl<I2C, PINS> Read for I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    type Error = Error;
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.send_start_and_wait()?;
+        self.send_addr_and_wait(addr, true)?;
+
+        match buffer.len() {
+            1 => {
+                self.i2c.cr1.modify(|_, w| w.ack().clear_bit());
+                self.i2c.sr1.read();
+                self.i2c.sr2.read();
+                self.send_stop();
+
+                while self.check_and_clear_error_flags()?.rx_ne().bit_is_clear() {}
+                buffer[0] = self.i2c.dr.read().dr().bits();
+
+                self.wait_for_stop();
+                self.i2c.cr1.modify(|_, w| w.ack().set_bit());
+            }
+            2 => {
+                self.i2c
+                    .cr1
+                    .modify(|_, w| w.pos().set_bit().ack().set_bit());
+                self.i2c.sr1.read();
+                self.i2c.sr2.read();
+                self.i2c.cr1.modify(|_, w| w.ack().clear_bit());
+
+                while self.check_and_clear_error_flags()?.btf().bit_is_clear() {}
+                self.send_stop();
+                buffer[0] = self.i2c.dr.read().dr().bits();
+                buffer[1] = self.i2c.dr.read().dr().bits();
+
+                self.wait_for_stop();
+                self.i2c
+                    .cr1
+                    .modify(|_, w| w.pos().clear_bit().ack().clear_bit());
+                self.i2c.cr1.modify(|_, w| w.ack().set_bit());
+            }
+            buffer_len => {
+                self.i2c.cr1.modify(|_, w| w.ack().set_bit());
+                self.i2c.sr1.read();
+                self.i2c.sr2.read();
+
+                let (first_bytes, last_two_bytes) = buffer.split_at_mut(buffer_len - 3);
+                for byte in first_bytes {
+                    while self.check_and_clear_error_flags()?.rx_ne().bit_is_clear() {}
+                    *byte = self.i2c.dr.read().dr().bits();
+                }
+
+                while self.check_and_clear_error_flags()?.btf().bit_is_clear() {}
+                self.i2c.cr1.modify(|_, w| w.ack().clear_bit());
+                last_two_bytes[0] = self.i2c.dr.read().dr().bits();
+                self.send_stop();
+                last_two_bytes[1] = self.i2c.dr.read().dr().bits();
+                while self.check_and_clear_error_flags()?.rx_ne().bit_is_clear() {}
+                last_two_bytes[2] = self.i2c.dr.read().dr().bits();
+
+                self.wait_for_stop();
+                self.i2c.cr1.modify(|_, w| w.ack().set_bit());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<I2C, PINS> WriteRead for I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    type Error = Error;
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        if !bytes.is_empty() {
+            self.write_without_stop(addr, bytes)?;
+        }
+
+        if !buffer.is_empty() {
+            self.read(addr, buffer)?;
+        } else if !bytes.is_empty() {
+            self.send_stop();
+            self.wait_for_stop();
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
See #300 .
cc @TheZoq2 
This is same implementation as for BlockingI2c, but without checking DWT timeouts.
Also this includes #298 .