### PR TITLE
Fix failing flash verification on erase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix i2c interactions after errors
 - Fix SPI3 alternate function remapping
 - Do not enable UART DMA flags unconditionally
+- Fix flash erase verification always failing
 
 ### Changed
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -170,7 +170,7 @@ impl<'a> FlashWriter<'a> {
                 // 'start_offset' was.
                 let size = self.sector_sz.kbytes() as u32;
                 let start = start_offset & !(size - 1);
-                for idx in start..start + size {
+                for idx in (start..start + size).step_by(2) {
                     let write_address = (FLASH_START + idx as u32) as *const u16;
                     let verify: u16 = unsafe { core::ptr::read_volatile(write_address) };
                     if verify != 0xFFFF {


### PR DESCRIPTION
When erasing a 2kb flash page, flash erase verification wanted all `u16`s with addresses starting from 0 to 2047 to be `0xFFFF`.
This includes the u16 located from 2047 to 2048 (inclusive), which contains the last byte of the to-be-erased page and the first byte of the next page.
Surely, this u16 cannot reasonably be expected to be 0xFFFF after the erase.

Stepping over even addresses only solves this issue.