### PR TITLE
Fix, enable PWR clock before accessing the PWR_CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- RTC not enable PWR clock
 - USART2 remap
 - Fix > 2 byte i2c reads
 - Send stop after acknowledge errors on i2c

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -327,6 +327,7 @@ impl BKP {
         // Enable the backup interface by setting PWREN and BKPEN
         let rcc = unsafe { &(*RCC::ptr()) };
         crate::pac::BKP::enable(rcc);
+        crate::pac::PWR::enable(rcc);
 
         // Enable access to the backup registers
         pwr.cr.modify(|_r, w| w.dbp().set_bit());


### PR DESCRIPTION
dbp can't be written to unless PWRen has been set.
