### PR TITLE
feat: adds `get_interrupt` to `Timer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- `Timer`: adds `get_interrupt` to `Timer`
 - `gpio`: port and pin generics first, then mode,
   `PinMode` for modes instead of pins, `HL` trait, other cleanups
 - `flash`: add one-cycle delay of reading `BSY` bit after setting `STRT` bit to

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -678,6 +678,10 @@ impl<TIM: Instance> Timer<TIM> {
         self.tim.clear_interrupt_flag(event);
     }
 
+    pub fn get_interrupt(&mut self) -> Event {
+        self.tim.get_interrupt_flag()
+    }
+
     /// Stops listening for an `event`
     pub fn unlisten(&mut self, event: Event) {
         self.tim.listen_interrupt(event, false);


### PR DESCRIPTION
Adds the `get_interrupt` method to `Timer` (just as it already exists for `FTimer` here: https://github.com/stm32-rs/stm32f1xx-hal/blob/master/src/timer.rs#L768)