### PR TITLE
add uart4 uart5

### DIFF
--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -73,7 +73,7 @@ bus! {
     CAN1 => (APB1, 25),
     CAN2 => (APB1, 26),
 }
-#[cfg(all(feature = "stm32f103", feature = "high"))]
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
 bus! {
     ADC3 => (APB2, 15),
     DAC => (APB1, 29),

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -270,7 +270,7 @@ macro_rules! uart_stop_bits {
         impl Stopbits for $UARTX {
             fn config_stop_bits(stopbits: StopBits) {
                 assert!(
-                    (stopbits == StopBits::STOP0P5) || (stopbits == StopBits::STOP1P5),
+                    (stopbits == StopBits::STOP1) || (stopbits == StopBits::STOP2),
                     "The 0.5 Stop bit and 1.5 Stop bit are not available for UART4 & UART5."
                 );
                 let uart = unsafe { &(*$UARTX::ptr()) };

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -37,23 +37,26 @@
 //!  ```
 
 use core::marker::PhantomData;
-use core::ops::Deref;
 use core::ptr;
 use core::sync::atomic::{self, Ordering};
 
 use crate::pac::{RCC, USART1, USART2, USART3};
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+use crate::pac::{UART4, UART5};
 use core::convert::Infallible;
 use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 use embedded_hal::serial::Write;
 
 use crate::afio::MAPR;
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+use crate::dma::dma2;
 use crate::dma::{dma1, CircBuffer, RxDma, Transfer, TxDma, R, W};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
-use crate::gpio::gpioc::{PC10, PC11};
-use crate::gpio::gpiod::{PD5, PD6, PD8, PD9};
+use crate::gpio::gpioc::{PC10, PC11, PC12};
+use crate::gpio::gpiod::{PD2, PD5, PD6, PD8, PD9};
 use crate::gpio::{Alternate, Floating, Input, PushPull};
-use crate::rcc::{Clocks, Enable, GetBusFreq, Reset};
+use crate::rcc::{Clocks, Enable, GetBusFreq, RccBus, Reset};
 use crate::time::{Bps, U32Ext};
 
 /// Interrupt event
@@ -83,36 +86,56 @@ pub enum Error {
 // USART REMAPPING, see: https://www.st.com/content/ccc/resource/technical/document/reference_manual/59/b9/ba/7f/11/af/43/d5/CD00171190.pdf/files/CD00171190.pdf/jcr:content/translations/en.CD00171190.pdf
 // Section 9.3.8
 pub trait Pins<USART> {
-    const REMAP: u8;
+    fn remap(&self, _mapr: &mut MAPR) {}
 }
 
 impl Pins<USART1> for (PA9<Alternate<PushPull>>, PA10<Input<Floating>>) {
-    const REMAP: u8 = 0;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| w.usart1_remap().clear_bit())
+    }
 }
 
 impl Pins<USART1> for (PB6<Alternate<PushPull>>, PB7<Input<Floating>>) {
-    const REMAP: u8 = 1;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| w.usart1_remap().set_bit())
+    }
 }
 
 impl Pins<USART2> for (PA2<Alternate<PushPull>>, PA3<Input<Floating>>) {
-    const REMAP: u8 = 0;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| w.usart2_remap().clear_bit())
+    }
 }
 
 impl Pins<USART2> for (PD5<Alternate<PushPull>>, PD6<Input<Floating>>) {
-    const REMAP: u8 = 1;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| w.usart2_remap().set_bit())
+    }
 }
 
 impl Pins<USART3> for (PB10<Alternate<PushPull>>, PB11<Input<Floating>>) {
-    const REMAP: u8 = 0;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| unsafe { w.usart3_remap().bits(0) })
+    }
 }
 
 impl Pins<USART3> for (PC10<Alternate<PushPull>>, PC11<Input<Floating>>) {
-    const REMAP: u8 = 1;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| unsafe { w.usart3_remap().bits(1) })
+    }
 }
 
 impl Pins<USART3> for (PD8<Alternate<PushPull>>, PD9<Input<Floating>>) {
-    const REMAP: u8 = 0b11;
+    fn remap(&self, mapr: &mut MAPR) {
+        mapr.modify_mapr(|_, w| unsafe { w.usart3_remap().bits(0b11) })
+    }
 }
+
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+impl Pins<UART4> for (PC10<Alternate<PushPull>>, PC11<Input<Floating>>) {}
+
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+impl Pins<UART5> for (PC12<Alternate<PushPull>>, PD2<Input<Floating>>) {}
 
 pub enum Parity {
     ParityNone,
@@ -120,6 +143,7 @@ pub enum Parity {
     ParityOdd,
 }
 
+#[derive(PartialEq)]
 pub enum StopBits {
     #[doc = "1 stop bit"]
     STOP1,
@@ -181,21 +205,12 @@ impl From<Bps> for Config {
     }
 }
 
-use crate::pac::usart1 as uart_base;
-
 /// Serial abstraction
 pub struct Serial<USART, PINS> {
     usart: USART,
     pins: PINS,
     tx: Tx<USART>,
     rx: Rx<USART>,
-}
-
-pub trait Instance:
-    crate::Sealed + Deref<Target = uart_base::RegisterBlock> + Enable + Reset + GetBusFreq
-{
-    #[doc(hidden)]
-    fn ptr() -> *const uart_base::RegisterBlock;
 }
 
 /// Serial receiver
@@ -224,137 +239,64 @@ impl<USART> Tx<USART> {
     }
 }
 
