### PR TITLE
Allow all pullup inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added DMA receive support for `SPI`
 - Added `release` functions to SPI DMA
 - Add GPIOF/GPIOG support for high/xl density lines
+- Allow using `Input<PullUp>` and `Input<PullDown>` for timers' pwm and qei inputs.
 
 ### Fixed
 - Fix > 2 byte i2c reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added DMA receive support for `SPI`
 - Added `release` functions to SPI DMA
 - Add GPIOF/GPIOG support for high/xl density lines
-- Allow using `Input<PullUp>` and `Input<PullDown>` for timers' pwm and qei inputs.
+- Allow using `Input<PullUp>` and `Input<PullDown>` for all alternate
+  function inputs.
 
 ### Fixed
 - Fix > 2 byte i2c reads

--- a/src/can.rs
+++ b/src/can.rs
@@ -3,7 +3,7 @@
 //! ## Alternate function remapping
 //!
 //! TX: Alternate Push-Pull Output
-//! RX: Input Floating Input
+//! RX: Input
 //!
 //! ### CAN1
 //!
@@ -25,7 +25,7 @@ use crate::gpio::gpiob::{PB12, PB13, PB5, PB6};
 use crate::gpio::{
     gpioa::{PA11, PA12},
     gpiob::{PB8, PB9},
-    Alternate, Floating, Input, PushPull,
+    Alternate, Input, PushPull,
 };
 #[cfg(feature = "connectivity")]
 use crate::pac::CAN2;
@@ -38,8 +38,8 @@ pub trait Pins: crate::Sealed {
     fn remap(mapr: &mut MAPR);
 }
 
