### PR TITLE
Serial changes v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting.
 - Allow `Serial` reconfiguration by references to the `Tx` and `Rx` parts.
+- Allow `Serial` release after splitting.
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking changes
 
 - Passing the `Clock` parameter to `Serial` by reference
+- `Serial::usart1/2/3` -> `Serial::new`
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
-- Passing the `Clock` parameter to `Serial` by reference
-- `Serial::usart1/2/3` -> `Serial::new`
+- Passing the `Clock` parameter to `Serial` by reference.
+- `Serial::usart1/2/3` -> `Serial::new`.
+- `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16.
+
+### Added
+
+- Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting.
 
 ## [v0.9.0] - 2022-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `gpio`: port and pin generics first, then mode, `PinMode` for modes instead of pins, other cleanups
 
+### Breaking changes
+
+- Passing the `Clock` parameter to `Serial` by reference
+
 ## [v0.9.0] - 2022-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting.
+- Allow `Serial` reconfiguration by references to the `Tx` and `Rx` parts.
 
 ## [v0.9.0] - 2022-03-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ heapless = "0.7.10"
 mfrc522 = "0.2.0"
 usb-device = "0.2.8"
 usbd-serial = "0.1.1"
+unwrap-infallible = "0.1.5"
 
 [features]
 device-selected = []

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    let rx = serial.split().1.with_dma(channels.5);
+    let rx = serial.rx.with_dma(channels.5);
     let buf = singleton!(: [[u8; 8]; 2] = [[0; 8]; 2]).unwrap();
 
     let mut circ_buffer = rx.circ_read(buf);

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -53,7 +53,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9_600.bps()),
-        clocks,
+        &clocks,
     );
 
     let rx = serial.split().1.with_dma(channels.5);

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    let rx = serial.split().1.with_dma(channels.5);
+    let rx = serial.rx.with_dma(channels.5);
     let buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
 
     let t = rx.read(buf);

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default(),
-        clocks,
+        &clocks,
     );
 
     let rx = serial.split().1.with_dma(channels.5);

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    let rx = serial.split().1.with_dma(channels.5);
+    let rx = serial.rx.with_dma(channels.5);
     let buf = singleton!(: [u8; 8] = [0; 8]).unwrap();
 
     let (_buf, _rx) = rx.read(buf).wait();

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9_600.bps()),
-        clocks,
+        &clocks,
     );
 
     let rx = serial.split().1.with_dma(channels.5);

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    let tx = serial.split().0.with_dma(channels.4);
+    let tx = serial.tx.with_dma(channels.4);
 
     let (_, tx) = tx.write(b"The quick brown fox").wait();
 

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let tx = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     // let rx = gpiob.pb11;
 
-    let serial = Serial::usart1(
+    let serial = Serial::new(
         p.USART1,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     let tx = serial.split().0.with_dma(channels.4);

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     // Split the serial struct into a receiving and a transmitting part

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::usart3(
+    let serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -19,6 +19,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{Config, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 #[entry]
 fn main() -> ! {
@@ -58,7 +59,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(
         p.USART3,
@@ -70,7 +71,7 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.tx.write(sent)).ok();
+    block!(serial.tx.write(sent)).unwrap_infallible();
 
     // Read the byte that was just sent. Blocks until the read is complete
     let received = block!(serial.rx.read()).unwrap();
@@ -84,7 +85,7 @@ fn main() -> ! {
     // You can also split the serial struct into a receiving and a transmitting part
     let (mut tx, mut rx) = serial.split();
     let sent = b'Y';
-    block!(tx.write(sent)).ok();
+    block!(tx.write(sent)).unwrap_infallible();
     let received = block!(rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::usart3(
+    let mut serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -70,10 +70,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.write(sent)).ok();
+    block!(serial.tx.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(serial.read()).unwrap();
+    let received = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     // Loopback test. Write `X` and wait until the write is successful.

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -125,7 +125,7 @@ fn main() -> ! {
             .baudrate(9600.bps())
             .wordlength_9bits()
             .parity_none(),
-        clocks,
+        &clocks,
     )
     // Switching the 'Word' type parameter for the 'Read' and 'Write' traits from u8 to u16.
     .with_u16_data();

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -18,6 +18,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{self, Config, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 // The address of the slave device.
 const SLAVE_ADDR: u8 = 123;
@@ -82,15 +83,15 @@ where
         + embedded_hal::serial::Write<u16, Error = Infallible>,
 {
     // Send address.
-    block!(serial_tx.write(SLAVE_ADDR as u16 | 0x100)).ok();
+    block!(serial_tx.write(SLAVE_ADDR as u16 | 0x100)).unwrap_infallible();
 
     // Send message len.
     assert!(msg.len() <= MSG_MAX_LEN);
-    block!(serial_tx.write(msg.len() as u8)).ok();
+    block!(serial_tx.write(msg.len() as u8)).unwrap_infallible();
 
     // Send message.
     for &b in msg {
-        block!(serial_tx.write(b)).ok();
+        block!(serial_tx.write(b)).unwrap_infallible();
     }
 }
 
@@ -117,7 +118,7 @@ fn main() -> ! {
     let tx_pin = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
     let rx_pin = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -117,7 +117,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::usart3(
+    let serial = Serial::new(
         p.USART3,
         (tx_pin, rx_pin),
         &mut afio.mapr,

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -67,7 +67,7 @@ fn main() -> ! {
             .stopbits(serial::StopBits::STOP2)
             .wordlength_9bits()
             .parity_odd(),
-        clocks,
+        &clocks,
     );
 
     // Split the serial struct into a receiving and a transmitting part

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -17,6 +17,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{self, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 #[entry]
 fn main() -> ! {
@@ -56,7 +57,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,
@@ -74,8 +75,8 @@ fn main() -> ! {
     let (mut tx, _rx) = serial.split();
 
     let sent = b'U';
-    block!(tx.write(sent)).ok();
-    block!(tx.write(sent)).ok();
+    block!(tx.write(sent)).unwrap_infallible();
+    block!(tx.write(sent)).unwrap_infallible();
 
     loop {}
 }

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -58,7 +58,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::usart3(
+    let serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -17,7 +17,7 @@ use cortex_m_rt::entry;
 use stm32f1xx_hal::{
     pac,
     prelude::*,
-    serial::{Config, Serial},
+    serial::{self, Config, Serial},
 };
 
 #[entry]
@@ -91,6 +91,16 @@ fn main() -> ! {
     let received = block!(serial.rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
+
+    // You can reconfigure the serial port after split.
+    let (mut tx, mut rx) = serial.split();
+    block!(serial::reconfigure(
+        &mut tx,
+        &mut rx,
+        Config::default().baudrate(9600.bps()),
+        &clocks
+    ))
+    .unwrap();
 
     loop {}
 }

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -70,10 +70,10 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.write(sent)).ok();
+    block!(serial.tx.write(sent)).ok();
 
     // Read the byte that was just sent. Blocks until the read is complete
-    let received = block!(serial.read()).unwrap();
+    let received = block!(serial.rx.read()).unwrap();
 
     // Since we have connected tx and rx, the byte we sent should be the one we received
     assert_eq!(received, sent);
@@ -87,8 +87,8 @@ fn main() -> ! {
 
     // Let's see if it works.'
     let sent = b'Y';
-    block!(serial.write(sent)).ok();
-    let received = block!(serial.read()).unwrap();
+    block!(serial.tx.write(sent)).ok();
+    let received = block!(serial.rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();
 

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::usart3(
+    let mut serial = Serial::new(
         p.USART3,
         (tx, rx),
         &mut afio.mapr,

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         (tx, rx),
         &mut afio.mapr,
         Config::default().baudrate(9600.bps()),
-        clocks,
+        &clocks,
     );
 
     // Loopback test. Write `X` and wait until the write is successful.
@@ -83,7 +83,7 @@ fn main() -> ! {
 
     // You can reconfigure the serial port to use a different baud rate at runtime.
     // This may block for a while if the transmission is still in progress.
-    block!(serial.reconfigure(Config::default().baudrate(115_200.bps()), clocks)).unwrap();
+    block!(serial.reconfigure(Config::default().baudrate(115_200.bps()), &clocks)).unwrap();
 
     // Let's see if it works.'
     let sent = b'Y';

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -19,6 +19,7 @@ use stm32f1xx_hal::{
     prelude::*,
     serial::{self, Config, Serial},
 };
+use unwrap_infallible::UnwrapInfallible;
 
 #[entry]
 fn main() -> ! {
@@ -58,7 +59,7 @@ fn main() -> ! {
     // Take ownership over pb11
     let rx = gpiob.pb11;
 
-    // Set up the usart device. Taks ownership over the USART register and tx/rx pins. The rest of
+    // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(
         p.USART3,
@@ -70,7 +71,7 @@ fn main() -> ! {
 
     // Loopback test. Write `X` and wait until the write is successful.
     let sent = b'X';
-    block!(serial.tx.write(sent)).ok();
+    block!(serial.tx.write(sent)).unwrap_infallible();
 
     // Read the byte that was just sent. Blocks until the read is complete
     let received = block!(serial.rx.read()).unwrap();
@@ -87,7 +88,7 @@ fn main() -> ! {
 
     // Let's see if it works.'
     let sent = b'Y';
-    block!(serial.tx.write(sent)).ok();
+    block!(serial.tx.write(sent)).unwrap_infallible();
     let received = block!(serial.rx.read()).unwrap();
     assert_eq!(received, sent);
     asm::bkpt();

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -43,7 +43,7 @@
 //!         .baudrate(9_600.bps())
 //!         .wordlength_9bits()
 //!         .parity_none(),
-//!     clocks,
+//!     &clocks,
 //! );
 //!
 //! // Switching the 'Word' type parameter for the 'Read' and 'Write' traits between u8 and u16.
@@ -297,7 +297,7 @@ impl<USART, PINS, WORD> Serial<USART, PINS, WORD>
 where
     USART: Instance,
 {
-    fn init(self, config: Config, clocks: Clocks, remap: impl FnOnce()) -> Self {
+    fn init(self, config: Config, clocks: &Clocks, remap: impl FnOnce()) -> Self {
         // enable and reset $USARTX
         let rcc = unsafe { &(*RCC::ptr()) };
         USART::enable(rcc);
@@ -316,9 +316,9 @@ where
         self
     }
 
-    fn apply_config(&self, config: Config, clocks: Clocks) {
+    fn apply_config(&self, config: Config, clocks: &Clocks) {
         // Configure baud rate
-        let brr = USART::clock(&clocks).raw() / config.baudrate.0;
+        let brr = USART::clock(clocks).raw() / config.baudrate.0;
         assert!(brr >= 16, "impossible baud rate");
         self.usart.brr.write(|w| unsafe { w.bits(brr) });
 
@@ -354,7 +354,7 @@ where
     pub fn reconfigure(
         &mut self,
         config: impl Into<Config>,
-        clocks: Clocks,
+        clocks: &Clocks,
     ) -> nb::Result<(), Infallible> {
         // if we're currently busy transmitting, we have to wait until that is
         // over -- regarding reception, we assume that the caller -- with
@@ -459,7 +459,7 @@ macro_rules! hal {
                 pins: PINS,
                 mapr: &mut MAPR,
                 config: impl Into<Config>,
-                clocks: Clocks,
+                clocks: &Clocks,
             ) -> Self
             where
                 PINS: Pins<$USARTX>,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -46,37 +46,21 @@
 //!     &clocks,
 //! );
 //!
-//! // Switching the 'Word' type parameter for the 'Read' and 'Write' traits between u8 and u16.
-//! let serial = serial.with_u16_data();
-//! let serial = serial.with_u8_data();
-//!
 //! // Separate into tx and rx channels
 //! let (mut tx, mut rx) = serial.split();
 //!
-//! // Switch tx to u16.
-//! let mut tx = tx.with_u16_data();
-//!
-//! // Write data to the USART.
+//! // Write data (9 bits) to the USART.
 //! // Depending on the configuration, only the lower 7, 8, or 9 bits are used.
-//! block!(tx.write(0x1FF)).ok();
+//! block!(tx.write_u16(0x1FF)).ok();
 //!
-//! // Switch tx back to u8
-//! let mut tx = tx.with_u8_data();
-//!
-//! // Write 'R' to the USART
+//! // Write 'R' (8 bits) to the USART
 //! block!(tx.write(b'R')).ok();
 //!
-//! // Switch rx to u16.
-//! let mut rx = rx.with_u16_data();
+//! // Receive a data (9 bits) from the USART and store it in "received"
+//! let received = block!(rx.read_u16()).unwrap();
 //!
-//! // Receive a data from the USART and store it in "received"
-//! let received: u16 = block!(rx.read()).unwrap();
-//!
-//! // Switch rx back to u8.
-//! let mut rx = rx.with_u8_data();
-//!
-//! // Receive a data from the USART and store it in "received"
-//! let received: u8 = block!(rx.read()).unwrap();
+//! // Receive a data (8 bits) from the USART and store it in "received"
+//! let received = block!(rx.read()).unwrap();
 //!  ```
 
 use core::convert::Infallible;
