### PR TITLE
Serial changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Passing the `Clocks` parameter to `Serial` by reference
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
   (the `WORD` must be derived from the context or specified explicitly)
+- Removed duplication of `Tx` and `Rx` functions from `Serial`.
+  serial.some_tx_fn -> serial.tx.some_tx_fn
+  serial.some_rx_fn -> serial.rx.some_rx_fn
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking changes
 
 - `Serial::usart1/2/3` -> `Serial::new`
+- Passing the `Clocks` parameter to `Serial` by reference
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `embedded-dma` 0.2.0
 - Connectivity line devices configuration supports ADC2
 - replace `GetBusFreq` with `BusClock` and `BusTimerClock`
+- Serial::usart1/2/3 -> Serial::new
 
 ## [v0.8.0] - 2021-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added the ability to reconfigure `Serial` by refs to 'Tx' an 'Rx' parts
+- Added the ability to release `Serial` after split
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
-- `Serial::usart1/2/3` -> `Serial::new`
+- `serial::Serial::usart1/2/3` -> `serial::new`
 - Passing the `Clocks` parameter to `Serial` by reference
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
   (the `WORD` must be derived from the context or specified explicitly)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   serial.some_tx_fn -> serial.tx.some_tx_fn
   serial.some_rx_fn -> serial.rx.some_rx_fn
 
+### Added
+
+- Added the ability to reconfigure `Serial` by refs to 'Tx' an 'Rx' parts
+
 ## [v0.9.0] - 2022-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Serial::usart1/2/3` -> `Serial::new`
 - Passing the `Clocks` parameter to `Serial` by reference
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
-  (the `WORD` must be derived from the context or specified explicitly)
 
 ### Added
 
-- Added the ability to reconfigure `Serial` by refs to 'Tx' an 'Rx' parts
-- Added the ability to release `Serial` after split
+- Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting
+- Allow `Serial` reconfiguration by reference to the `Tx` and `Rx` parts
+- Allow `Serial` release after splitting
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `gpio`: port and pin generics first, then mode, `PinMode` for modes instead of pins, other cleanups
 
+### Breaking changes
+
+- `Serial::usart1/2/3` -> `Serial::new`
+
 ## [v0.9.0] - 2022-03-02
 
 ### Added
@@ -24,7 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `embedded-dma` 0.2.0
 - Connectivity line devices configuration supports ADC2
 - replace `GetBusFreq` with `BusClock` and `BusTimerClock`
-- Serial::usart1/2/3 -> Serial::new
 
 ## [v0.8.0] - 2021-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Serial::usart1/2/3` -> `Serial::new`
 - Passing the `Clocks` parameter to `Serial` by reference