-impl<USART, PINS> Serial<USART, PINS>
-where
-    USART: Instance,
-{
-    fn init(self, config: Config, clocks: Clocks, remap: impl FnOnce()) -> Self {
-        // enable and reset $USARTX
-        let rcc = unsafe { &(*RCC::ptr()) };
-        USART::enable(rcc);
-        USART::reset(rcc);
-
-        remap();
-        // Configure baud rate
-        let brr = USART::get_frequency(&clocks).0 / config.baudrate.0;
-        assert!(brr >= 16, "impossible baud rate");
-        self.usart.brr.write(|w| unsafe { w.bits(brr) });
-
-        // Configure parity and word length
-        // Unlike most uart devices, the "word length" of this usart device refers to
-        // the size of the data plus the parity bit. I.e. "word length"=8, parity=even
-        // results in 7 bits of data. Therefore, in order to get 8 bits and one parity
-        // bit, we need to set the "word" length to 9 when using parity bits.
-        let (word_length, parity_control_enable, parity) = match config.parity {
-            Parity::ParityNone => (false, false, false),
-            Parity::ParityEven => (true, true, false),
-            Parity::ParityOdd => (true, true, true),
-        };
-        self.usart.cr1.modify(|_r, w| {
-            w.m()
-                .bit(word_length)
-                .ps()
-                .bit(parity)
-                .pce()
-                .bit(parity_control_enable)
-        });
-
-        // Configure stop bits
-        let stop_bits = match config.stopbits {
-            StopBits::STOP1 => 0b00,
-            StopBits::STOP0P5 => 0b01,
-            StopBits::STOP2 => 0b10,
-            StopBits::STOP1P5 => 0b11,
-        };
-        self.usart.cr2.modify(|_r, w| w.stop().bits(stop_bits));
-
-        // UE: enable USART
-        // RE: enable receiver
-        // TE: enable transceiver
-        self.usart
-            .cr1
-            .modify(|_r, w| w.ue().set_bit().re().set_bit().te().set_bit());
-
-        self
-    }
-
-    /// Starts listening to the USART by enabling the _Received data
-    /// ready to be read (RXNE)_ interrupt and _Transmit data
-    /// register empty (TXE)_ interrupt
-    pub fn listen(&mut self, event: Event) {
-        match event {
-            Event::Rxne => self.usart.cr1.modify(|_, w| w.rxneie().set_bit()),
-            Event::Txe => self.usart.cr1.modify(|_, w| w.txeie().set_bit()),
-            Event::Idle => self.usart.cr1.modify(|_, w| w.idleie().set_bit()),
-        }
-    }
-
-    /// Stops listening to the USART by disabling the _Received data
-    /// ready to be read (RXNE)_ interrupt and _Transmit data
-    /// register empty (TXE)_ interrupt
-    pub fn unlisten(&mut self, event: Event) {
-        match event {
-            Event::Rxne => self.usart.cr1.modify(|_, w| w.rxneie().clear_bit()),
-            Event::Txe => self.usart.cr1.modify(|_, w| w.txeie().clear_bit()),
-            Event::Idle => self.usart.cr1.modify(|_, w| w.idleie().clear_bit()),
-        }
-    }
-
-    /// Returns true if the line idle status is set
-    pub fn is_idle(&self) -> bool {
-        self.usart.sr.read().idle().bit_is_set()
-    }
-
-    /// Returns true if the tx register is empty (and can accept data)
-    pub fn is_tx_empty(&self) -> bool {
-        self.usart.sr.read().txe().bit_is_set()
-    }
-
-    /// Returns true if the rx register is not empty (and can be read)
-    pub fn is_rx_not_empty(&self) -> bool {
-        self.usart.sr.read().rxne().bit_is_set()
-    }
-
-    /// Clear idle line interrupt flag
-    pub fn clear_idle_interrupt(&self) {
-        unsafe {
-            let _ = (*USART::ptr()).sr.read();
-            let _ = (*USART::ptr()).dr.read();
-        }
-    }
-
-    /// Returns ownership of the borrowed register handles
-    pub fn release(self) -> (USART, PINS) {
-        (self.usart, self.pins)
-    }
-
-    /// Separates the serial struct into separate channel objects for sending (Tx) and
-    /// receiving (Rx)
-    pub fn split(self) -> (Tx<USART>, Rx<USART>) {
-        (self.tx, self.rx)
-    }
+trait Stopbits {
+    fn config_stop_bits(stopbits: StopBits);
 }
+
+macro_rules! usart_stop_bits {
+    ($USARTX:ident) => {
+        impl Stopbits for $USARTX {
+            fn config_stop_bits(stopbits: StopBits) {
+                let stop_bits = match stopbits {
+                    StopBits::STOP1 => 0b00,
+                    StopBits::STOP0P5 => 0b01,
+                    StopBits::STOP2 => 0b10,
+                    StopBits::STOP1P5 => 0b11,
+                };
+                let usart = unsafe { &(*$USARTX::ptr()) };
+                usart.cr2.modify(|_r, w| w.stop().bits(stop_bits));
+            }
+        }
+    };
+}
+
+macro_rules! uart_stop_bits {
+    ($UARTX:ident) => {
+        impl Stopbits for $UARTX {
+            fn config_stop_bits(stopbits: StopBits) {
+                assert!(
+                    (stopbits == StopBits::STOP0P5) || (stopbits == StopBits::STOP1P5),
+                    "The 0.5 Stop bit and 1.5 Stop bit are not available for UART4 & UART5."
+                );
+                let uart = unsafe { &(*$UARTX::ptr()) };
+                if stopbits == StopBits::STOP1 {
+                    uart.cr2.modify(|_r, w| w.stop().stop1());
+                } else {
+                    uart.cr2.modify(|_r, w| w.stop().stop2());
+                }
+            }
+        }
+    };
+}
+
+usart_stop_bits! {USART1}
+usart_stop_bits! {USART2}
+usart_stop_bits! {USART3}
+uart_stop_bits! {UART4}
+uart_stop_bits! {UART5}
 
 macro_rules! hal {
     (
         $(#[$meta:meta])*
         $USARTX:ident: (
             $usartX:ident,
-            $usartX_remap:ident,
-            $bit:ident,
-            $closure:expr,
         ),
     ) => {
-        impl Instance for $USARTX {
-            fn ptr() -> *const uart_base::RegisterBlock {
-                <$USARTX>::ptr() as *const _
-            }
-        }
-
         $(#[$meta])*
         /// The behaviour of the functions is equal for all three USARTs.
         /// Except that they are using the corresponding USART hardware and pins.
-        impl<PINS> Serial<$USARTX, PINS> {
+        impl<PINS> Serial<$USARTX, PINS>
+        {
             /// Configures the serial interface and creates the interface
             /// struct.
             ///
@@ -374,188 +316,262 @@ macro_rules! hal {
                 usart: $USARTX,
                 pins: PINS,
                 mapr: &mut MAPR,
-                config: impl Into<Config>,
+                config: Config,
                 clocks: Clocks,
             ) -> Self
             where
                 PINS: Pins<$USARTX>,
             {
-                #[allow(unused_unsafe)]
-                Serial { usart, pins, tx: Tx::new(), rx: Rx::new() }.init(config.into(), clocks, || {
-                    mapr.modify_mapr(|_, w| unsafe {
-                        #[allow(clippy::redundant_closure_call)]
-                        w.$usartX_remap().$bit(($closure)(PINS::REMAP))
-                    })
-                })
+                // enable and reset $USARTX
+                let rcc = unsafe { &(*RCC::ptr()) };
+                $USARTX::enable(rcc);
+                $USARTX::reset(rcc);
+
+                pins.remap(mapr);
+
+                // Configure baud rate
+                let brr = <$USARTX as RccBus>::Bus::get_frequency(&clocks).0 / config.baudrate.0;
+                assert!(brr >= 16, "impossible baud rate");
+                usart.brr.write(|w| unsafe { w.bits(brr) });
+
+                // Configure parity and word length
+                // Unlike most uart devices, the "word length" of this usart device refers to
+                // the size of the data plus the parity bit. I.e. "word length"=8, parity=even
+                // results in 7 bits of data. Therefore, in order to get 8 bits and one parity
+                // bit, we need to set the "word" length to 9 when using parity bits.
+                let (word_length, parity_control_enable, parity) = match config.parity {
+                    Parity::ParityNone => (false, false, false),
+                    Parity::ParityEven => (true, true, false),
+                    Parity::ParityOdd => (true, true, true),
+                };
+                usart.cr1.modify(|_r, w| {
+                    w.m()
+                        .bit(word_length)
+                        .ps()
+                        .bit(parity)
+                        .pce()
+                        .bit(parity_control_enable)
+                });
+
+                // Configure stop bits
+                $USARTX::config_stop_bits(config.stopbits);
+
+                // UE: enable USART
+                // RE: enable receiver
+                // TE: enable transceiver
+                usart.cr1
+                    .modify(|_r, w| w.ue().set_bit().re().set_bit().te().set_bit());
+
+                let tx = Tx::<$USARTX>::new();
+                let rx = Rx::<$USARTX>::new();
+                Serial { usart, pins, tx, rx }
+            }
+
+            /// Starts listening to the USART by enabling the _Received data
+            /// ready to be read (RXNE)_ interrupt and _Transmit data
+            /// register empty (TXE)_ interrupt
+            pub fn listen(&mut self, event: Event) {
+                match event {
+                    Event::Rxne => self.usart.cr1.modify(|_, w| w.rxneie().set_bit()),
+                    Event::Txe => self.usart.cr1.modify(|_, w| w.txeie().set_bit()),
+                    Event::Idle => self.usart.cr1.modify(|_, w| w.idleie().set_bit()),
+                }
+            }
+
+            /// Stops listening to the USART by disabling the _Received data
+            /// ready to be read (RXNE)_ interrupt and _Transmit data
+            /// register empty (TXE)_ interrupt
+            pub fn unlisten(&mut self, event: Event) {
+                match event {
+                    Event::Rxne => self.usart.cr1.modify(|_, w| w.rxneie().clear_bit()),
+                    Event::Txe => self.usart.cr1.modify(|_, w| w.txeie().clear_bit()),
+                    Event::Idle => self.usart.cr1.modify(|_, w| w.idleie().clear_bit()),
+                }
+            }
+
+            /// Returns true if the line idle status is set
+            pub fn is_idle(&self) -> bool {
+                self.usart.sr.read().idle().bit_is_set()
+            }
+
+            /// Returns true if the tx register is empty (and can accept data)
+            pub fn is_tx_empty(&self) -> bool {
+                self.usart.sr.read().txe().bit_is_set()
+            }
+
+            /// Returns true if the rx register is not empty (and can be read)
+            pub fn is_rx_not_empty(&self) -> bool {
+                self.usart.sr.read().rxne().bit_is_set()
+            }
+
+            /// Clear idle line interrupt flag
+            pub fn clear_idle_interrupt(&self) {
+                unsafe {
+                    let _ = (*$USARTX::ptr()).sr.read();
+                    let _ = (*$USARTX::ptr()).dr.read();
+                }
+            }
+
+            /// Returns ownership of the borrowed register handles
+            pub fn release(self) -> ($USARTX, PINS) {
+                (self.usart, self.pins)
+            }
+
+            /// Separates the serial struct into separate channel objects for sending (Tx) and
+            /// receiving (Rx)
+            pub fn split(self) -> (Tx<$USARTX>, Rx<$USARTX>) {
+                (self.tx, self.rx)
+            }
+        }
+
+        impl Tx<$USARTX> {
+            /// Start listening for transmit interrupt event
+            pub fn listen(&mut self) {
+                unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) };
+            }
+
+            /// Stop listening for transmit interrupt event
+            pub fn unlisten(&mut self) {
+                unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) };
+            }
+
+            /// Returns true if the tx register is empty (and can accept data)
+            pub fn is_tx_empty(&self) -> bool {
+                unsafe { (*$USARTX::ptr()).sr.read().txe().bit_is_set() }
+            }
+        }
+
+        impl Rx<$USARTX> {
+            /// Start listening for receive interrupt event
+            pub fn listen(&mut self) {
+                unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) };
+            }
+
+            /// Stop listening for receive interrupt event
+            pub fn unlisten(&mut self) {
+                unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) };
+            }
+
+            /// Start listening for idle interrupt event
+            pub fn listen_idle(&mut self) {
+                unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) };
+            }
+
+            /// Stop listening for idle interrupt event
+            pub fn unlisten_idle(&mut self) {
+                unsafe { (*$USARTX::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) };
+            }
+
+            /// Returns true if the line idle status is set
+            pub fn is_idle(&self) -> bool {
+                unsafe { (*$USARTX::ptr()).sr.read().idle().bit_is_set() }
+            }
+
+            /// Returns true if the rx register is not empty (and can be read)
+            pub fn is_rx_not_empty(&self) -> bool {
+                unsafe { (*$USARTX::ptr()).sr.read().rxne().bit_is_set() }
+            }
+
+            /// Clear idle line interrupt flag
+            pub fn clear_idle_interrupt(&self) {
+                unsafe {
+                    let _ = (*$USARTX::ptr()).sr.read();
+                    let _ = (*$USARTX::ptr()).dr.read();
+                }
+            }
+        }
+
+        impl crate::hal::serial::Read<u8> for Rx<$USARTX> {
+            type Error = Error;
+
+            fn read(&mut self) -> nb::Result<u8, Error> {
+                let usart = unsafe { &*$USARTX::ptr() };
+                let sr = usart.sr.read();
+
+                // Check for any errors
+                let err = if sr.pe().bit_is_set() {
+                    Some(Error::Parity)
+                } else if sr.fe().bit_is_set() {
+                    Some(Error::Framing)
+                } else if sr.ne().bit_is_set() {
+                    Some(Error::Noise)
+                } else if sr.ore().bit_is_set() {
+                    Some(Error::Overrun)
+                } else {
+                    None
+                };
+
+                if let Some(err) = err {
+                    // Some error occurred. In order to clear that error flag, you have to
+                    // do a read from the sr register followed by a read from the dr
+                    // register
+                    // NOTE(read_volatile) see `write_volatile` below
+                    unsafe {
+                        ptr::read_volatile(&usart.sr as *const _ as *const _);
+                        ptr::read_volatile(&usart.dr as *const _ as *const _);
+                    }
+                    Err(nb::Error::Other(err))
+                } else {
+                    // Check if a byte is available
+                    if sr.rxne().bit_is_set() {
+                        // Read the received byte
+                        // NOTE(read_volatile) see `write_volatile` below
+                        Ok(unsafe { ptr::read_volatile(&usart.dr as *const _ as *const _) })
+                    } else {
+                        Err(nb::Error::WouldBlock)
+                    }
+                }
+            }
+        }
+
+        impl crate::hal::serial::Write<u8> for Tx<$USARTX> {
+            type Error = Infallible;
+
+            fn flush(&mut self) -> nb::Result<(), Self::Error> {
+                let sr = unsafe { &*$USARTX::ptr() }.sr.read();
+
+                if sr.tc().bit_is_set() {
+                    Ok(())
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
+            fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
+                let usart = unsafe { &*$USARTX::ptr() };
+                let sr = usart.sr.read();
+
+                if sr.txe().bit_is_set() {
+                    // NOTE(unsafe) atomic write to stateless register
+                    // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
+                    unsafe { ptr::write_volatile(&usart.dr as *const _ as *mut _, byte) }
+                    Ok(())
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
+        }
+
+        impl<PINS> crate::hal::serial::Read<u8> for Serial<$USARTX, PINS> {
+            type Error = Error;
+
+            fn read(&mut self) -> nb::Result<u8, Error> {
+                self.rx.read()
+            }
+        }
+
+        impl<PINS> crate::hal::serial::Write<u8> for Serial<$USARTX, PINS> {
+            type Error = Infallible;
+
+            fn flush(&mut self) -> nb::Result<(), Self::Error> {
+                self.tx.flush()
+            }
+
+            fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
+                self.tx.write(byte)
             }
         }
 
     };
-}
-
-impl<USART> Tx<USART>
-where
-    USART: Instance,
-{
-    /// Start listening for transmit interrupt event
-    pub fn listen(&mut self) {
-        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) };
-    }
-
-    /// Stop listening for transmit interrupt event
-    pub fn unlisten(&mut self) {
-        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) };
-    }
-
-    /// Returns true if the tx register is empty (and can accept data)
-    pub fn is_tx_empty(&self) -> bool {
-        unsafe { (*USART::ptr()).sr.read().txe().bit_is_set() }
-    }
-}
-
-impl<USART> Rx<USART>
-where
-    USART: Instance,
-{
-    /// Start listening for receive interrupt event
-    pub fn listen(&mut self) {
-        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) };
-    }
-
-    /// Stop listening for receive interrupt event
-    pub fn unlisten(&mut self) {
-        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) };
-    }
-
-    /// Start listening for idle interrupt event
-    pub fn listen_idle(&mut self) {
-        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) };
-    }
-
-    /// Stop listening for idle interrupt event
-    pub fn unlisten_idle(&mut self) {
-        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) };
-    }
-
-    /// Returns true if the line idle status is set
-    pub fn is_idle(&self) -> bool {
-        unsafe { (*USART::ptr()).sr.read().idle().bit_is_set() }
-    }
-
-    /// Returns true if the rx register is not empty (and can be read)
-    pub fn is_rx_not_empty(&self) -> bool {
-        unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
-    }
-
-    /// Clear idle line interrupt flag
-    pub fn clear_idle_interrupt(&self) {
-        unsafe {
-            let _ = (*USART::ptr()).sr.read();
-            let _ = (*USART::ptr()).dr.read();
-        }
-    }
-}
-
-impl<USART> crate::hal::serial::Read<u8> for Rx<USART>
-where
-    USART: Instance,
-{
-    type Error = Error;
-
-    fn read(&mut self) -> nb::Result<u8, Error> {
-        let usart = unsafe { &*USART::ptr() };
-        let sr = usart.sr.read();
-
-        // Check for any errors
-        let err = if sr.pe().bit_is_set() {
-            Some(Error::Parity)
-        } else if sr.fe().bit_is_set() {
-            Some(Error::Framing)
-        } else if sr.ne().bit_is_set() {
-            Some(Error::Noise)
-        } else if sr.ore().bit_is_set() {
-            Some(Error::Overrun)
-        } else {
-            None
-        };
-
-        if let Some(err) = err {
-            // Some error occurred. In order to clear that error flag, you have to
-            // do a read from the sr register followed by a read from the dr
-            // register
-            // NOTE(read_volatile) see `write_volatile` below
-            unsafe {
-                ptr::read_volatile(&usart.sr as *const _ as *const _);
-                ptr::read_volatile(&usart.dr as *const _ as *const _);
-            }
-            Err(nb::Error::Other(err))
-        } else {
-            // Check if a byte is available
-            if sr.rxne().bit_is_set() {
-                // Read the received byte
-                // NOTE(read_volatile) see `write_volatile` below
-                Ok(unsafe { ptr::read_volatile(&usart.dr as *const _ as *const _) })
-            } else {
-                Err(nb::Error::WouldBlock)
-            }
-        }
-    }
-}
-
-impl<USART> crate::hal::serial::Write<u8> for Tx<USART>
-where
-    USART: Instance,
-{
-    type Error = Infallible;
-
-    fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        let sr = unsafe { &*USART::ptr() }.sr.read();
-
-        if sr.tc().bit_is_set() {
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
-    }
-    fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
-        let usart = unsafe { &*USART::ptr() };
-        let sr = usart.sr.read();
-
-        if sr.txe().bit_is_set() {
-            // NOTE(unsafe) atomic write to stateless register
-            // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
-            unsafe { ptr::write_volatile(&usart.dr as *const _ as *mut _, byte) }
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
-    }
-}
-
-impl<USART, PINS> crate::hal::serial::Read<u8> for Serial<USART, PINS>
-where
-    USART: Instance,
-{
-    type Error = Error;
-
-    fn read(&mut self) -> nb::Result<u8, Error> {
-        self.rx.read()
-    }
-}
-
-impl<USART, PINS> crate::hal::serial::Write<u8> for Serial<USART, PINS>
-where
-    USART: Instance,
-{
-    type Error = Infallible;
-
-    fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        self.tx.flush()
-    }
-
-    fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
-        self.tx.write(byte)
-    }
 }
 
 impl<USART> core::fmt::Write for Tx<USART>
