### PR TITLE
Add a public method to check for Busy flag in SPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow access to the `Tx` and `Rx` parts of the `Serial` without the need for splitting.
 - Allow `Serial` reconfiguration by references to the `Tx` and `Rx` parts.
 - Allow `Serial` release after splitting.
+- Allow to stop an incomplete DMA transfer.
+- `Spi::is_busy()`
 
 ## [v0.9.0] - 2022-03-02
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -460,6 +460,10 @@ where
     pub fn is_overrun(&self) -> bool {
         self.spi.sr.read().ovr().bit_is_set()
     }
+
+    pub fn is_busy(&self) -> bool {
+        self.spi.sr.read().bsy().bit_is_set()
+    }
 }
 
 impl<SPI, REMAP, PINS> Spi<SPI, REMAP, PINS, u8, Master>


### PR DESCRIPTION
Use case: after waiting on a DMA transfer in master mode, make sure the last byte is transferred correctly by waiting for the busy flag to be cleared before disabling SPI.