### PR TITLE
Implement Rx/Tx reunification for Serial

### DIFF
--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -88,5 +88,13 @@ fn main() -> ! {
     assert_eq!(received, sent);
     asm::bkpt();
 
+    // And later reunite it again
+    let mut serial = tx.reunite(rx);
+    let sent = b'Z';
+    block!(serial.write(sent)).ok();
+    let received = block!(serial.read()).unwrap();
+    assert_eq!(received, sent);
+    asm::bkpt();
+
     loop {}
 }


### PR DESCRIPTION
There are many possible pin combinations for a Serial peripheral. Many support at least one alternative pin group to be used, and in addition to that, each pin can also be configured differently. For instance, instead of the common `Output<PushPull>` with an `Input<Floating>`, one could also use `Output<OpenDrain>` and `Input<PullUp>`, e.g. when
interfacing with a 1-Wire bus.

This pin information is already lost when splitting the Serial object into `Rx`/`Tx`. In order to allow a reunification into a Serial object which represents ownership of both `Tx` and `Rx`, we need a Serial variant which has that pin information erased. 

This PR introduces `ErasedSerial`, which serves exactly that purpose. In addition, `Tx` and `Rx` both gain a consuming `reunite` function which restores the original `Serial`. To facilitate that and provide the original contents of the `ErasedSerial` struct, we use the `Tx` to stash away the USART instance -- this choice is arbitrary. As the USART is zero-sized anyway and we get both parts (Rx and Tx) when reuniting, it shouldn't matter where we stash it away.

Fixes #386.