### PR TITLE
Use max frequency and round down when calculating PCLK1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Renamed `serial`'s `RxDma`/`TxDma`'s `split` method into `release`
 - Renamed I2C's `free` method into `release`
 - Enable SPI DMA in `with_tx_dma`, not in `SpiTxDma::start`
+- Use maximum frequency of 36 MHz on PCLK1
+- Round up when calculating the PCLK1 prescaler
 
 ## [v0.7.0]- 2020-10-17
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -230,17 +230,15 @@ impl CFGR {
 
         assert!(hclk <= 72_000_000);
 
-        let ppre1_bits = self
-            .pclk1
-            .map(|pclk1| match hclk / pclk1 {
-                0 => unreachable!(),
-                1 => 0b011,
-                2 => 0b100,
-                3..=5 => 0b101,
-                6..=11 => 0b110,
-                _ => 0b111,
-            })
-            .unwrap_or(0b011);
+        let pclk1 = self.pclk1.unwrap_or_else(|| cmp::min(hclk, 36_000_000));
+        let ppre1_bits = match (hclk + pclk1 - 1) / pclk1 {
+            0 => unreachable!(),
+            1 => 0b011,
+            2 => 0b100,
+            3..=5 => 0b101,
+            6..=11 => 0b110,
+            _ => 0b111,
+        };
 
         let ppre1 = 1 << (ppre1_bits - 0b011);
         let pclk1 = hclk / u32(ppre1);


### PR DESCRIPTION
When pclk1 is not set use hclk or 36 MHz to stay below the max frequency of PCLK1.
This is needed if you set the hclk to a value > 36 MHz and don't specify a value for pclk1. Then the prescaler would be set to one automatically and the maximum value would be exceeded. 

Also round up when calculating the prescaler so that the given pclk1 value is not exceeded.
This is important because you could have configurations where the prescaler would still be too small to stay below 36 MHz. For example when hclk = 48 MHz and pclk1 = 36 Mhz than hclk / pclk1 = 1 (integer division is rounded down) and the prescaler would be set to one.