### PR TITLE
DMA: allow to stop incomplete transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting.
 - Allow `Serial` reconfiguration by references to the `Tx` and `Rx` parts.
 - Allow `Serial` release after splitting.
+- Allow to stop an incomplete DMA transfer.
 
 ## [v0.9.0] - 2022-03-02
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -302,9 +302,16 @@ macro_rules! dma {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
+                        /// Waits for the transfer to complete,
+                        /// then stops it and returns the underlying buffer and RxDma.
+                        pub fn wait(self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
+                            self.stop()
+                        }
+
+                        /// Stops the transfer and returns the underlying buffer and RxDma.
+                        pub fn stop(mut self) -> (BUFFER, RxDma<PAYLOAD, $CX>) {
                             atomic::compiler_fence(Ordering::Acquire);
 
                             self.payload.stop();
@@ -340,9 +347,16 @@ macro_rules! dma {
                             !self.payload.channel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
+                        /// Waits for the transfer to complete,
+                        /// then stops it and returns the underlying buffer and TxDma.
+                        pub fn wait(self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
                             while !self.is_done() {}
 
+                            self.stop()
+                        }
+
+                        /// Stops the transfer and returns the underlying buffer and TxDma.
+                        pub fn stop(mut self) -> (BUFFER, TxDma<PAYLOAD, $CX>) {
                             atomic::compiler_fence(Ordering::Acquire);
 
                             self.payload.stop();
@@ -378,9 +392,16 @@ macro_rules! dma {
                             !self.payload.rxchannel.in_progress()
                         }
 
-                        pub fn wait(mut self) -> (BUFFER, RxTxDma<PAYLOAD, $CX, TXC>) {
+                        /// Waits for the transfer to complete,
+                        /// then stops it and returns the underlying buffer and RxTxDma.
+                        pub fn wait(self) -> (BUFFER, RxTxDma<PAYLOAD, $CX, TXC>) {
                             while !self.is_done() {}
 
+                            self.stop()
+                        }
+
+                        /// Stops the transfer and returns the underlying buffer and RxTxDma.
+                        pub fn stop(mut self) -> (BUFFER, RxTxDma<PAYLOAD, $CX, TXC>) {
                             atomic::compiler_fence(Ordering::Acquire);
 
                             self.payload.stop();


### PR DESCRIPTION
Add a method Transfer::stop() which stops the transfer immediately without waiting.
Use case: receiving SPI transfers of variable length in slave mode based on a CS pin.