### PR TITLE
Bump bxcan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Passing the `Clock` parameter to `Serial` by reference.
 - `Serial::usart1/2/3` -> `Serial::new`.
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16.
+- Bump bxcan version to [v0.7.0](https://github.com/stm32-rs/bxcan/releases/tag/v0.7.0)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m-rt = "0.7.1"
 nb = "1"
 stm32f1 = "0.14.0"
 embedded-dma = "0.2.0"
-bxcan = "0.6"
+bxcan = "0.7"
 void = { default-features = false, version = "1.0.2" }
 embedded-hal = { features = ["unproven"], version = "0.2.7" }
 fugit = "0.3.5"

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
 
         // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
         // Value was calculated with http://www.bittiming.can-wiki.info/
-        let mut can2 = bxcan::Can::builder(can)
+        let can2 = bxcan::Can::builder(can)
             .set_bit_timing(0x001c_0003)
             .leave_disabled();
 

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -4,6 +4,7 @@
 #![no_main]
 #![no_std]
 
+use bxcan::Fifo;
 use panic_halt as _;
 
 use bxcan::filter::Mask32;
@@ -45,7 +46,7 @@ fn main() -> ! {
 
     // Configure filters so that can frames can be received.
     let mut filters = can1.modify_filters();
-    filters.enable_bank(0, Mask32::accept_all());
+    filters.enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
 
     #[cfg(feature = "connectivity")]
     let _can2 = {
@@ -65,7 +66,7 @@ fn main() -> ! {
         // A total of 28 filters are shared between the two CAN instances.
         // Split them equally between CAN1 and CAN2.
         let mut slave_filters = filters.set_split(14).slave_filters();
-        slave_filters.enable_bank(14, Mask32::accept_all());
+        slave_filters.enable_bank(14, Fifo::Fifo0, Mask32::accept_all());
         can2
     };
 

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -4,10 +4,7 @@
 #![no_main]
 #![no_std]
 
-use bxcan::{
-    filter::{ListEntry16, ListEntry32, Mask16},
-    ExtendedId, Frame, StandardId,
-};
+use bxcan::{filter::{ListEntry16, ListEntry32, Mask16}, ExtendedId, Frame, StandardId, Fifo};
 use panic_halt as _;
 
 use cortex_m_rt::entry;
@@ -50,6 +47,7 @@ fn main() -> ! {
     // TODO: Make this accept also ID 2
     filters.enable_bank(
         0,
+            Fifo::Fifo0,
         [
             // accepts 0 and 1
             Mask16::frames_with_std_id(StandardId::new(0).unwrap(), StandardId::new(1).unwrap()),
@@ -61,6 +59,7 @@ fn main() -> ! {
     // 2x 29bit id filter bank: Matches 4, 5
     filters.enable_bank(
         1,
+            Fifo::Fifo0,
         [
             ListEntry32::data_frames_with_id(ExtendedId::new(4).unwrap()),
             ListEntry32::data_frames_with_id(ExtendedId::new(5).unwrap()),
@@ -70,6 +69,7 @@ fn main() -> ! {
     // 4x 11bit id filter bank: Matches 8, 9, 10, 11
     filters.enable_bank(
         2,
+            Fifo::Fifo0,
         [
             ListEntry16::data_frames_with_id(StandardId::new(8).unwrap()),
             ListEntry16::data_frames_with_id(StandardId::new(9).unwrap()),

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -4,7 +4,10 @@
 #![no_main]
 #![no_std]
 
-use bxcan::{filter::{ListEntry16, ListEntry32, Mask16}, ExtendedId, Frame, StandardId, Fifo};
+use bxcan::{
+    filter::{ListEntry16, ListEntry32, Mask16},
+    ExtendedId, Fifo, Frame, StandardId,
+};
 use panic_halt as _;
 
 use cortex_m_rt::entry;
@@ -47,7 +50,7 @@ fn main() -> ! {
     // TODO: Make this accept also ID 2
     filters.enable_bank(
         0,
-            Fifo::Fifo0,
+        Fifo::Fifo0,
         [
             // accepts 0 and 1
             Mask16::frames_with_std_id(StandardId::new(0).unwrap(), StandardId::new(1).unwrap()),
@@ -59,7 +62,7 @@ fn main() -> ! {
     // 2x 29bit id filter bank: Matches 4, 5
     filters.enable_bank(
         1,
-            Fifo::Fifo0,
+        Fifo::Fifo0,
         [
             ListEntry32::data_frames_with_id(ExtendedId::new(4).unwrap()),
             ListEntry32::data_frames_with_id(ExtendedId::new(5).unwrap()),
@@ -69,7 +72,7 @@ fn main() -> ! {
     // 4x 11bit id filter bank: Matches 8, 9, 10, 11
     filters.enable_bank(
         2,
-            Fifo::Fifo0,
+        Fifo::Fifo0,
         [
             ListEntry16::data_frames_with_id(StandardId::new(8).unwrap()),
             ListEntry16::data_frames_with_id(StandardId::new(9).unwrap()),

--- a/examples/can-rtic.rs
+++ b/examples/can-rtic.rs
@@ -53,14 +53,14 @@ fn enqueue_frame(queue: &mut BinaryHeap<PriorityFrame, Max, 16>, frame: Frame) {
 #[rtic::app(device = stm32f1xx_hal::pac)]
 mod app {
     use super::{enqueue_frame, PriorityFrame};
-    use bxcan::{filter::Mask32, ExtendedId, Frame, Interrupts, Rx, StandardId, Tx};
+    use bxcan::{filter::Mask32, ExtendedId, Frame, Interrupts, StandardId, Tx, Rx0, Fifo};
     use heapless::binary_heap::{BinaryHeap, Max};
     use stm32f1xx_hal::{can::Can, pac::CAN1, prelude::*};
 
     #[local]
     struct Local {
         can_tx: Tx<Can<CAN1>>,
-        can_rx: Rx<Can<CAN1>>,
+        can_rx: Rx0<Can<CAN1>>,
     }
     #[shared]
     struct Shared {
@@ -101,7 +101,7 @@ mod app {
             .set_bit_timing(0x001c_0000)
             .leave_disabled();
 
-        can.modify_filters().enable_bank(0, Mask32::accept_all());
+        can.modify_filters().enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
 
         // Sync to the bus and start normal operation.
         can.enable_interrupts(

--- a/examples/can-rtic.rs
+++ b/examples/can-rtic.rs
@@ -53,7 +53,7 @@ fn enqueue_frame(queue: &mut BinaryHeap<PriorityFrame, Max, 16>, frame: Frame) {
 #[rtic::app(device = stm32f1xx_hal::pac)]
 mod app {
     use super::{enqueue_frame, PriorityFrame};
-    use bxcan::{filter::Mask32, ExtendedId, Frame, Interrupts, StandardId, Tx, Rx0, Fifo};
+    use bxcan::{filter::Mask32, ExtendedId, Fifo, Frame, Interrupts, Rx0, StandardId, Tx};
     use heapless::binary_heap::{BinaryHeap, Max};
     use stm32f1xx_hal::{can::Can, pac::CAN1, prelude::*};
 
@@ -101,7 +101,8 @@ mod app {
             .set_bit_timing(0x001c_0000)
             .leave_disabled();
 
-        can.modify_filters().enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
+        can.modify_filters()
+            .enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
 
         // Sync to the bus and start normal operation.
         can.enable_interrupts(
@@ -109,7 +110,7 @@ mod app {
         );
         nb::block!(can.enable_non_blocking()).unwrap();
 
-        let (can_tx, can_rx) = can.split();
+        let (can_tx, can_rx, _) = can.split();
 
         let can_tx_queue = BinaryHeap::new();
 


### PR DESCRIPTION
This pull request bump the version of bxcan from 0.6 to [0.7](https://github.com/stm32-rs/bxcan/releases/tag/v0.7.0), which introduce the second can FIFO. 
All CAN example are updated to use the new version of bxcan.
(I don't know how to add label, but this is a breaking change)