### PR TITLE
add temp/vref controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Serial` support for UART4/5
 - Allow to set HSE bypass bit in `RCC` clock configuration register to use an external clock input on the `OSC_IN` pin [#485]
 - initial support of `embedded-hal-1.0` [#416]
+- Added ADC methods for temp/vref sensor control. The time required for reading from the ADC can be reduced using these [#422]
 - Add tools/check.py python script for local check [#467]
 - Add changelog check on PRs [#467]
 - Reexport `Direction` from `qei` [#479]
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add enable/disable EOC interrupt functions for ADCs [#526]
 
 [#416]: https://github.com/stm32-rs/stm32f1xx-hal/pull/416
+[#422]: https://github.com/stm32-rs/stm32f1xx-hal/pull/422
 [#453]: https://github.com/stm32-rs/stm32f1xx-hal/pull/453
 [#462]: https://github.com/stm32-rs/stm32f1xx-hal/pull/462
 [#467]: https://github.com/stm32-rs/stm32f1xx-hal/pull/467


### PR DESCRIPTION
Previously when an `Adc` is initialized, the temp/vref sensor was disabled. During an ADC read, the sensor has to be turned on and off, which significantly increases the time it takes for a read. Additionally, since there was no way to enable to sensor manually, I don't think it was possible to read VREF in DMA mode.

Now, there are 3 additional functions, `enable_temp_vref`, `disable_temp_vref` and `is_temp_vref_enabled`. These functions are optional, and will speed up reading from the ADC if it is enabled manually. 

The `read_aux` function now also only enables the sensor if the temp or vref channel is being read.

I tested this with an STM32F103 (bluepill)