### PR TITLE
Fix computation of timer frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `PinMode` for modes instead of pins, `HL` trait, other cleanups
 - `flash`: add one-cycle delay of reading `BSY` bit after setting `STRT` bit to
            fix errata.
+- `PwmHz::get_period`: fix computation of return value, prevent division by zero
 
 ### Breaking changes
 

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -372,7 +372,7 @@ where
         let arr = TIM::read_auto_reload();
 
         // Length in ms of an internal clock pulse
-        clk / (psc * arr)
+        clk / ((psc + 1) * (arr + 1))
     }
 
     pub fn set_period(&mut self, period: Hertz) {


### PR DESCRIPTION
Retrieving timer frequency using PwmHz::get_period() function can cause
division by zero exception for certain types of frequencies which are
configured by having zero in any of the PSC or ARR register - current
implementation uses "clk / (psc * arr)" expression to compute the
frequency.

Implementation of compute_arr_presc() sets PSC and ARR registers
correctly. Performing inverse computation leads to different expression:
"clk / ((psc + 1) * (arr + 1))" which properly computes timer frequency
from PSC and ARR registers. This patch uses new/fixed expression for
computing timer frequency.

Change log was modified.