@@ -574,27 +590,32 @@ hal! {
     /// # USART1 functions
     USART1: (
         usart1,
-        usart1_remap,
-        bit,
-        |remap| remap == 1,
     ),
 }
 hal! {
     /// # USART2 functions
     USART2: (
         usart2,
-        usart2_remap,
-        bit,
-        |remap| remap == 1,
     ),
 }
 hal! {
     /// # USART3 functions
     USART3: (
         usart3,
-        usart3_remap,
-        bits,
-        |remap| remap,
+    ),
+}
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+hal! {
+    /// # UART4 functions
+    UART4: (
+        uart4,
+    ),
+}
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+hal! {
+    /// # UART5 functions
+    UART5: (
+        uart5,
     ),
 }
 
@@ -604,190 +625,219 @@ pub type Rx2 = Rx<USART2>;
 pub type Tx2 = Tx<USART2>;
 pub type Rx3 = Rx<USART3>;
 pub type Tx3 = Tx<USART3>;
+pub type Rx4 = Rx<UART4>;
+pub type Tx4 = Tx<UART4>;
 
 use crate::dma::{Receive, TransferPayload, Transmit};
 
 macro_rules! serialdma {
-    ($(
+    (
         $USARTX:ident: (
             $rxdma:ident,
             $txdma:ident,
             $dmarxch:ty,
             $dmatxch:ty,
         ),
-    )+) => {
-        $(
-            pub type $rxdma = RxDma<Rx<$USARTX>, $dmarxch>;
-            pub type $txdma = TxDma<Tx<$USARTX>, $dmatxch>;
+    ) => {
+        pub type $rxdma = RxDma<Rx<$USARTX>, $dmarxch>;
+        pub type $txdma = TxDma<Tx<$USARTX>, $dmatxch>;
 
-            impl Receive for $rxdma {
-                type RxChannel = $dmarxch;
-                type TransmittedWord = u8;
+        impl Receive for $rxdma {
+            type RxChannel = $dmarxch;
+            type TransmittedWord = u8;
+        }
+
+        impl Transmit for $txdma {
+            type TxChannel = $dmatxch;
+            type ReceivedWord = u8;
+        }
+
+        impl TransferPayload for $rxdma {
+            fn start(&mut self) {
+                self.channel.start();
             }
-
-            impl Transmit for $txdma {
-                type TxChannel = $dmatxch;
-                type ReceivedWord = u8;
+            fn stop(&mut self) {
+                self.channel.stop();
             }
+        }
 
-            impl TransferPayload for $rxdma {
-                fn start(&mut self) {
-                    self.channel.start();
-                }
-                fn stop(&mut self) {
-                    self.channel.stop();
-                }
+        impl TransferPayload for $txdma {
+            fn start(&mut self) {
+                self.channel.start();
             }
-
-            impl TransferPayload for $txdma {
-                fn start(&mut self) {
-                    self.channel.start();
-                }
-                fn stop(&mut self) {
-                    self.channel.stop();
-                }
+            fn stop(&mut self) {
+                self.channel.stop();
             }
+        }
 
-            impl Rx<$USARTX> {
-                pub fn with_dma(self, channel: $dmarxch) -> $rxdma {
-                    unsafe { (*$USARTX::ptr()).cr3.write(|w| w.dmar().set_bit()); }
-                    RxDma {
-                        payload: self,
-                        channel,
-                    }
+        impl Rx<$USARTX> {
+            pub fn with_dma(self, channel: $dmarxch) -> $rxdma {
+                unsafe {
+                    (*$USARTX::ptr()).cr3.write(|w| w.dmar().set_bit());
                 }
-            }
-
-            impl Tx<$USARTX> {
-                pub fn with_dma(self, channel: $dmatxch) -> $txdma {
-                    unsafe { (*$USARTX::ptr()).cr3.write(|w| w.dmat().set_bit()); }
-                    TxDma {
-                        payload: self,
-                        channel,
-                    }
+                RxDma {
+                    payload: self,
+                    channel,
                 }
             }
+        }
 
-            impl $rxdma {
-                #[deprecated(since = "0.7.1", note = "Please use release instead")]
-                pub fn split(self) -> (Rx<$USARTX>, $dmarxch) {
-                    self.release()
+        impl Tx<$USARTX> {
+            pub fn with_dma(self, channel: $dmatxch) -> $txdma {
+                unsafe {
+                    (*$USARTX::ptr()).cr3.write(|w| w.dmat().set_bit());
                 }
-                pub fn release(mut self) -> (Rx<$USARTX>, $dmarxch) {
-                    self.stop();
-                    unsafe { (*$USARTX::ptr()).cr3.write(|w| w.dmar().clear_bit()); }
-                    let RxDma {payload, channel} = self;
-                    (
-                        payload,
-                        channel
-                    )
+                TxDma {
+                    payload: self,
+                    channel,
                 }
             }
+        }
 
-            impl $txdma {
-                #[deprecated(since = "0.7.1", note = "Please use release instead")]
-                pub fn split(self) -> (Tx<$USARTX>, $dmatxch) {
-                    self.release()
-                }
-                pub fn release(mut self) -> (Tx<$USARTX>, $dmatxch) {
-                    self.stop();
-                    unsafe { (*$USARTX::ptr()).cr3.write(|w| w.dmat().clear_bit()); }
-                    let TxDma {payload, channel} = self;
-                    (
-                        payload,
-                        channel,
-                    )
-                }
+        impl $rxdma {
+            #[deprecated(since = "0.7.1", note = "Please use release instead")]
+            pub fn split(self) -> (Rx<$USARTX>, $dmarxch) {
+                self.release()
             }
-
-            impl<B> crate::dma::CircReadDma<B, u8> for $rxdma
-            where
-                &'static mut [B; 2]: StaticWriteBuffer<Word = u8>,
-                B: 'static,
-            {
-                fn circ_read(mut self, mut buffer: &'static mut [B; 2]) -> CircBuffer<B, Self> {
-                    // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
-                    // until the end of the transfer.
-                    let (ptr, len) = unsafe { buffer.static_write_buffer() };
-                    self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
-                    self.channel.set_memory_address(ptr as u32, true);
-                    self.channel.set_transfer_length(len);
-
-                    atomic::compiler_fence(Ordering::Release);
-
-                    self.channel.ch().cr.modify(|_, w| { w
-                        .mem2mem() .clear_bit()
-                        .pl()      .medium()
-                        .msize()   .bits8()
-                        .psize()   .bits8()
-                        .circ()    .set_bit()
-                        .dir()     .clear_bit()
-                    });
-
-                    self.start();
-
-                    CircBuffer::new(buffer, self)
+            pub fn release(mut self) -> (Rx<$USARTX>, $dmarxch) {
+                self.stop();
+                unsafe {
+                    (*$USARTX::ptr()).cr3.write(|w| w.dmar().clear_bit());
                 }
+                let RxDma { payload, channel } = self;
+                (payload, channel)
             }
+        }
 
-            impl<B> crate::dma::ReadDma<B, u8> for $rxdma
-            where
-                B: StaticWriteBuffer<Word = u8>,
-            {
-                fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
-                    // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
-                    // until the end of the transfer.
-                    let (ptr, len) = unsafe { buffer.static_write_buffer() };
-                    self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
-                    self.channel.set_memory_address(ptr as u32, true);
-                    self.channel.set_transfer_length(len);
-
-                    atomic::compiler_fence(Ordering::Release);
-                    self.channel.ch().cr.modify(|_, w| { w
-                        .mem2mem() .clear_bit()
-                        .pl()      .medium()
-                        .msize()   .bits8()
-                        .psize()   .bits8()
-                        .circ()    .clear_bit()
-                        .dir()     .clear_bit()
-                    });
-                    self.start();
-
-                    Transfer::w(buffer, self)
+        impl $txdma {
+            #[deprecated(since = "0.7.1", note = "Please use release instead")]
+            pub fn split(self) -> (Tx<$USARTX>, $dmatxch) {
+                self.release()
+            }
+            pub fn release(mut self) -> (Tx<$USARTX>, $dmatxch) {
+                self.stop();
+                unsafe {
+                    (*$USARTX::ptr()).cr3.write(|w| w.dmat().clear_bit());
                 }
+                let TxDma { payload, channel } = self;
+                (payload, channel)
             }
+        }
 
-            impl<B> crate::dma::WriteDma<B, u8> for $txdma
-            where
-                B: StaticReadBuffer<Word = u8>,
-            {
-                fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
-                    // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
-                    // until the end of the transfer.
-                    let (ptr, len) = unsafe { buffer.static_read_buffer() };
+        impl<B> crate::dma::CircReadDma<B, u8> for $rxdma
+        where
+            &'static mut [B; 2]: StaticWriteBuffer<Word = u8>,
+            B: 'static,
+        {
+            fn circ_read(mut self, mut buffer: &'static mut [B; 2]) -> CircBuffer<B, Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (ptr, len) = unsafe { buffer.static_write_buffer() };
+                self.channel.set_peripheral_address(
+                    unsafe { &(*$USARTX::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.channel.set_memory_address(ptr as u32, true);
+                self.channel.set_transfer_length(len);
 
-                    self.channel.set_peripheral_address(unsafe{ &(*$USARTX::ptr()).dr as *const _ as u32 }, false);
+                atomic::compiler_fence(Ordering::Release);
 
-                    self.channel.set_memory_address(ptr as u32, true);
-                    self.channel.set_transfer_length(len);
+                self.channel.ch().cr.modify(|_, w| {
+                    w.mem2mem()
+                        .clear_bit()
+                        .pl()
+                        .medium()
+                        .msize()
+                        .bits8()
+                        .psize()
+                        .bits8()
+                        .circ()
+                        .set_bit()
+                        .dir()
+                        .clear_bit()
+                });
 
-                    atomic::compiler_fence(Ordering::Release);
+                self.start();
 
-                    self.channel.ch().cr.modify(|_, w| { w
-                        .mem2mem() .clear_bit()
-                        .pl()      .medium()
-                        .msize()   .bits8()
-                        .psize()   .bits8()
-                        .circ()    .clear_bit()
-                        .dir()     .set_bit()
-                    });
-                    self.start();
-
-                    Transfer::r(buffer, self)
-                }
+                CircBuffer::new(buffer, self)
             }
-        )+
-    }
+        }
+
+        impl<B> crate::dma::ReadDma<B, u8> for $rxdma
+        where
+            B: StaticWriteBuffer<Word = u8>,
+        {
+            fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (ptr, len) = unsafe { buffer.static_write_buffer() };
+                self.channel.set_peripheral_address(
+                    unsafe { &(*$USARTX::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.channel.set_memory_address(ptr as u32, true);
+                self.channel.set_transfer_length(len);
+
+                atomic::compiler_fence(Ordering::Release);
+                self.channel.ch().cr.modify(|_, w| {
+                    w.mem2mem()
+                        .clear_bit()
+                        .pl()
+                        .medium()
+                        .msize()
+                        .bits8()
+                        .psize()
+                        .bits8()
+                        .circ()
+                        .clear_bit()
+                        .dir()
+                        .clear_bit()
+                });
+                self.start();
+
+                Transfer::w(buffer, self)
+            }
+        }
+
+        impl<B> crate::dma::WriteDma<B, u8> for $txdma
+        where
+            B: StaticReadBuffer<Word = u8>,
+        {
+            fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (ptr, len) = unsafe { buffer.static_read_buffer() };
+
+                self.channel.set_peripheral_address(
+                    unsafe { &(*$USARTX::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+
+                self.channel.set_memory_address(ptr as u32, true);
+                self.channel.set_transfer_length(len);
+
+                atomic::compiler_fence(Ordering::Release);
+
+                self.channel.ch().cr.modify(|_, w| {
+                    w.mem2mem()
+                        .clear_bit()
+                        .pl()
+                        .medium()
+                        .msize()
+                        .bits8()
+                        .psize()
+                        .bits8()
+                        .circ()
+                        .clear_bit()
+                        .dir()
+                        .set_bit()
+                });
+                self.start();
+
+                Transfer::r(buffer, self)
+            }
+        }
+    };
 }
 
 serialdma! {
@@ -797,16 +847,29 @@ serialdma! {
         dma1::C5,
         dma1::C4,
     ),
+}
+serialdma! {
     USART2: (
         RxDma2,
         TxDma2,
         dma1::C6,
         dma1::C7,
     ),
+}
+serialdma! {
     USART3: (
         RxDma3,
         TxDma3,
         dma1::C3,
         dma1::C2,
+    ),
+}
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+serialdma! {
+    UART4: (
+        RxDma4,
+        TxDma4,
+        dma2::C3,
+        dma2::C5,
     ),
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -53,8 +53,12 @@ use crate::dma::dma2;
 use crate::dma::{dma1, CircBuffer, RxDma, Transfer, TxDma, R, W};
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
-use crate::gpio::gpioc::{PC10, PC11, PC12};
-use crate::gpio::gpiod::{PD2, PD5, PD6, PD8, PD9};
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+use crate::gpio::gpioc::PC12;
+use crate::gpio::gpioc::{PC10, PC11};
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
+use crate::gpio::gpiod::PD2;
+use crate::gpio::gpiod::{PD5, PD6, PD8, PD9};
 use crate::gpio::{Alternate, Floating, Input, PushPull};
 use crate::rcc::{Clocks, Enable, GetBusFreq, RccBus, Reset};
 use crate::time::{Bps, U32Ext};
@@ -260,6 +264,7 @@ macro_rules! usart_stop_bits {
     };
 }
 
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
 macro_rules! uart_stop_bits {
     ($UARTX:ident) => {
         impl Stopbits for $UARTX {
@@ -282,7 +287,9 @@ macro_rules! uart_stop_bits {
 usart_stop_bits! {USART1}
 usart_stop_bits! {USART2}
 usart_stop_bits! {USART3}
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
 uart_stop_bits! {UART4}
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
 uart_stop_bits! {UART5}
 
 macro_rules! hal {
@@ -625,7 +632,9 @@ pub type Rx2 = Rx<USART2>;
 pub type Tx2 = Tx<USART2>;
 pub type Rx3 = Rx<USART3>;
 pub type Tx3 = Tx<USART3>;
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
 pub type Rx4 = Rx<UART4>;
+#[cfg(all(feature = "stm32f103", any(feature = "high", feature = "xl")))]
 pub type Tx4 = Tx<UART4>;
 
 use crate::dma::{Receive, TransferPayload, Transmit};


### PR DESCRIPTION
USART123 use crate::pac::usart1::RegisterBlock
UART45 use crate::pac::uart4::RegisterBlock

Cannot use the same Instance [ffba652](https://github.com/stm32-rs/stm32f1xx-hal/commit/ffba652ca0311a8e216386638adc29a9be5e536b)

I use the previous macro to increase UART45
