### PR TITLE
Don't overwrite other bits when enabling a PWM timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Serial::usart1/2/3` -> `Serial::new`.
 - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as u8 and u16.
 - Bump bxcan version to [v0.7.0](https://github.com/stm32-rs/bxcan/releases/tag/v0.7.0)
+- PWM timer auto reload value is now preloaded/buffered
 
 ### Added
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -400,7 +400,7 @@ macro_rules! hal {
                 }
                 #[inline(always)]
                 fn start_one_pulse(&mut self) {
-                    self.cr1.write(|w| unsafe { w.bits(1 << 3) }.cen().set_bit());
+                    self.cr1.modify(|_, w| w.opm().set_bit().cen().set_bit());
                 }
                 #[inline(always)]
                 fn cr1_reset(&mut self) {
@@ -460,7 +460,7 @@ macro_rules! with_pwm {
 
             #[inline(always)]
             fn start_pwm(&mut self) {
-                self.cr1.write(|w| w.cen().set_bit());
+                self.cr1.modify(|_, w| w.cen().set_bit());
             }
 
             #[inline(always)]
@@ -512,7 +512,7 @@ macro_rules! with_pwm {
 
             #[inline(always)]
             fn start_pwm(&mut self) {
-                self.cr1.write(|w| w.cen().set_bit());
+                self.cr1.modify(|_, w| w.cen().set_bit());
             }
 
             #[inline(always)]
@@ -565,7 +565,7 @@ macro_rules! with_pwm {
             #[inline(always)]
             fn start_pwm(&mut self) {
                 $(let $aoe = self.bdtr.modify(|_, w| w.aoe().set_bit());)?
-                self.cr1.write(|w| w.cen().set_bit());
+                self.cr1.modify(|_, w| w.cen().set_bit());
             }
 
             #[inline(always)]


### PR DESCRIPTION
In practice the only bit we set is CR1.ARPE which enables preloading/buffering of the timer auto reload value. Before this patch we set the bit ([`tim.enable_preload(true)`](https://github.com/stm32-rs/stm32f1xx-hal/blob/21c64d861c29a97753a22afdd06daaea614592c6/src/timer/pwm.rs#L324)) but then immediately unset the bit again when enabling PWM.
