### PR TITLE
Allow GPIO splitting without reset and pin output configuration keeping initial state

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -119,8 +119,13 @@ pub trait GpioExt {
     /// The to split the GPIO into
     type Parts;
 
-    /// Splits the GPIO block into independent pins and registers
+    /// Splits the GPIO block into independent pins and registers.
+    ///
+    /// This resets the state of the GPIO block.
     fn split(self) -> Self::Parts;
+
+    /// Splits the GPIO block into independent pins and registers without resetting its state.
+    fn split_without_reset(self) -> Self::Parts;
 }
 
 /// Marker trait for active states.
@@ -382,6 +387,19 @@ macro_rules! gpio {
                     let rcc = unsafe { &(*RCC::ptr()) };
                     $GPIOX::enable(rcc);
                     $GPIOX::reset(rcc);
+
+                    Parts {
+                        crl: Cr::<$port_id, false>(()),
+                        crh: Cr::<$port_id, true>(()),
+                        $(
+                            $pxi: $PXi::new(),
+                        )+
+                    }
+                }
+
+                fn split_without_reset(self) -> Parts {
+                    let rcc = unsafe { &(*RCC::ptr()) };
+                    $GPIOX::enable(rcc);
 
                     Parts {
                         crl: Cr::<$port_id, false>(()),

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -820,6 +820,17 @@ where
         Pin::new()
     }
 
+    /// Configures the pin to operate as an push-pull output pin.
+    /// The state will not be changed.
+    #[inline]
+    pub fn into_push_pull_output_with_current_state(
+        mut self,
+        cr: &mut <Self as HL>::Cr,
+    ) -> Pin<P, N, Output<PushPull>> {
+        self.mode::<Output<PushPull>>(cr);
+        Pin::new()
+    }
+
     /// Configures the pin to operate as an analog input pin
     #[inline]
     pub fn into_analog(mut self, cr: &mut <Self as HL>::Cr) -> Pin<P, N, Analog> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -125,7 +125,7 @@ pub trait GpioExt {
     fn split(self) -> Self::Parts;
 
     /// Splits the GPIO block into independent pins and registers without resetting its state.
-    fn split_without_reset(self) -> Self::Parts;
+    unsafe fn split_without_reset(self) -> Self::Parts;
 }
 
 /// Marker trait for active states.
@@ -397,7 +397,7 @@ macro_rules! gpio {
                     }
                 }
 
-                fn split_without_reset(self) -> Parts {
+                unsafe fn split_without_reset(self) -> Parts {
                     let rcc = unsafe { &(*RCC::ptr()) };
                     $GPIOX::enable(rcc);
 


### PR DESCRIPTION
Fixes #459.
