### PR TITLE
Fix flash write error, according to errata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `gpio`: port and pin generics first, then mode,
   `PinMode` for modes instead of pins, `HL` trait, other cleanups
+- `flash`: add one-cycle delay of reading `BSY` bit after setting `STRT` bit to
+           fix errata.
 
 ### Breaking changes
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -146,6 +146,13 @@ impl<'a> FlashWriter<'a> {
         // Start Operation
         self.flash.cr.cr().modify(|_, w| w.strt().set_bit());
 
+        // Wait for at least one clock cycle before reading the
+        // BSY bit, because there is a one-cycle delay between
+        // setting the STRT bit and the BSY bit being asserted
+        // by hardware. See STM32F105xx, STM32F107xx device errata,
+        // section 2.2.8
+        cortex_m::asm::nop();
+
         // Wait for operation to finish
         while self.flash.sr.sr().read().bsy().bit_is_set() {}
 


### PR DESCRIPTION
According to the [errata](https://www.st.com/resource/en/errata_sheet/es096-stm32f101x8b-stm32f102x8b-and-stm32f103x8b-mediumdensity-device-limitations-stmicroelectronics.pdf) for stm32f1, section 2.2.8, reading `BSY` after writing `STRT` needs a 1-cycle delay to be read correctly.

It took a while for us to hit an issue with this (presumably due to eventual optimization by the compiler). Once you hit it, the chip just hangs, as the `while` loop that waits for `BSY` to be cleared immediately completes, which causes the page erase and lock bits are reset while an erase operation is still ongoing, which is probably not good.