### PR TITLE
Un-publish crate::rcc::Config::get_clocks

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -661,7 +661,10 @@ impl Config {
             adcpre: apre_bits,
         }
     }
-    pub fn get_clocks(&self) -> Clocks {
+
+    // NOTE: to maintain the invariant that the existence of a Clocks
+    // value implies frozen clocks, this function must not be pub.
+    fn get_clocks(&self) -> Clocks {
         let sysclk = if let Some(pllmul_bits) = self.pllmul {
             let pllsrcclk = if let Some(hse) = self.hse {
                 hse


### PR DESCRIPTION
The existence of a crate::rcc::Clocks value is supposed to assert that
the MCU clocks have been configured and that they cannot be changed
anymore. That works by consuming the only instance of CFGR in the
corresponding function and then returning a Clocks value.

However, having crate::rcc::config::Config::get_clocks public implies
that external code can, at any time, generate a Clocks value: by simply
constructing a Config instance (all fields are public) and calling the
function.

```rust
#![no_std]
#![no_main]

use panic_halt as _;

use stm32f1xx_hal as hal;

use cortex_m_rt::entry;

#[entry]
fn main() -> ! {
        let clocks: hal::rcc::Clocks = hal::rcc::Config{
                hse: Some(8000000),
                pllmul: Some(8),
                hpre: hal::rcc::HPre::DIV1,
                ppre1: hal::rcc::PPre::DIV2,
                ppre2: hal::rcc::PPre::DIV1,
                adcpre: hal::rcc::AdcPre::DIV8,
                usbpre: hal::rcc::UsbPre::DIV1,
        }.get_clocks();

        loop{}
}
```

This is a breaking change, obviously, but there are no non-breaking
alternatives.

Fixes #437.