### PR TITLE
Rename Serial items

### DIFF
--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -121,7 +121,10 @@ fn main() -> ! {
         p.USART3,
         (tx_pin, rx_pin),
         &mut afio.mapr,
-        Config::default().baudrate(9600.bps()).wordlength_9(),
+        Config::default()
+            .baudrate(9600.bps())
+            .wordlength_9bits()
+            .parity_none(),
         clocks,
     )
     // Switching the 'Word' type parameter for the 'Read' and 'Write' traits from u8 to u16.

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         serial::Config::default()
             .baudrate(9600.bps())
             .stopbits(serial::StopBits::STOP2)
-            .wordlength_9()
+            .wordlength_9bits()
             .parity_odd(),
         clocks,
     );


### PR DESCRIPTION
Maybe do the following renaming?

wordlength_8 -> wordlength_8bits
wordlength_9 -> wordlength_9bits

(since there may be not only data bits but also parity)
WordLength::DataBits8 -> WordLength::Bits8
WordLength::DataBits9 -> WordLength::Bits9

And also add 
Config::wordlength(mut self, wordlength: WordLength).
