### PR TITLE
Bugfix: `CounterHz` and `Counter` `wait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow `Serial` release after splitting.
 - `Spi::is_busy()`
 
+### Fixed
+
+- `CounterHz` and `Counter` do not `wait` properly after the second and subsequent `start`.
+
 ## [v0.9.0] - 2022-03-02
 
 ### Added

--- a/src/timer/counter.rs
+++ b/src/timer/counter.rs
@@ -33,6 +33,9 @@ impl<TIM: Instance> CounterHz<TIM> {
     pub fn start(&mut self, timeout: Hertz) -> Result<(), Error> {
         // pause
         self.tim.disable_counter();
+
+        self.tim.clear_interrupt_flag(Event::Update);
+
         // reset counter
         self.tim.reset_counter();
 
@@ -158,6 +161,9 @@ impl<TIM: Instance, const FREQ: u32> Counter<TIM, FREQ> {
     pub fn start(&mut self, timeout: TimerDurationU32<FREQ>) -> Result<(), Error> {
         // pause
         self.tim.disable_counter();
+
+        self.tim.clear_interrupt_flag(Event::Update);
+
         // reset counter
         self.tim.reset_counter();
 


### PR DESCRIPTION
`CounterHz` and `Counter` do not `wait` properly after the second and subsequent `start`.