### PR TITLE
Serial rethinking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ heapless = "0.7.9"
 mfrc522 = "0.2.0"
 usb-device = "0.2.8"
 usbd-serial = "0.1.1"
+unwrap-infallible = "0.1.5"
 
 [features]
 device-selected = []

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -7,13 +7,10 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
-
 use cortex_m::asm;
-
-use nb::block;
-
 use cortex_m_rt::entry;
+use nb::block;
+use panic_halt as _;
 use stm32f1xx_hal::{pac, prelude::*, serial::Serial};
 
 #[entry]
@@ -54,16 +51,16 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(p.USART3, (tx, rx), &mut afio.mapr, 9600.bps(), &clocks);
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.write(sent)).ok();
+    block!(serial.tx.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -75,7 +72,7 @@ fn main() -> ! {
     let (mut tx, mut rx) = serial.split();
     let sent = b'Y';
     block!(tx.write(sent)).ok();
-    let received = block!(rx.read()).unwrap();
+    let received: u8 = block!(rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -58,7 +58,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(
         p.USART3,
@@ -70,10 +70,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.write(sent)).ok();
+    block!(serial.tx.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -87,8 +87,8 @@ fn main() -> ! {
 
     // Let's see if it works.'
     let sent = b'Y';
-    block!(serial.write(sent)).ok();
-    let received = block!(serial.read()).unwrap();
+    block!(serial.tx.write(sent)).ok();
+    let received: u8 = block!(serial.rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 


### PR DESCRIPTION
1. Removed duplication of `Tx` and `Rx` functions from `Serial`.
Simplifying a `Serial` type function to store three elements: `Tx`, `Rx`, `ReleaseToken`.
(breaking change:
`serial.some_tx_fn` -> `serial.tx.some_tx_fn`
`serial.some_rx_fn` -> `serial.rx.some_rx_fn`).

2. Added the ability to release resources (USART, TX_PIN, RX_PIN).

3. `Tx` simultaneously implements `Write<u8>` and `Write<u16>`.
`Rx` simultaneously implements `Read<u8>` and `Read<u16>`.
Deleted the `with_u8_data` and `with_u16_data` functions.
(the `WORD` size must be derived from the context or specified explicitly (breaking change))

(some parts of the code are not deleted but commented out
in order to make it easier to view the changes,
they will be deleted in the next commit)