### PR TITLE
Derive PartialOrd for time module types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add GPIOF/GPIOG support for high/xl density lines
 - Allow using `Input<PullUp>` and `Input<PullDown>` for all alternate
   function inputs.
+- Add `PartialOrd` derivation for `Bps`, `Hertz`, `KiloHertz`, and `MegaHertz`
 
 ### Fixed
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -33,7 +33,7 @@ use cortex_m::peripheral::{DCB, DWT};
 use crate::rcc::Clocks;
 
 /// Bits per second
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
 pub struct Bps(pub u32);
 
 /// Hertz
@@ -52,7 +52,7 @@ pub struct Bps(pub u32);
 ///
 /// let freq = 60.hz();
 /// ```
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
 pub struct Hertz(pub u32);
 
 /// Kilohertz
@@ -74,7 +74,7 @@ pub struct Hertz(pub u32);
 ///
 /// let freq = 100.khz();
 /// ```
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
 pub struct KiloHertz(pub u32);
 
 /// Megahertz
@@ -95,7 +95,7 @@ pub struct KiloHertz(pub u32);
 ///
 /// let freq = 8.mhz();
 /// ```
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
 pub struct MegaHertz(pub u32);
 
 /// Time unit


### PR DESCRIPTION
This PR derives `PartialOrd` for types in the `time` module. Which is useful in cases where it is necessary to compare frequencies.

## Proposed Changes

* Derive `PartialOrd` for `Bps`
* Derive `PartialOrd` for `Hertz`
* Derive `PartialOrd` for `KiloHertz`
* Derive `PartialOrd` for `MegaHertz`