-impl crate::Sealed for (PA12<Alternate<PushPull>>, PA11<Input<Floating>>) {}
-impl Pins for (PA12<Alternate<PushPull>>, PA11<Input<Floating>>) {
+impl<MODE> crate::Sealed for (PA12<Alternate<PushPull>>, PA11<Input<MODE>>) {}
+impl<MODE> Pins for (PA12<Alternate<PushPull>>, PA11<Input<MODE>>) {
     type Instance = CAN1;
 
     fn remap(mapr: &mut MAPR) {
@@ -50,8 +50,8 @@ impl Pins for (PA12<Alternate<PushPull>>, PA11<Input<Floating>>) {
     }
 }
 
-impl crate::Sealed for (PB9<Alternate<PushPull>>, PB8<Input<Floating>>) {}
-impl Pins for (PB9<Alternate<PushPull>>, PB8<Input<Floating>>) {
+impl<MODE> crate::Sealed for (PB9<Alternate<PushPull>>, PB8<Input<MODE>>) {}
+impl<MODE> Pins for (PB9<Alternate<PushPull>>, PB8<Input<MODE>>) {
     type Instance = CAN1;
 
     fn remap(mapr: &mut MAPR) {
@@ -63,9 +63,9 @@ impl Pins for (PB9<Alternate<PushPull>>, PB8<Input<Floating>>) {
 }
 
 #[cfg(feature = "connectivity")]
-impl crate::Sealed for (PB13<Alternate<PushPull>>, PB12<Input<Floating>>) {}
+impl<MODE> crate::Sealed for (PB13<Alternate<PushPull>>, PB12<Input<MODE>>) {}
 #[cfg(feature = "connectivity")]
-impl Pins for (PB13<Alternate<PushPull>>, PB12<Input<Floating>>) {
+impl<MODE> Pins for (PB13<Alternate<PushPull>>, PB12<Input<MODE>>) {
     type Instance = CAN2;
 
     fn remap(mapr: &mut MAPR) {
@@ -74,9 +74,9 @@ impl Pins for (PB13<Alternate<PushPull>>, PB12<Input<Floating>>) {
 }
 
 #[cfg(feature = "connectivity")]
-impl crate::Sealed for (PB6<Alternate<PushPull>>, PB5<Input<Floating>>) {}
+impl<MODE> crate::Sealed for (PB6<Alternate<PushPull>>, PB5<Input<MODE>>) {}
 #[cfg(feature = "connectivity")]
-impl Pins for (PB6<Alternate<PushPull>>, PB5<Input<Floating>>) {
+impl<MODE> Pins for (PB6<Alternate<PushPull>>, PB5<Input<MODE>>) {
     type Instance = CAN2;
 
     fn remap(mapr: &mut MAPR) {

--- a/src/pwm_input.rs
+++ b/src/pwm_input.rs
@@ -12,7 +12,7 @@ use crate::pac::TIM4;
 use crate::pac::{TIM2, TIM3};
 
 use crate::afio::MAPR;
-use crate::gpio::{self, Floating, Input};
+use crate::gpio::{self, Input};
 use crate::rcc::{Clocks, GetBusFreq, RccBus};
 use crate::time::Hertz;
 use crate::timer::Timer;
@@ -21,11 +21,11 @@ pub trait Pins<REMAP> {}
 
 use crate::timer::sealed::{Ch1, Ch2, Remap};
 
-impl<TIM, REMAP, P1, P2> Pins<REMAP> for (P1, P2)
+impl<TIM, REMAP, P1, P2, MODE1, MODE2> Pins<REMAP> for (P1, P2)
 where
     REMAP: Remap<Periph = TIM>,
-    P1: Ch1<REMAP> + gpio::PinExt<Mode = Input<Floating>>,
-    P2: Ch2<REMAP> + gpio::PinExt<Mode = Input<Floating>>,
+    P1: Ch1<REMAP> + gpio::PinExt<Mode = Input<MODE1>>,
+    P2: Ch2<REMAP> + gpio::PinExt<Mode = Input<MODE2>>,
 {
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -53,7 +53,7 @@ use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 use crate::gpio::gpioc::{PC10, PC11};
 use crate::gpio::gpiod::{PD5, PD6, PD8, PD9};
-use crate::gpio::{Alternate, Floating, Input, PushPull};
+use crate::gpio::{Alternate, Input, PushPull};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset};
 use crate::time::{Bps, U32Ext};
 
@@ -87,31 +87,31 @@ pub trait Pins<USART> {
     const REMAP: u8;
 }
 
-impl Pins<USART1> for (PA9<Alternate<PushPull>>, PA10<Input<Floating>>) {
+impl<MODE> Pins<USART1> for (PA9<Alternate<PushPull>>, PA10<Input<MODE>>) {
     const REMAP: u8 = 0;
 }
 
-impl Pins<USART1> for (PB6<Alternate<PushPull>>, PB7<Input<Floating>>) {
+impl<MODE> Pins<USART1> for (PB6<Alternate<PushPull>>, PB7<Input<MODE>>) {
     const REMAP: u8 = 1;
 }
 
-impl Pins<USART2> for (PA2<Alternate<PushPull>>, PA3<Input<Floating>>) {
+impl<MODE> Pins<USART2> for (PA2<Alternate<PushPull>>, PA3<Input<MODE>>) {
     const REMAP: u8 = 0;
 }
 
-impl Pins<USART2> for (PD5<Alternate<PushPull>>, PD6<Input<Floating>>) {
+impl<MODE> Pins<USART2> for (PD5<Alternate<PushPull>>, PD6<Input<MODE>>) {
     const REMAP: u8 = 0;
 }
 
-impl Pins<USART3> for (PB10<Alternate<PushPull>>, PB11<Input<Floating>>) {
+impl<MODE> Pins<USART3> for (PB10<Alternate<PushPull>>, PB11<Input<MODE>>) {
     const REMAP: u8 = 0;
 }
 
-impl Pins<USART3> for (PC10<Alternate<PushPull>>, PC11<Input<Floating>>) {
+impl<MODE> Pins<USART3> for (PC10<Alternate<PushPull>>, PC11<Input<MODE>>) {
     const REMAP: u8 = 1;
 }
 
-impl Pins<USART3> for (PD8<Alternate<PushPull>>, PD9<Input<Floating>>) {
+impl<MODE> Pins<USART3> for (PD8<Alternate<PushPull>>, PD9<Input<MODE>>) {
     const REMAP: u8 = 0b11;
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2,7 +2,7 @@
   # Serial Peripheral Interface
   To construct the SPI instances, use the `Spi::spiX` functions.
 
-  The pin parameter is a tuple containing `(sck, miso, mosi)` which should be configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+  The pin parameter is a tuple containing `(sck, miso, mosi)` which should be configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
   As some STM32F1xx chips have 5V tolerant SPI pins, it is also possible to configure Sck and Mosi outputs as `Alternate<PushPull>`. Then
   a simple Pull-Up to 5V can be used to use SPI on a 5V bus without a level shifter.
 
@@ -50,7 +50,7 @@ use crate::gpio::gpioa::{PA5, PA6, PA7};
 use crate::gpio::gpiob::{PB13, PB14, PB15, PB3, PB4, PB5};
 #[cfg(feature = "connectivity")]
 use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::{Alternate, Floating, Input, OpenDrain, PushPull};
+use crate::gpio::{Alternate, Input, OpenDrain, PushPull};
 use crate::rcc::{Clocks, Enable, GetBusFreq, Reset};
 use crate::time::Hertz;
 
@@ -129,7 +129,7 @@ macro_rules! remap {
         }
         impl Sck<$name> for $SCK<Alternate<PushPull>> {}
         impl Sck<$name> for $SCK<Alternate<OpenDrain>> {}
-        impl Miso<$name> for $MISO<Input<Floating>> {}
+        impl<MODE> Miso<$name> for $MISO<Input<MODE>> {}
         impl Mosi<$name> for $MOSI<Alternate<PushPull>> {}
         impl Mosi<$name> for $MOSI<Alternate<OpenDrain>> {}
     };
@@ -157,7 +157,7 @@ impl<REMAP, PINS> Spi<SPI1, REMAP, PINS, u8> {
     /**
       Constructs an SPI instance using SPI1 in 8bit dataframe mode.
 
-      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
 
       You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
     */
@@ -183,7 +183,7 @@ impl<REMAP, PINS> Spi<SPI2, REMAP, PINS, u8> {
     /**
       Constructs an SPI instance using SPI2 in 8bit dataframe mode.
 
-      The pin parameter tuple (sck, miso, mosi) should be `(PB13, PB14, PB15)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+      The pin parameter tuple (sck, miso, mosi) should be `(PB13, PB14, PB15)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
 
       You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
     */
@@ -202,7 +202,7 @@ impl<REMAP, PINS> Spi<SPI3, REMAP, PINS, u8> {
     /**
       Constructs an SPI instance using SPI3 in 8bit dataframe mode.
 
-      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
 
       You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
     */
@@ -219,7 +219,7 @@ impl<REMAP, PINS> Spi<SPI3, REMAP, PINS, u8> {
     /**
       Constructs an SPI instance using SPI3 in 8bit dataframe mode.
 
-      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)` configured as `(Alternate<PushPull>, Input<Floating>, Alternate<PushPull>)`.
+      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
 
       You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
     */


### PR DESCRIPTION
This fixes #321, extends on #118, and also fixes this issue for other peripherals that don't mind whether their Inputs have pull-ups or -downs enabled.

This is a superset of #357 and a subset of #358.