### PR TITLE
Remove wfi in examples

### DIFF
--- a/examples/blinky_rtcalarm_irq.rs
+++ b/examples/blinky_rtcalarm_irq.rs
@@ -24,7 +24,7 @@ use crate::hal::{
 };
 
 use core::cell::RefCell;
-use cortex_m::{asm::wfi, interrupt::Mutex};
+use cortex_m::interrupt::Mutex;
 use cortex_m_rt::entry;
 
 // A type definition for the GPIO pin to be used for our LED
@@ -108,7 +108,5 @@ fn main() -> ! {
     // Enable RTCALARM IRQ
     unsafe { cortex_m::peripheral::NVIC::unmask(Interrupt::RTCALARM) };
 
-    loop {
-        wfi();
-    }
+    loop {}
 }

--- a/examples/blinky_timer_irq.rs
+++ b/examples/blinky_timer_irq.rs
@@ -7,6 +7,7 @@
 //! GPIOs PC13 to PC15 in output mode is restricted: the speed has to be limited to 2MHz with
 //! a maximum load of 30pF and these IOs must not be used as a current source (e.g. to drive a LED)"
 
+#![allow(clippy::empty_loop)]
 #![no_main]
 #![no_std]
 
@@ -22,7 +23,7 @@ use crate::hal::{
 };
 
 use core::cell::RefCell;
-use cortex_m::{asm::wfi, interrupt::Mutex};
+use cortex_m::interrupt::Mutex;
 use cortex_m_rt::entry;
 
 // NOTE You can uncomment 'hprintln' here and in the code below for a bit more
@@ -99,7 +100,5 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(Interrupt::TIM2);
     }
 
-    loop {
-        wfi();
-    }
+    loop {}
 }

--- a/examples/serial-interrupt-idle.rs
+++ b/examples/serial-interrupt-idle.rs
@@ -2,6 +2,7 @@
 //!
 //! You have to short the TX and RX pins to make this program work
 
+#![allow(clippy::empty_loop)]
 #![no_main]
 #![no_std]
 
@@ -64,9 +65,7 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(pac::Interrupt::USART1);
     }
 
-    loop {
-        cortex_m::asm::wfi()
-    }
+    loop {}
 }
 const BUFFER_LEN: usize = 4096;
 static mut BUFFER: &mut [u8; BUFFER_LEN] = &mut [0; BUFFER_LEN];

--- a/examples/usb_serial_interrupt.rs
+++ b/examples/usb_serial_interrupt.rs
@@ -1,11 +1,13 @@
 //! CDC-ACM serial port example using interrupts.
 //! Target board: Blue Pill
+
+#![allow(clippy::empty_loop)]
 #![no_std]
 #![no_main]
 
 extern crate panic_semihosting;
 
-use cortex_m::asm::{delay, wfi};
+use cortex_m::asm::delay;
 use cortex_m_rt::entry;
 use stm32f1xx_hal::pac::{self, interrupt, Interrupt, NVIC};
 use stm32f1xx_hal::prelude::*;
@@ -75,9 +77,7 @@ fn main() -> ! {
         NVIC::unmask(Interrupt::USB_LP_CAN_RX0);
     }
 
-    loop {
-        wfi();
-    }
+    loop {}
 }
 
 #[interrupt]


### PR DESCRIPTION
This PR removes `wfi` from examples. I ran into an issue flashing code onto my board after flashing one of the examples and found [this thread](https://github.com/probe-rs/probe-rs/issues/350) which finally gave me the method I needed to erase the code flash. 

Since these are examples and power consumption is not a big deal, I think it's not necessary to use `wfi` and instead just let the microcontroller processor spin. Seems better than pushing someone through some general headache around the board no longer being connectable via SWD. I did leave it as-is in `examples/timer-interrupt-rtic.rs` as I'm less certain of it's necessity in an RTIC context.