@@ -249,11 +233,11 @@ impl From<Bps> for Config {
 use crate::pac::usart1 as uart_base;
 
 /// Serial abstraction
-pub struct Serial<USART, PINS, WORD = u8> {
+pub struct Serial<USART, PINS> {
     usart: USART,
     pins: PINS,
-    tx: Tx<USART, WORD>,
-    rx: Rx<USART, WORD>,
+    pub tx: Tx<USART>,
+    pub rx: Rx<USART>,
 }
 
 pub trait Instance:
@@ -264,36 +248,32 @@ pub trait Instance:
 }
 
 /// Serial receiver
-pub struct Rx<USART, WORD = u8> {
+pub struct Rx<USART> {
     _usart: PhantomData<USART>,
-    _word: PhantomData<WORD>,
 }
 
 /// Serial transmitter
-pub struct Tx<USART, WORD = u8> {
+pub struct Tx<USART> {
     _usart: PhantomData<USART>,
-    _word: PhantomData<WORD>,
 }
 
-impl<USART, WORD> Rx<USART, WORD> {
+impl<USART> Rx<USART> {
     fn new() -> Self {
         Self {
             _usart: PhantomData,
-            _word: PhantomData,
         }
     }
 }
 
-impl<USART, WORD> Tx<USART, WORD> {
+impl<USART> Tx<USART> {
     fn new() -> Self {
         Self {
             _usart: PhantomData,
-            _word: PhantomData,
         }
     }
 }
 
-impl<USART, PINS, WORD> Serial<USART, PINS, WORD>
+impl<USART, PINS> Serial<USART, PINS>
 where
     USART: Instance,
 {
@@ -446,7 +426,7 @@ where
 
     /// Separates the serial struct into separate channel objects for sending (Tx) and
     /// receiving (Rx)
-    pub fn split(self) -> (Tx<USART, WORD>, Rx<USART, WORD>) {
+    pub fn split(self) -> (Tx<USART>, Rx<USART>) {
         (self.tx, self.rx)
     }
 }
@@ -477,6 +457,49 @@ impl<USART> Tx<USART>
 where
     USART: Instance,
 {
+    pub fn write_u16(&mut self, word: u16) -> nb::Result<(), Infallible> {
+        let usart = unsafe { &*USART::ptr() };
+
+        if usart.sr.read().txe().bit_is_set() {
+            usart.dr.write(|w| w.dr().bits(word));
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    pub fn write(&mut self, word: u8) -> nb::Result<(), Infallible> {
+        self.write_u16(word as u16)
+    }
+
+    pub fn bwrite_all_u16(&mut self, buffer: &[u16]) -> Result<(), Infallible> {
+        for &w in buffer {
+            nb::block!(self.write_u16(w))?;
+        }
+        Ok(())
+    }
+
+    pub fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Infallible> {
+        for &w in buffer {
+            nb::block!(self.write(w))?;
+        }
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> nb::Result<(), Infallible> {
+        let usart = unsafe { &*USART::ptr() };
+
+        if usart.sr.read().tc().bit_is_set() {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    pub fn bflush(&mut self) -> Result<(), Infallible> {
+        nb::block!(self.flush())
+    }
+
     /// Start listening for transmit interrupt event
     pub fn listen(&mut self) {
         unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) };
@@ -497,6 +520,49 @@ impl<USART> Rx<USART>
 where
     USART: Instance,
 {
+    /// Reads 9-bit words from the UART/USART
+    ///
+    /// If the UART/USART was configured with `WordLength::Bits9`, the returned value will contain
+    /// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
+    /// 8 received data bits and all other bits set to zero.
+    pub fn read_u16(&mut self) -> nb::Result<u16, Error> {
+        let usart = unsafe { &*USART::ptr() };
+        let sr = usart.sr.read();
+
+        // Check for any errors
+        let err = if sr.pe().bit_is_set() {
+            Some(Error::Parity)
+        } else if sr.fe().bit_is_set() {
+            Some(Error::Framing)
+        } else if sr.ne().bit_is_set() {
+            Some(Error::Noise)
+        } else if sr.ore().bit_is_set() {
+            Some(Error::Overrun)
+        } else {
+            None
+        };
+
+        if let Some(err) = err {
+            // Some error occurred. In order to clear that error flag, you have to
+            // do a read from the sr register followed by a read from the dr register.
+            let _ = usart.sr.read();
+            let _ = usart.dr.read();
+            Err(nb::Error::Other(err))
+        } else {
+            // Check if a byte is available
+            if sr.rxne().bit_is_set() {
+                // Read the received byte
+                Ok(usart.dr.read().dr().bits())
+            } else {
+                Err(nb::Error::WouldBlock)
+            }
+        }
+    }
+
+    pub fn read(&mut self) -> nb::Result<u8, Error> {
+        self.read_u16().map(|word16| word16 as u8)
+    }
+
     /// Start listening for receive interrupt event
     pub fn listen(&mut self) {
         unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) };
@@ -536,138 +602,53 @@ where
     }
 }
 
-impl<USART, PINS> Serial<USART, PINS, u8>
-where
-    USART: Instance,
-{
-    /// Converts this Serial into a version that can read and write `u16` values instead of `u8`s
-    ///
-    /// This can be used with a word length of 9 bits.
-    pub fn with_u16_data(self) -> Serial<USART, PINS, u16> {
-        Serial {
-            usart: self.usart,
-            pins: self.pins,
-            tx: Tx::new(),
-            rx: Rx::new(),
-        }
-    }
-}
-
-impl<USART, PINS> Serial<USART, PINS, u16>
-where
-    USART: Instance,
-{
-    /// Converts this Serial into a version that can read and write `u8` values instead of `u16`s
-    ///
-    /// This can be used with a word length of 8 bits.
-    pub fn with_u8_data(self) -> Serial<USART, PINS, u8> {
-        Serial {
-            usart: self.usart,
-            pins: self.pins,
-            tx: Tx::new(),
-            rx: Rx::new(),
-        }
-    }
-}
-
-impl<USARTX> Rx<USARTX, u8> {
-    pub fn with_u16_data(self) -> Rx<USARTX, u16> {
-        Rx::new()
-    }
-}
-
-impl<USARTX> Rx<USARTX, u16> {
-    pub fn with_u8_data(self) -> Rx<USARTX, u8> {
-        Rx::new()
-    }
-}
-
-impl<USARTX> Tx<USARTX, u8> {
-    pub fn with_u16_data(self) -> Tx<USARTX, u16> {
-        Tx::new()
-    }
-}
-
-impl<USARTX> Tx<USARTX, u16> {
-    pub fn with_u8_data(self) -> Tx<USARTX, u8> {
-        Tx::new()
-    }
-}
-
-impl<USART, PINS, WORD> crate::hal::serial::Read<WORD> for Serial<USART, PINS, WORD>
-where
-    USART: Instance,
-    Rx<USART, WORD>: crate::hal::serial::Read<WORD, Error = Error>,
-{
-    type Error = Error;
-
-    fn read(&mut self) -> nb::Result<WORD, Error> {
-        self.rx.read()
-    }
-}
-
-impl<USART> crate::hal::serial::Read<u8> for Rx<USART, u8>
-where
-    USART: Instance,
-{
-    type Error = Error;
-
-    fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        // Delegate to the Read<u16> implementation, then truncate to 8 bits
-        Rx::<USART, u16>::new().read().map(|word16| word16 as u8)
-    }
-}
-
-/// Reads 9-bit words from the UART/USART
-///
-/// If the UART/USART was configured with `WordLength::Bits9`, the returned value will contain
-/// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
-/// 8 received data bits and all other bits set to zero.
-impl<USART> crate::hal::serial::Read<u16> for Rx<USART, u16>
+impl<USART, PINS> crate::hal::serial::Read<u16> for Serial<USART, PINS>
 where
     USART: Instance,
 {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u16, Error> {
-        let usart = unsafe { &*USART::ptr() };
-        let sr = usart.sr.read();
-
-        // Check for any errors
-        let err = if sr.pe().bit_is_set() {
-            Some(Error::Parity)
-        } else if sr.fe().bit_is_set() {
-            Some(Error::Framing)
-        } else if sr.ne().bit_is_set() {
-            Some(Error::Noise)
-        } else if sr.ore().bit_is_set() {
-            Some(Error::Overrun)
-        } else {
-            None
-        };
-
-        if let Some(err) = err {
-            // Some error occurred. In order to clear that error flag, you have to
-            // do a read from the sr register followed by a read from the dr register.
-            let _ = usart.sr.read();
-            let _ = usart.dr.read();
-            Err(nb::Error::Other(err))
-        } else {
-            // Check if a byte is available
-            if sr.rxne().bit_is_set() {
-                // Read the received byte
-                Ok(usart.dr.read().dr().bits())
-            } else {
-                Err(nb::Error::WouldBlock)
-            }
-        }
+        self.rx.read_u16()
     }
 }
 
-impl<USART, PINS, WORD> crate::hal::serial::Write<WORD> for Serial<USART, PINS, WORD>
+impl<USART, PINS> crate::hal::serial::Read<u8> for Serial<USART, PINS>
 where
     USART: Instance,
-    Tx<USART, WORD>: crate::hal::serial::Write<WORD, Error = Infallible>,
+{
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u8, Error> {
+        self.rx.read()
+    }
+}
+
+impl<USART> crate::hal::serial::Read<u8> for Rx<USART>
+where
+    USART: Instance,
+{
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        self.read()
+    }
+}
+
+impl<USART> crate::hal::serial::Read<u16> for Rx<USART>
+where
+    USART: Instance,
+{
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u16, Error> {
+        self.read_u16()
+    }
+}
+
+impl<USART, PINS> crate::hal::serial::Write<u16> for Serial<USART, PINS>
+where
+    USART: Instance,
 {
     type Error = Infallible;
 
@@ -675,12 +656,27 @@ where
         self.tx.flush()
     }
 
-    fn write(&mut self, byte: WORD) -> nb::Result<(), Self::Error> {
-        self.tx.write(byte)
+    fn write(&mut self, word: u16) -> nb::Result<(), Self::Error> {
+        self.tx.write_u16(word)
     }
 }
 
-impl<USART> crate::hal::serial::Write<u8> for Tx<USART, u8>
+impl<USART, PINS> crate::hal::serial::Write<u8> for Serial<USART, PINS>
+where
+    USART: Instance,
+{
+    type Error = Infallible;
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        self.tx.flush()
+    }
+
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        self.tx.write(word)
+    }
+}
+
+impl<USART> crate::hal::serial::Write<u8> for Tx<USART>
 where
     USART: Instance,
 {
@@ -688,14 +684,12 @@ where
 
     #[inline(always)]
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-        // Delegate to u16 version
-        Tx::<USART, u16>::new().write(word as u16)
+        self.write(word)
     }
 
     #[inline(always)]
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        // Delegate to u16 version
-        Tx::<USART, u16>::new().flush()
+        self.flush()
     }
 }
 
@@ -704,78 +698,59 @@ where
 /// If the UART/USART was configured with `WordLength::Bits9`, the 9 least significant bits will
 /// be transmitted and the other 7 bits will be ignored. Otherwise, the 8 least significant bits
 /// will be transmitted and the other 8 bits will be ignored.
-impl<USART> crate::hal::serial::Write<u16> for Tx<USART, u16>
+impl<USART> crate::hal::serial::Write<u16> for Tx<USART>
 where
     USART: Instance,
 {
     type Error = Infallible;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        let usart = unsafe { &*USART::ptr() };
-
-        if usart.sr.read().tc().bit_is_set() {
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
+        self.flush()
     }
 
     fn write(&mut self, word: u16) -> nb::Result<(), Self::Error> {
-        let usart = unsafe { &*USART::ptr() };
-
-        if usart.sr.read().txe().bit_is_set() {
-            usart.dr.write(|w| w.dr().bits(word));
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
+        self.write_u16(word)
     }
 }
 
-impl<USART> crate::hal::blocking::serial::Write<u16> for Tx<USART, u16>
+impl<USART> crate::hal::blocking::serial::Write<u16> for Tx<USART>
 where
     USART: Instance,
 {
     type Error = Infallible;
 
     fn bwrite_all(&mut self, buffer: &[u16]) -> Result<(), Self::Error> {
-        for &w in buffer {
-            nb::block!(<Self as crate::hal::serial::Write<u16>>::write(self, w))?;
-        }
-        Ok(())
+        self.bwrite_all_u16(buffer)
     }
 
     fn bflush(&mut self) -> Result<(), Self::Error> {
-        nb::block!(<Self as crate::hal::serial::Write<u16>>::flush(self))
+        self.bflush()
     }
 }
 
-impl<USART> crate::hal::blocking::serial::Write<u8> for Tx<USART, u8>
+impl<USART> crate::hal::blocking::serial::Write<u8> for Tx<USART>
 where
     USART: Instance,
 {
     type Error = Infallible;
 
     fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
-        for &w in buffer {
-            nb::block!(<Self as crate::hal::serial::Write<u8>>::write(self, w))?;
-        }
-        Ok(())
+        self.bwrite_all(buffer)
     }
 
     fn bflush(&mut self) -> Result<(), Self::Error> {
-        nb::block!(<Self as crate::hal::serial::Write<u8>>::flush(self))
+        self.bflush()
     }
 }
 
-impl<USART, PINS> crate::hal::blocking::serial::Write<u16> for Serial<USART, PINS, u16>
+impl<USART, PINS> crate::hal::blocking::serial::Write<u16> for Serial<USART, PINS>
 where
     USART: Instance,
 {
     type Error = Infallible;
 
     fn bwrite_all(&mut self, buffer: &[u16]) -> Result<(), Self::Error> {
-        self.tx.bwrite_all(buffer)
+        self.tx.bwrite_all_u16(buffer)
     }
 
     fn bflush(&mut self) -> Result<(), Self::Error> {
@@ -783,7 +758,7 @@ where
     }
 }
 
-impl<USART, PINS> crate::hal::blocking::serial::Write<u8> for Serial<USART, PINS, u8>
+impl<USART, PINS> crate::hal::blocking::serial::Write<u8> for Serial<USART, PINS>
 where
     USART: Instance,
 {
@@ -824,13 +799,6 @@ pub type Rx2 = Rx<USART2>;
 pub type Tx2 = Tx<USART2>;
 pub type Rx3 = Rx<USART3>;
 pub type Tx3 = Tx<USART3>;
-
-pub type Rx1_16 = Rx<USART1, u16>;
-pub type Tx1_16 = Tx<USART1, u16>;
-pub type Rx2_16 = Rx<USART2, u16>;
-pub type Tx2_16 = Tx<USART2, u16>;
-pub type Rx3_16 = Rx<USART3, u16>;
-pub type Tx3_16 = Tx<USART3, u16>;
 
 use crate::dma::{Receive, TransferPayload, Transmit};
 


### PR DESCRIPTION
### Breaking changes

- Passing the `Clock` parameter to `Serial` by reference.
- `Serial::usart1/2/3` -> `Serial::new`.
- `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16.

### Added

- Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting.
- Allow `Serial` reconfiguration by references to the `Tx` and `Rx` parts.
- Allow `Serial` release after splitting.

Instead of #414 and #409.