+- `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
+  (the `WORD` must be derived from the context or specified explicitly)
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
-- `serial::Serial::usart1/2/3` -> `serial::new`
+- `Serial::usart1/2/3` -> `Serial::new`
 - Passing the `Clocks` parameter to `Serial` by reference
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
   (the `WORD` must be derived from the context or specified explicitly)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Passing the `Clocks` parameter to `Serial` by reference
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
   (the `WORD` must be derived from the context or specified explicitly)
-- Removed duplication of `Tx` and `Rx` functions from `Serial`.
-  serial.some_tx_fn -> serial.tx.some_tx_fn
-  serial.some_rx_fn -> serial.rx.some_rx_fn
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ heapless = "0.7.10"
 mfrc522 = "0.2.0"
 usb-device = "0.2.8"
 usbd-serial = "0.1.1"
+unwrap-infallible = "0.1.5"
 
 [features]
 device-selected = []

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -14,7 +14,7 @@ use stm32f1xx_hal::{
     dma::Half,
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 #[entry]
@@ -48,7 +48,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -14,7 +14,7 @@ use stm32f1xx_hal::{
     dma::Half,
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{Config, Serial},
 };
 
 #[entry]
@@ -48,7 +48,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -53,7 +53,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9_600.bps()),
-        clocks,
+        &clocks,
     );
 
     let rx = serial.split().1.with_dma(channels.5);

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{Config, Serial},
 };
 
 #[entry]
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 #[entry]
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default(),
-        clocks,
+        &clocks,
     );
 
     let rx = serial.split().1.with_dma(channels.5);

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{Config, Serial},
 };
 
 #[entry]
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9_600.bps()),
-        clocks,
+        &clocks,
     );
 
     let rx = serial.split().1.with_dma(channels.5);

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 #[entry]
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{Config, Serial},
 };
 
 #[entry]
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 #[entry]
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     let tx = serial.split().0.with_dma(channels.4);

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     // Split the serial struct into a receiving and a transmitting part

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::usart3(
+    let serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -14,7 +14,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 use core::fmt::Write;
@@ -59,7 +59,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -14,7 +14,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{Config, Serial},
 };
 
 use core::fmt::Write;
@@ -59,7 +59,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -17,7 +17,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 #[entry]
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::new(
+    let mut serial = serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -70,10 +70,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.write(sent)).ok();
+    block!(serial.tx.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received: u8 = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::usart3(
+    let mut serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -73,7 +73,7 @@ fn main() -> ! {
     block!(serial.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -85,7 +85,7 @@ fn main() -> ! {
     let (mut tx, mut rx) = serial.split();
     let sent = b'Y';
     block!(tx.write(sent)).ok();
-    let received = block!(rx.read()).unwrap();
+    let received: u8 = block!(rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -19,6 +19,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{Config, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 #[entry]
 fn main() -> ! {
@@ -58,7 +59,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(
         p.USART3,
@@ -70,10 +71,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.tx.write(sent)).ok();
+    block!(serial.tx.write(sent)).unwrap_infallible();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received: u8 = block!(serial.rx.read()).unwrap();
+    let received = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -84,8 +85,8 @@ fn main() -> ! {
     // You can also split the serial struct into a receiving and a transmitting part
     let (mut tx, mut rx) = serial.split();
     let sent = b'Y';
-    block!(tx.write(sent)).ok();
-    let received: u8 = block!(rx.read()).unwrap();
+    block!(tx.write(sent)).unwrap_infallible();
+    let received = block!(rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -17,7 +17,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{Config, Serial},
 };
 
 #[entry]
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = serial::new(
+    let mut serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     // Loopback test. Write `X` and wait until the write is successful.

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -125,7 +125,7 @@ fn main() -> ! {
             .baudrate(9600.bps())
             .wordlength_9bits()
             .parity_none(),
-        clocks,
+        &clocks,
     )
     // Switching the 'Word' type parameter for the 'Read' and 'Write' traits from u8 to u16.
     .with_u16_data();

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -15,7 +15,7 @@ use panic_halt as _;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{self, Config, Serial},
 };
 
 // The address of the slave device.
@@ -117,7 +117,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART3,
         (tx_pin, rx_pin),
         &mut afio.mapr,

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -9,6 +9,7 @@
 #![no_main]
 #![no_std]
 
+use core::convert::Infallible;
 use cortex_m_rt::entry;
 use nb::block;
 use panic_halt as _;
@@ -17,6 +18,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{self, Config, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 // The address of the slave device.
 const SLAVE_ADDR: u8 = 123;
@@ -77,18 +79,19 @@ where
 // Send message.
 fn send_msg<TX>(serial_tx: &mut TX, msg: &[u8])
 where
-    TX: embedded_hal::serial::Write<u8> + embedded_hal::serial::Write<u16>,
+    TX: embedded_hal::serial::Write<u8, Error = Infallible>
+        + embedded_hal::serial::Write<u16, Error = Infallible>,
 {
     // Send address.
-    block!(serial_tx.write(SLAVE_ADDR as u16 | 0x100)).ok();
+    block!(serial_tx.write(SLAVE_ADDR as u16 | 0x100)).unwrap_infallible();
 
     // Send message len.
     assert!(msg.len() <= MSG_MAX_LEN);
-    block!(serial_tx.write(msg.len() as u8)).ok();
+    block!(serial_tx.write(msg.len() as u8)).unwrap_infallible();
 
     // Send message.
     for &b in msg {
-        block!(serial_tx.write(b)).ok();
+        block!(serial_tx.write(b)).unwrap_infallible();
     }
 }
 
@@ -115,7 +118,7 @@ fn main() -> ! {
     let tx_pin = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     let rx_pin = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -15,7 +15,7 @@ use panic_halt as _;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Rx3_16, Serial, Tx3_16},
+    serial::{self, Config, Serial},
 };
 
 // The address of the slave device.
@@ -25,7 +25,10 @@ const SLAVE_ADDR: u8 = 123;
 const MSG_MAX_LEN: usize = u8::MAX as usize;
 
 // Receives a message addressed to the slave device. Returns the size of the received message.
-fn receive_msg(serial_rx: &mut Rx3_16, buf: &mut [u8; MSG_MAX_LEN]) -> usize {
+fn receive_msg<RX>(serial_rx: &mut RX, buf: &mut [u8; MSG_MAX_LEN]) -> usize
+where
+    RX: embedded_hal::serial::Read<u16, Error = serial::Error>,
+{
     enum RxPhase {
         Start,
         Length,
@@ -72,12 +75,12 @@ fn receive_msg(serial_rx: &mut Rx3_16, buf: &mut [u8; MSG_MAX_LEN]) -> usize {
 }
 
 // Send message.
-fn send_msg(mut serial_tx: Tx3_16, msg: &[u8]) -> Tx3_16 {
+fn send_msg<TX>(serial_tx: &mut TX, msg: &[u8])
+where
+    TX: embedded_hal::serial::Write<u8> + embedded_hal::serial::Write<u16>,
+{
     // Send address.
     block!(serial_tx.write(SLAVE_ADDR as u16 | 0x100)).ok();
-
-    // Switching from u16 to u8 data.
-    let mut serial_tx = serial_tx.with_u8_data();
 
     // Send message len.
     assert!(msg.len() <= MSG_MAX_LEN);
@@ -87,9 +90,6 @@ fn send_msg(mut serial_tx: Tx3_16, msg: &[u8]) -> Tx3_16 {
     for &b in msg {
         block!(serial_tx.write(b)).ok();
     }
-
-    // Switching back from u8 to u16 data.
-    serial_tx.with_u16_data()
 }
 
 #[entry]
@@ -126,9 +126,7 @@ fn main() -> ! {
             .wordlength_9bits()
             .parity_none(),
         &clocks,
-    )
-    // Switching the 'Word' type parameter for the 'Read' and 'Write' traits from u8 to u16.
-    .with_u16_data();
+    );
 
     // Split the serial struct into a transmitting and a receiving part.
     let (mut serial_tx, mut serial_rx) = serial.split();
@@ -140,6 +138,6 @@ fn main() -> ! {
         // Receive message from master device.
         let received_msg_len = receive_msg(&mut serial_rx, &mut buf);
         // Send the received message back.
-        serial_tx = send_msg(serial_tx, &buf[..received_msg_len]);
+        send_msg(&mut serial_tx, &buf[..received_msg_len]);
     }
 }

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -117,7 +117,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::usart3(
+    let serial = Serial::new(
         p.USART3,
         (tx_pin, rx_pin),
         &mut afio.mapr,

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -15,7 +15,7 @@ use panic_halt as _;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config, Serial},
+    serial::{self, Config},
 };
 
 // The address of the slave device.
@@ -117,7 +117,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART3,
         (tx_pin, rx_pin),
         &mut afio.mapr,

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -15,7 +15,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Serial},
+    serial,
 };
 
 #[entry]
@@ -58,7 +58,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::new(
+    let serial = serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -67,7 +67,7 @@ fn main() -> ! {
             .stopbits(serial::StopBits::STOP2)
             .wordlength_9bits()
             .parity_odd(),
-        clocks,
+        &clocks,
     );
 
     // Split the serial struct into a receiving and a transmitting part

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -12,7 +12,11 @@ use panic_halt as _;
 use nb::block;
 
 use cortex_m_rt::entry;
-use stm32f1xx_hal::{pac, prelude::*, serial};
+use stm32f1xx_hal::{
+    pac,
+    prelude::*,
+    serial::{self, Serial},
+};
 
 #[entry]
 fn main() -> ! {
@@ -54,7 +58,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = serial::new(
+    let serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -17,6 +17,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{self, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 #[entry]
 fn main() -> ! {
@@ -56,7 +57,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,
@@ -74,8 +75,8 @@ fn main() -> ! {
     let (mut tx, _rx) = serial.split();
 
     let sent = b'U';
-    block!(tx.write(sent)).ok();
-    block!(tx.write(sent)).ok();
+    block!(tx.write(sent)).unwrap_infallible();
+    block!(tx.write(sent)).unwrap_infallible();
 
     loop {}
 }

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -58,7 +58,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::usart3(
+    let serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -12,11 +12,7 @@ use panic_halt as _;
 use nb::block;
 
 use cortex_m_rt::entry;
-use stm32f1xx_hal::{
-    pac,
-    prelude::*,
-    serial,
-};
+use stm32f1xx_hal::{pac, prelude::*, serial};
 
 #[entry]
 fn main() -> ! {

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -19,6 +19,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{self, Config, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 #[entry]
 fn main() -> ! {
@@ -58,7 +59,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(
         p.USART3,
@@ -70,10 +71,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.tx.write(sent)).ok();
+    block!(serial.tx.write(sent)).unwrap_infallible();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received: u8 = block!(serial.rx.read()).unwrap();
+    let received = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -87,8 +88,8 @@ fn main() -> ! {
 
     // Let's see if it works.'
     let sent = b'Y';
-    block!(serial.tx.write(sent)).ok();
-    let received: u8 = block!(serial.rx.read()).unwrap();
+    block!(serial.tx.write(sent)).unwrap_infallible();
+    let received = block!(serial.rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -17,7 +17,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config},
 };
 
 #[entry]
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::new(
+    let mut serial = serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -70,10 +70,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.write(sent)).ok();
+    block!(serial.tx.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received: u8 = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -87,8 +87,8 @@ fn main() -> ! {
 
     // Let's see if it works.'
     let sent = b'Y';
-    block!(serial.write(sent)).ok();
-    let received: u8 = block!(serial.read()).unwrap();
+    block!(serial.tx.write(sent)).ok();
+    let received: u8 = block!(serial.rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -73,7 +73,7 @@ fn main() -> ! {
     block!(serial.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -88,7 +88,7 @@ fn main() -> ! {
     // Let's see if it works.'
     let sent = b'Y';
     block!(serial.write(sent)).ok();
-    let received = block!(serial.read()).unwrap();
+    let received: u8 = block!(serial.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -17,7 +17,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Config},
+    serial::{self, Config, Serial},
 };
 
 #[entry]
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = serial::new(
+    let mut serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::usart3(
+    let mut serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     // Loopback test. Write `X` and wait until the write is successful.
@@ -83,7 +83,7 @@ fn main() -> ! {
 
     // You can reconfigure the serial port to use a different baud rate at runtime.
     // This may block for a while if the transmission is still in progress.
-    block!(serial.reconfigure(Config::default().baudrate(115_200.bps()), clocks)).unwrap();
+    block!(serial.reconfigure(Config::default().baudrate(115_200.bps()), &clocks)).unwrap();
 
     // Let's see if it works.'
     let sent = b'Y';

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -92,5 +92,14 @@ fn main() -> ! {
     assert_eq!(received, sent);
     asm::bkpt();
 
+    let (mut tx, mut rx) = serial.split();
+    block!(serial::reconfigure(
+        &mut tx,
+        &mut rx,
+        Config::default().baudrate(9600.bps()),
+        &clocks
+    ))
+    .unwrap();
+
     loop {}
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,6 +13,7 @@ pub use crate::hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_Stat
 pub use crate::hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32_hal_rcc_RccExt;
+pub use crate::serial::SerialNew as _stm32_hal_serial_SerialNew;
 pub use crate::time::U32Ext as _stm32_hal_time_U32Ext;
 #[cfg(feature = "rtic")]
 pub use crate::timer::MonoTimerExt as _stm32f4xx_hal_timer_MonoTimerExt;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,6 @@ pub use crate::hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_Stat
 pub use crate::hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32_hal_rcc_RccExt;
-pub use crate::serial::SerialNew as _stm32_hal_serial_SerialNew;
 pub use crate::time::U32Ext as _stm32_hal_time_U32Ext;
 #[cfg(feature = "rtic")]
 pub use crate::timer::MonoTimerExt as _stm32f4xx_hal_timer_MonoTimerExt;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -271,11 +271,7 @@ pub struct Rx<USART> {
     _usart: PhantomData<USART>,
 }
 
-impl<USART, PINS> Serial<USART, PINS>
-where
-    USART: Instance,
-    PINS: Pins<USART>,
-{
+impl<USART: Instance, PINS> Serial<USART, PINS> {
     /// Configures the serial interface and creates the interface
     /// struct.
     ///
@@ -297,7 +293,10 @@ where
         mapr: &mut MAPR,
         config: impl Into<Config>,
         clocks: &Clocks,
-    ) -> Self {
+    ) -> Self
+    where
+        PINS: Pins<USART>,
+    {
         // enable and reset $USARTX
         let rcc = unsafe { &(*RCC::ptr()) };
         USART::enable(rcc);

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -526,7 +526,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::serial::Read<u8> for Serial<USART, PINS>
+impl<USART, PINS> embedded_hal::serial::Read<u8> for Serial<USART, PINS>
 where
     USART: Instance,
 {
@@ -537,7 +537,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::serial::Read<u16> for Serial<USART, PINS>
+impl<USART, PINS> embedded_hal::serial::Read<u16> for Serial<USART, PINS>
 where
     USART: Instance,
 {
@@ -548,7 +548,7 @@ where
     }
 }
 
-impl<USART> crate::hal::serial::Read<u8> for Rx<USART>
+impl<USART> embedded_hal::serial::Read<u8> for Rx<USART>
 where
     USART: Instance,
 {
@@ -564,7 +564,7 @@ where
 /// If the UART/USART was configured with `WordLength::Bits9`, the returned value will contain
 /// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
 /// 8 received data bits and all other bits set to zero.
-impl<USART> crate::hal::serial::Read<u16> for Rx<USART>
+impl<USART> embedded_hal::serial::Read<u16> for Rx<USART>
 where
     USART: Instance,
 {
@@ -618,7 +618,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::serial::Write<u8> for Serial<USART, PINS>
+impl<USART, PINS> embedded_hal::serial::Write<u8> for Serial<USART, PINS>
 where
     USART: Instance,
 {
@@ -633,7 +633,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::serial::Write<u16> for Serial<USART, PINS>
+impl<USART, PINS> embedded_hal::serial::Write<u16> for Serial<USART, PINS>
 where
     USART: Instance,
 {
@@ -648,7 +648,7 @@ where
     }
 }
 
-impl<USART> crate::hal::serial::Write<u8> for Tx<USART>
+impl<USART> embedded_hal::serial::Write<u8> for Tx<USART>
 where
     USART: Instance,
 {
@@ -668,7 +668,7 @@ where
 /// If the UART/USART was configured with `WordLength::Bits9`, the 9 least significant bits will
 /// be transmitted and the other 7 bits will be ignored. Otherwise, the 8 least significant bits
 /// will be transmitted and the other 8 bits will be ignored.
-impl<USART> crate::hal::serial::Write<u16> for Tx<USART>
+impl<USART> embedded_hal::serial::Write<u16> for Tx<USART>
 where
     USART: Instance,
 {
@@ -713,7 +713,7 @@ where
     }
 }
 
-impl<USART> crate::hal::blocking::serial::Write<u16> for Tx<USART>
+impl<USART> embedded_hal::blocking::serial::Write<u16> for Tx<USART>
 where
     USART: Instance,
 {
@@ -728,7 +728,7 @@ where
     }
 }
 
-impl<USART> crate::hal::blocking::serial::Write<u8> for Tx<USART>
+impl<USART> embedded_hal::blocking::serial::Write<u8> for Tx<USART>
 where
     USART: Instance,
 {
@@ -766,7 +766,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::blocking::serial::Write<u16> for Serial<USART, PINS>
+impl<USART, PINS> embedded_hal::blocking::serial::Write<u16> for Serial<USART, PINS>
 where
     USART: Instance,
     Tx<USART>: embedded_hal::serial::Write<u16, Error = Infallible>,
@@ -782,7 +782,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::blocking::serial::Write<u8> for Serial<USART, PINS>
+impl<USART, PINS> embedded_hal::blocking::serial::Write<u8> for Serial<USART, PINS>
 where
     USART: Instance,
 {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -298,7 +298,7 @@ where
     USART: Instance,
     PINS: Pins<USART>,
 {
-    fn init(self, config: Config, clocks: Clocks, mapr: &mut MAPR) -> Self {
+    fn init(self, config: Config, clocks: &Clocks, mapr: &mut MAPR) -> Self {
         // enable and reset $USARTX
         let rcc = unsafe { &(*RCC::ptr()) };
         USART::enable(rcc);
@@ -317,7 +317,7 @@ where
         self
     }
 
-    fn apply_config(&self, config: Config, clocks: Clocks) {
+    fn apply_config(&self, config: Config, clocks: &Clocks) {
         // Configure baud rate
         let brr = USART::clock(&clocks).raw() / config.baudrate.0;
         assert!(brr >= 16, "impossible baud rate");
@@ -355,7 +355,7 @@ where
     pub fn reconfigure(
         &mut self,
         config: impl Into<Config>,
-        clocks: Clocks,
+        clocks: &Clocks,
     ) -> nb::Result<(), Infallible> {
         // if we're currently busy transmitting, we have to wait until that is
         // over -- regarding reception, we assume that the caller -- with
@@ -364,7 +364,7 @@ where
         if self.usart.sr.read().tc().bit_is_clear() {
             return nb::Result::Err(nb::Error::WouldBlock);
         }
-        self.apply_config(config.into(), clocks);
+        self.apply_config(config.into(), &clocks);
         nb::Result::Ok(())
     }
 
@@ -429,7 +429,7 @@ pub trait SerialNew<USART, PINS> {
         pins: PINS,
         mapr: &mut MAPR,
         config: impl Into<Config>,
-        clocks: Clocks,
+        clocks: &Clocks,
     ) -> Self
     where
         PINS: Pins<USART>;
@@ -470,7 +470,7 @@ macro_rules! hal {
                 pins: PINS,
                 mapr: &mut MAPR,
                 config: impl Into<Config>,
-                clocks: Clocks,
+                clocks: &Clocks,
             ) -> Serial<$USARTX, PINS>
             where
                 PINS: Pins<$USARTX>,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -402,18 +402,6 @@ where
     }
 }
 
-pub trait SerialNew<USART, PINS> {
-    fn new(
-        usart: USART,
-        pins: PINS,
-        mapr: &mut MAPR,
-        config: impl Into<Config>,
-        clocks: &Clocks,
-    ) -> Self
-    where
-        PINS: Pins<USART>;
-}
-
 macro_rules! hal {
     (
         $(#[$meta:meta])*
@@ -424,42 +412,38 @@ macro_rules! hal {
                 <$USARTX>::ptr() as *const _
             }
         }
-
-        $(#[$meta])*
-        /// The behaviour of the functions is equal for all three USARTs.
-        /// Except that they are using the corresponding USART hardware and pins.
-        impl<PINS> SerialNew<$USARTX, PINS> for Serial<$USARTX, PINS> {
-            /// Configures the serial interface and creates the interface
-            /// struct.
-            ///
-            /// `Bps` is the baud rate of the interface.
-            ///
-            /// `Clocks` passes information about the current frequencies of
-            /// the clocks.  The existence of the struct ensures that the
-            /// clock settings are fixed.
-            ///
-            /// The `serial` struct takes ownership over the `USARTX` device
-            /// registers and the specified `PINS`
-            ///
-            /// `MAPR` and `APBX` are register handles which are passed for
-            /// configuration. (`MAPR` is used to map the USART to the
-            /// corresponding pins. `APBX` is used to reset the USART.)
-            fn new(
-                usart: $USARTX,
-                pins: PINS,
-                mapr: &mut MAPR,
-                config: impl Into<Config>,
-                clocks: &Clocks,
-            ) -> Serial<$USARTX, PINS>
-            where
-                PINS: Pins<$USARTX>,
-            {
-                Serial { usart, pins, tx: Tx::new(), rx: Rx::new() }.init(config.into(), clocks, mapr)
-            }
-        }
-
     };
 }
+
+/// Configures the serial interface and creates the interface
+/// struct.
+///
+/// `Bps` is the baud rate of the interface.
+///
+/// `Clocks` passes information about the current frequencies of
+/// the clocks.  The existence of the struct ensures that the
+/// clock settings are fixed.
+///
+/// The `serial` struct takes ownership over the `USARTX` device
+/// registers and the specified `PINS`
+///
+/// `MAPR` and `APBX` are register handles which are passed for
+/// configuration. (`MAPR` is used to map the USART to the
+/// corresponding pins. `APBX` is used to reset the USART.)
+pub fn new<USART, PINS>(
+    usart: USART,
+    pins: PINS,
+    mapr: &mut MAPR,
+    config: impl Into<Config>,
+    clocks: &Clocks,
+) -> Serial<USART, PINS>
+where
+    USART: Instance,
+    PINS: Pins<USART>,
+{
+    Serial { usart, pins, tx: Tx::new(), rx: Rx::new() }.init(config.into(), clocks, mapr)
+}
+
 
 hal! {
     /// # USART1 functions

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -340,7 +340,7 @@ impl<USART: Instance, PINS> Serial<USART, PINS> {
         // what they're doing.
         self.tx.flush()?;
 
-        apply_config::<USART>(config.into(), &clocks);
+        apply_config::<USART>(config.into(), clocks);
         nb::Result::Ok(())
     }
 
@@ -382,7 +382,7 @@ fn apply_config<USART: Instance>(config: Config, clocks: &Clocks) {
     let usart = unsafe { &*USART::ptr() };
 
     // Configure baud rate
-    let brr = USART::clock(&clocks).raw() / config.baudrate.0;
+    let brr = USART::clock(clocks).raw() / config.baudrate.0;
     assert!(brr >= 16, "impossible baud rate");
     usart.brr.write(|w| unsafe { w.bits(brr) });
 
@@ -428,7 +428,7 @@ pub fn reconfigure<USART: Instance>(
     // what they're doing.
     tx.flush()?;
 
-    apply_config::<USART>(config.into(), &clocks);
+    apply_config::<USART>(config.into(), clocks);
     nb::Result::Ok(())
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -426,11 +426,22 @@ where
     }
 }
 
+pub trait SerialNew<USART, PINS> {
+    fn new(
+        usart: USART,
+        pins: PINS,
+        mapr: &mut MAPR,
+        config: impl Into<Config>,
+        clocks: Clocks,
+    ) -> Self
+    where
+        PINS: Pins<USART>;
+}
+
 macro_rules! hal {
     (
         $(#[$meta:meta])*
         $USARTX:ident: (
-            $usartX:ident,
             $usartX_remap:ident,
             $bit:ident,
             $closure:expr,
@@ -445,7 +456,7 @@ macro_rules! hal {
         $(#[$meta])*
         /// The behaviour of the functions is equal for all three USARTs.
         /// Except that they are using the corresponding USART hardware and pins.
-        impl<PINS> Serial<$USARTX, PINS> {
+        impl<PINS> SerialNew<$USARTX, PINS> for Serial<$USARTX, PINS> {
             /// Configures the serial interface and creates the interface
             /// struct.
             ///
@@ -461,13 +472,13 @@ macro_rules! hal {
             /// `MAPR` and `APBX` are register handles which are passed for
             /// configuration. (`MAPR` is used to map the USART to the
             /// corresponding pins. `APBX` is used to reset the USART.)
-            pub fn $usartX(
+            fn new(
                 usart: $USARTX,
                 pins: PINS,
                 mapr: &mut MAPR,
                 config: impl Into<Config>,
                 clocks: Clocks,
-            ) -> Self
+            ) -> Serial<$USARTX, PINS>
             where
                 PINS: Pins<$USARTX>,
             {
@@ -487,7 +498,6 @@ macro_rules! hal {
 hal! {
     /// # USART1 functions
     USART1: (
-        usart1,
         usart1_remap,
         bit,
         |remap| remap == 1,
@@ -496,7 +506,6 @@ hal! {
 hal! {
     /// # USART2 functions
     USART2: (
-        usart2,
         usart2_remap,
         bit,
         |remap| remap == 1,
@@ -505,7 +514,6 @@ hal! {
 hal! {
     /// # USART3 functions
     USART3: (
-        usart3,
         usart3_remap,
         bits,
         |remap| remap,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -121,36 +121,32 @@ pub enum Error {
 // USART REMAPPING, see: https://www.st.com/content/ccc/resource/technical/document/reference_manual/59/b9/ba/7f/11/af/43/d5/CD00171190.pdf/files/CD00171190.pdf/jcr:content/translations/en.CD00171190.pdf
 // Section 9.3.8
 pub trait Pins<USART> {
-    const REMAP: u8;
+    fn remap(mapr: &mut MAPR);
 }
 
-impl<INMODE, OUTMODE> Pins<USART1> for (gpio::PA9<Alternate<OUTMODE>>, gpio::PA10<Input<INMODE>>) {
-    const REMAP: u8 = 0;
+macro_rules! remap {
+    ($($USART:ty, $TX:ident, $RX:ident => { $remapex:expr };)+) => {
+        $(
+            impl<INMODE, OUTMODE> Pins<$USART> for (gpio::$TX<Alternate<OUTMODE>>, gpio::$RX<Input<INMODE>>) {
+                fn remap(mapr: &mut MAPR) {
+                    mapr.modify_mapr($remapex);
+                }
+            }
+        )+
+    }
 }
 
-impl<INMODE, OUTMODE> Pins<USART1> for (gpio::PB6<Alternate<OUTMODE>>, gpio::PB7<Input<INMODE>>) {
-    const REMAP: u8 = 1;
-}
+remap!(
+    USART1, PA9, PA10 => { |_, w| w.usart1_remap().bit(false) };
+    USART1, PB6, PB7  => { |_, w| w.usart1_remap().bit(true) };
 
-impl<INMODE, OUTMODE> Pins<USART2> for (gpio::PA2<Alternate<OUTMODE>>, gpio::PA3<Input<INMODE>>) {
-    const REMAP: u8 = 0;
-}
+    USART2, PA2, PA3 => { |_, w| w.usart2_remap().bit(false) };
+    USART2, PD5, PD6 => { |_, w| w.usart2_remap().bit(true) };
 
-impl<INMODE, OUTMODE> Pins<USART2> for (gpio::PD5<Alternate<OUTMODE>>, gpio::PD6<Input<INMODE>>) {
-    const REMAP: u8 = 1;
-}
-
-impl<INMODE, OUTMODE> Pins<USART3> for (gpio::PB10<Alternate<OUTMODE>>, gpio::PB11<Input<INMODE>>) {
-    const REMAP: u8 = 0;
-}
-
-impl<INMODE, OUTMODE> Pins<USART3> for (gpio::PC10<Alternate<OUTMODE>>, gpio::PC11<Input<INMODE>>) {
-    const REMAP: u8 = 1;
-}
-
-impl<INMODE, OUTMODE> Pins<USART3> for (gpio::PD8<Alternate<OUTMODE>>, gpio::PD9<Input<INMODE>>) {
-    const REMAP: u8 = 0b11;
-}
+    USART3, PB10, PB11 => { |_, w| unsafe { w.usart3_remap().bits(0b00)} };
+    USART3, PC10, PC11 => { |_, w| unsafe { w.usart3_remap().bits(0b01)} };
+    USART3, PD8, PD9 => { |_, w| unsafe { w.usart3_remap().bits(0b11)} };
+);
 
 pub enum WordLength {
     /// When parity is enabled, a word has 7 data bits + 1 parity bit,
@@ -300,14 +296,15 @@ impl<USART, WORD> Tx<USART, WORD> {
 impl<USART, PINS, WORD> Serial<USART, PINS, WORD>
 where
     USART: Instance,
+    PINS: Pins<USART>,
 {
-    fn init(self, config: Config, clocks: Clocks, remap: impl FnOnce()) -> Self {
+    fn init(self, config: Config, clocks: Clocks, mapr: &mut MAPR) -> Self {
         // enable and reset $USARTX
         let rcc = unsafe { &(*RCC::ptr()) };
         USART::enable(rcc);
         USART::reset(rcc);
 
-        remap();
+        PINS::remap(mapr);
         self.apply_config(config, clocks);
 
         // UE: enable USART
@@ -441,11 +438,7 @@ pub trait SerialNew<USART, PINS> {
 macro_rules! hal {
     (
         $(#[$meta:meta])*
-        $USARTX:ident: (
-            $usartX_remap:ident,
-            $bit:ident,
-            $closure:expr,
-        ),
+        $USARTX:ident
     ) => {
         impl Instance for $USARTX {
             fn ptr() -> *const uart_base::RegisterBlock {
@@ -482,13 +475,7 @@ macro_rules! hal {
             where
                 PINS: Pins<$USARTX>,
             {
-                #[allow(unused_unsafe)]
-                Serial { usart, pins, tx: Tx::new(), rx: Rx::new() }.init(config.into(), clocks, || {
-                    mapr.modify_mapr(|_, w| unsafe {
-                        #[allow(clippy::redundant_closure_call)]
-                        w.$usartX_remap().$bit(($closure)(PINS::REMAP))
-                    })
-                })
+                Serial { usart, pins, tx: Tx::new(), rx: Rx::new() }.init(config.into(), clocks, mapr)
             }
         }
 
@@ -497,27 +484,15 @@ macro_rules! hal {
 
 hal! {
     /// # USART1 functions
-    USART1: (
-        usart1_remap,
-        bit,
-        |remap| remap == 1,
-    ),
+    USART1
 }
 hal! {
     /// # USART2 functions
-    USART2: (
-        usart2_remap,
-        bit,
-        |remap| remap == 1,
-    ),
+    USART2
 }
 hal! {
     /// # USART3 functions
-    USART3: (
-        usart3_remap,
-        bits,
-        |remap| remap,
-    ),
+    USART3
 }
 
 impl<USART> Tx<USART>

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -441,9 +441,14 @@ where
     USART: Instance,
     PINS: Pins<USART>,
 {
-    Serial { usart, pins, tx: Tx::new(), rx: Rx::new() }.init(config.into(), clocks, mapr)
+    Serial {
+        usart,
+        pins,
+        tx: Tx::new(),
+        rx: Rx::new(),
+    }
+    .init(config.into(), clocks, mapr)
 }
-
 
 hal! {
     /// # USART1 functions
@@ -764,7 +769,7 @@ where
 impl<USART, PINS> crate::hal::blocking::serial::Write<u16> for Serial<USART, PINS>
 where
     USART: Instance,
-    Tx<USART>: embedded_hal::serial::Write<u16, Error = Infallible>
+    Tx<USART>: embedded_hal::serial::Write<u16, Error = Infallible>,
 {
     type Error = Infallible;
 


### PR DESCRIPTION
- `Serial::usart1/2/3` -> `Serial::new`
- Passing the `Clocks` parameter to `Serial` by reference
- `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16
- Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting
- Allow `Serial` reconfiguration by reference to the `Tx` and `Rx` parts
- Allow `Serial` release after splitting
- Other various `Serial` improvements