### PR TITLE
remap enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Relax pin type generics for `Serial`, `I2c`, `Spi`, `Can`. [#462]
+  Use enums of pin tuples and `Enum::from<(tuple)>` for pin remap before passing to peripheral.
+  Remove `RemapStruct`s. [#462]
+- Use independent `Spi` and `SpiSlave` structures instead of `OP` generic [#462]
+- Take `&Clocks` instead of `Clocks` [#498]
+
 ### Changed
 
 - PWM timer auto reload value is now preloaded/buffered [#453]
@@ -14,7 +22,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace UB code by a legitimate pointer access [#480]
 - Fix flash error flag clearing [#489]
 - Clarify README for windows users [#496]
-- Take `&Clocks` instead of `Clocks`
 
 ### Added
 
@@ -28,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [#416]: https://github.com/stm32-rs/stm32f1xx-hal/pull/416
 [#453]: https://github.com/stm32-rs/stm32f1xx-hal/pull/453
+[#462]: https://github.com/stm32-rs/stm32f1xx-hal/pull/462
 [#467]: https://github.com/stm32-rs/stm32f1xx-hal/pull/467
 [#479]: https://github.com/stm32-rs/stm32f1xx-hal/pull/479
 [#480]: https://github.com/stm32-rs/stm32f1xx-hal/pull/480
@@ -36,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#489]: https://github.com/stm32-rs/stm32f1xx-hal/pull/489
 [#494]: https://github.com/stm32-rs/stm32f1xx-hal/pull/494
 [#496]: https://github.com/stm32-rs/stm32f1xx-hal/pull/496
+[#498]: https://github.com/stm32-rs/stm32f1xx-hal/pull/498
 
 ## [v0.10.0] - 2022-12-12
 

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -10,7 +10,7 @@ use panic_halt as _;
 use bxcan::filter::Mask32;
 use cortex_m_rt::entry;
 use nb::block;
-use stm32f1xx_hal::{can::Can, pac, prelude::*};
+use stm32f1xx_hal::{gpio::Floating, pac, prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -27,15 +27,15 @@ fn main() -> ! {
     let mut afio = dp.AFIO.constrain();
 
     let mut can1 = {
-        #[cfg(not(feature = "connectivity"))]
-        let can = Can::new(dp.CAN1, dp.USB);
-        #[cfg(feature = "connectivity")]
-        let can = Can::new(dp.CAN1);
+        let gpioa = dp.GPIOA.split();
+        let rx = gpioa.pa11;
+        let tx = gpioa.pa12;
 
-        let mut gpioa = dp.GPIOA.split();
-        let rx = gpioa.pa11.into_floating_input(&mut gpioa.crh);
-        let tx = gpioa.pa12.into_alternate_push_pull(&mut gpioa.crh);
-        can.assign_pins((tx, rx), &mut afio.mapr);
+        let can = dp.CAN1.can::<Floating>(
+            #[cfg(not(feature = "connectivity"))]
+            dp.USB,
+            (tx, rx, &mut afio.mapr),
+        );
 
         // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
         // Value was calculated with http://www.bittiming.can-wiki.info/
@@ -50,12 +50,10 @@ fn main() -> ! {
 
     #[cfg(feature = "connectivity")]
     let _can2 = {
-        let can = Can::new(dp.CAN2);
-
-        let mut gpiob = dp.GPIOB.split();
-        let rx = gpiob.pb5.into_floating_input(&mut gpiob.crl);
-        let tx = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
-        can.assign_pins((tx, rx), &mut afio.mapr);
+        let gpiob = dp.GPIOB.split();
+        let can = dp
+            .CAN2
+            .can::<Floating>((gpiob.pb6, gpiob.pb5, &mut afio.mapr));
 
         // APB1 (PCLK1): 8MHz, Bit rate: 125kBit/s, Sample Point 87.5%
         // Value was calculated with http://www.bittiming.can-wiki.info/

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -12,7 +12,7 @@ use panic_halt as _;
 
 use cortex_m_rt::entry;
 use nb::block;
-use stm32f1xx_hal::{can::Can, pac, prelude::*};
+use stm32f1xx_hal::{can::Can, gpio::Floating, pac, prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -25,11 +25,11 @@ fn main() -> ! {
     // resonator must be used.
     rcc.cfgr.use_hse(8.MHz()).freeze(&mut flash.acr);
 
-    #[cfg(not(feature = "connectivity"))]
-    let can = Can::new(dp.CAN1, dp.USB);
-
-    #[cfg(feature = "connectivity")]
-    let can = Can::new(dp.CAN1);
+    let can = Can::<_, Floating>::new_loopback(
+        dp.CAN1,
+        #[cfg(not(feature = "connectivity"))]
+        dp.USB,
+    );
 
     // Use loopback mode: No pins need to be assigned to peripheral.
     // APB1 (PCLK1): 8MHz, Bit rate: 500Bit/s, Sample Point 87.5%

--- a/examples/can-rtic.rs
+++ b/examples/can-rtic.rs
@@ -55,7 +55,7 @@ mod app {
     use super::{enqueue_frame, PriorityFrame};
     use bxcan::{filter::Mask32, ExtendedId, Fifo, Frame, Interrupts, Rx0, StandardId, Tx};
     use heapless::binary_heap::{BinaryHeap, Max};
-    use stm32f1xx_hal::{can::Can, pac::CAN1, prelude::*};
+    use stm32f1xx_hal::{can::Can, gpio::Floating, pac::CAN1, prelude::*};
 
     #[local]
     struct Local {
@@ -82,18 +82,21 @@ mod app {
             .pclk2(64.MHz())
             .freeze(&mut flash.acr);
 
+        // Select pins for CAN1.
+        let gpioa = cx.device.GPIOA.split();
+        let can_rx_pin = gpioa.pa11;
+        let can_tx_pin = gpioa.pa12;
+        let mut afio = cx.device.AFIO.constrain();
+
         #[cfg(not(feature = "connectivity"))]
-        let can = Can::new(cx.device.CAN1, cx.device.USB);
+        let can = Can::<_, Floating>::new(
+            cx.device.CAN1,
+            cx.device.USB,
+            (can_tx_pin, can_rx_pin, &mut afio.mapr),
+        );
 
         #[cfg(feature = "connectivity")]
-        let can = Can::new(cx.device.CAN1);
-
-        // Select pins for CAN1.
-        let mut gpioa = cx.device.GPIOA.split();
-        let can_rx_pin = gpioa.pa11.into_floating_input(&mut gpioa.crh);
-        let can_tx_pin = gpioa.pa12.into_alternate_push_pull(&mut gpioa.crh);
-        let mut afio = cx.device.AFIO.constrain();
-        can.assign_pins((can_tx_pin, can_rx_pin), &mut afio.mapr);
+        let can = Can::<_, Floating>::new(cx.device.CAN1, (can_tx_pin, can_rx_pin, &mut afio.mapr));
 
         // APB1 (PCLK1): 16MHz, Bit rate: 1000kBit/s, Sample Point 87.5%
         // Value was calculated with http://www.bittiming.can-wiki.info/

--- a/examples/mfrc522.rs
+++ b/examples/mfrc522.rs
@@ -7,9 +7,12 @@ use panic_itm as _;
 use cortex_m::iprintln;
 
 use cortex_m_rt::entry;
-use embedded_hal_02::spi::{Mode, Phase, Polarity};
 use mfrc522::Mfrc522;
-use stm32f1xx_hal::{pac, prelude::*, spi::Spi};
+use stm32f1xx_hal::{
+    pac,
+    prelude::*,
+    spi::{Mode, Phase, Polarity, Spi},
+};
 pub const MODE: Mode = Mode {
     polarity: Polarity::IdleLow,
     phase: Phase::CaptureOnFirstTransition,
@@ -32,10 +35,9 @@ fn main() -> ! {
     let sck = gpioa.pa5.into_alternate_push_pull(&mut gpioa.crl);
     let miso = gpioa.pa6;
     let mosi = gpioa.pa7.into_alternate_push_pull(&mut gpioa.crl);
-    let spi = Spi::spi1(
+    let spi = Spi::new(
         dp.SPI1,
-        (sck, miso, mosi),
-        &mut afio.mapr,
+        (sck, miso, mosi, &mut afio.mapr),
         MODE,
         1.MHz(),
         &clocks,

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -50,8 +50,7 @@ fn main() -> ! {
 
     let serial = Serial::new(
         p.USART1,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         Config::default().baudrate(9_600.bps()),
         &clocks,
     );

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -49,8 +49,7 @@ fn main() -> ! {
 
     let serial = Serial::new(
         p.USART1,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         Config::default(),
         &clocks,
     );

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -49,8 +49,7 @@ fn main() -> ! {
 
     let serial = Serial::new(
         p.USART1,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         Config::default().baudrate(9_600.bps()),
         &clocks,
     );

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -49,8 +49,7 @@ fn main() -> ! {
 
     let serial = Serial::new(
         p.USART1,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         Config::default().baudrate(9600.bps()),
         &clocks,
     );

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -61,8 +61,7 @@ fn main() -> ! {
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         Config::default().baudrate(9600.bps()),
         &clocks,
     );

--- a/examples/serial-interrupt-idle.rs
+++ b/examples/serial-interrupt-idle.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     // Set up the usart device. Takes ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
     let (mut tx, mut rx) =
-        Serial::new(p.USART1, (tx, rx), &mut afio.mapr, 115_200.bps(), &clocks).split();
+        Serial::new(p.USART1, (tx, rx, &mut afio.mapr), 115_200.bps(), &clocks).split();
     tx.listen();
     rx.listen();
     rx.listen_idle();
@@ -69,7 +69,7 @@ static mut WIDX: usize = 0;
 unsafe fn write(buf: &[u8]) {
     if let Some(tx) = TX.as_mut() {
         buf.iter()
-            .for_each(|w| if let Err(_err) = nb::block!(tx.write_u8(*w)) {})
+            .for_each(|w| if let Err(_err) = nb::block!(tx.write(*w)) {})
     }
 }
 #[interrupt]

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -14,11 +14,7 @@ use cortex_m::asm;
 use nb::block;
 
 use cortex_m_rt::entry;
-use stm32f1xx_hal::{
-    pac,
-    prelude::*,
-    serial::{Config, Serial},
-};
+use stm32f1xx_hal::{pac, prelude::*, serial::Config};
 
 #[entry]
 fn main() -> ! {
@@ -60,10 +56,8 @@ fn main() -> ! {
 
     // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let mut serial = Serial::new(
-        p.USART3,
-        (tx, rx),
-        &mut afio.mapr,
+    let mut serial = p.USART3.serial(
+        (tx, rx, &mut afio.mapr),
         Config::default().baudrate(9600.bps()),
         &clocks,
     );

--- a/examples/serial_9bits.rs
+++ b/examples/serial_9bits.rs
@@ -13,6 +13,7 @@ use cortex_m_rt::entry;
 use nb::block;
 use panic_halt as _;
 use stm32f1xx_hal::{
+    gpio::{Floating, PushPull},
     pac,
     prelude::*,
     serial::{self, Config, Error, Serial},
@@ -111,17 +112,16 @@ fn main() -> ! {
     let mut afio = p.AFIO.constrain();
 
     // Prepare the GPIOB peripheral.
-    let mut gpiob = p.GPIOB.split();
+    let gpiob = p.GPIOB.split();
 
-    let tx_pin = gpiob.pb10.into_alternate_push_pull(&mut gpiob.crh);
+    let tx_pin = gpiob.pb10;
     let rx_pin = gpiob.pb11;
 
     // Set up the usart device. Take ownership over the USART register and tx/rx pins. The rest of
     // the registers are used to enable and configure the device.
-    let serial = Serial::new(
+    let serial = Serial::<_, PushPull, Floating>::new(
         p.USART3,
-        (tx_pin, rx_pin),
-        &mut afio.mapr,
+        (tx_pin, rx_pin, &mut afio.mapr),
         Config::default()
             .baudrate(9600.bps())
             .wordlength_9bits()

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -60,8 +60,7 @@ fn main() -> ! {
     // the registers are used to enable and configure the device.
     let serial = Serial::new(
         p.USART3,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         serial::Config::default()
             .baudrate(9600.bps())
             .stopbits(serial::StopBits::STOP2)

--- a/examples/serial_reconfigure.rs
+++ b/examples/serial_reconfigure.rs
@@ -62,8 +62,7 @@ fn main() -> ! {
     // the registers are used to enable and configure the device.
     let mut serial = Serial::new(
         p.USART3,
-        (tx, rx),
-        &mut afio.mapr,
+        (tx, rx, &mut afio.mapr),
         Config::default().baudrate(9600.bps()),
         &clocks,
     );

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
         polarity: Polarity::IdleLow,
         phase: Phase::CaptureOnFirstTransition,
     };
-    let spi = Spi::spi2(dp.SPI2, pins, spi_mode, 100.kHz(), &clocks);
+    let spi = Spi::new(dp.SPI2, pins, spi_mode, 100.kHz(), &clocks);
 
     // Set up the DMA device
     let dma = dp.DMA1.split();

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -6,24 +6,19 @@
 use cortex_m_rt::entry;
 use panic_halt as _;
 
-use embedded_hal_02::spi::{Mode, Phase, Polarity};
 pub const MODE: Mode = Mode {
     phase: Phase::CaptureOnSecondTransition,
     polarity: Polarity::IdleHigh,
 };
 
 use stm32f1xx_hal::{
-    gpio::gpioa::PA4,
-    gpio::{Output, PushPull},
+    gpio::{Output, PA4},
     pac::{Peripherals, SPI1},
     prelude::*,
-    spi::{Pins, Spi, Spi1NoRemap},
+    spi::{Mode, Phase, Polarity, Spi},
 };
 
-fn setup() -> (
-    Spi<SPI1, Spi1NoRemap, impl Pins<Spi1NoRemap>, u8>,
-    PA4<Output<PushPull>>,
-) {
+fn setup() -> (Spi<SPI1, u8>, PA4<Output>) {
     let dp = Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
@@ -40,10 +35,9 @@ fn setup() -> (
     let mosi = gpioa.pa7.into_alternate_push_pull(&mut gpioa.crl);
     let cs = gpioa.pa4.into_push_pull_output(&mut gpioa.crl);
 
-    let spi = Spi::spi1(
+    let spi = Spi::new(
         dp.SPI1,
-        (sck, miso, mosi),
-        &mut afio.mapr,
+        (sck, miso, mosi, &mut afio.mapr),
         MODE,
         1.MHz(),
         &clocks,

--- a/src/can.rs
+++ b/src/can.rs
@@ -20,117 +20,203 @@
 //! | RX       | PB5     | PB12  |
 
 use crate::afio::MAPR;
-use crate::gpio::{self, Alternate, Input};
+use crate::gpio::{self, Alternate, Cr, Floating, Input, PinMode, PullUp};
 use crate::pac::{self, RCC};
 
-pub trait Pins: crate::Sealed {
-    type Instance;
-    fn remap(mapr: &mut MAPR);
-}
+pub trait InMode {}
+impl InMode for Floating {}
+impl InMode for PullUp {}
 
-impl<INMODE, OUTMODE> crate::Sealed
-    for (gpio::PA12<Alternate<OUTMODE>>, gpio::PA11<Input<INMODE>>)
-{
-}
-impl<INMODE, OUTMODE> Pins for (gpio::PA12<Alternate<OUTMODE>>, gpio::PA11<Input<INMODE>>) {
-    type Instance = pac::CAN1;
+pub mod can1 {
+    use super::*;
 
-    fn remap(mapr: &mut MAPR) {
-        #[cfg(not(feature = "connectivity"))]
-        mapr.modify_mapr(|_, w| unsafe { w.can_remap().bits(0) });
-        #[cfg(feature = "connectivity")]
-        mapr.modify_mapr(|_, w| unsafe { w.can1_remap().bits(0) });
-    }
-}
-
-impl<INMODE, OUTMODE> crate::Sealed for (gpio::PB9<Alternate<OUTMODE>>, gpio::PB8<Input<INMODE>>) {}
-impl<INMODE, OUTMODE> Pins for (gpio::PB9<Alternate<OUTMODE>>, gpio::PB8<Input<INMODE>>) {
-    type Instance = pac::CAN1;
-
-    fn remap(mapr: &mut MAPR) {
-        #[cfg(not(feature = "connectivity"))]
-        mapr.modify_mapr(|_, w| unsafe { w.can_remap().bits(0b10) });
-        #[cfg(feature = "connectivity")]
-        mapr.modify_mapr(|_, w| unsafe { w.can1_remap().bits(0b10) });
+    remap! {
+        Pins: [
+            #[cfg(not(feature = "connectivity"))]
+            All, Tx, Rx, PA12, PA11  => { |_, w| unsafe { w.can_remap().bits(0) } };
+            #[cfg(feature = "connectivity")]
+            All, Tx, Rx, PA12, PA11  => { |_, w| unsafe { w.can1_remap().bits(0) } };
+            #[cfg(not(feature = "connectivity"))]
+            Remap, RemapTx, RemapRx, PB9, PB8  => { |_, w| unsafe { w.can_remap().bits(10) } };
+            #[cfg(feature = "connectivity")]
+            Remap, RemapTx, RemapRx, PB9, PB8  => { |_, w| unsafe { w.can1_remap().bits(10) } };
+        ]
     }
 }
 
 #[cfg(feature = "connectivity")]
-impl<INMODE, OUTMODE> crate::Sealed
-    for (gpio::PB13<Alternate<OUTMODE>>, gpio::PB12<Input<INMODE>>)
-{
-}
-#[cfg(feature = "connectivity")]
-impl<INMODE, OUTMODE> Pins for (gpio::PB13<Alternate<OUTMODE>>, gpio::PB12<Input<INMODE>>) {
-    type Instance = pac::CAN2;
+pub mod can2 {
+    use super::*;
 
-    fn remap(mapr: &mut MAPR) {
-        mapr.modify_mapr(|_, w| w.can2_remap().clear_bit());
+    remap! {
+        Pins: [
+            All, Tx, Rx, PB6, PB5  => { |_, w| w.can2_remap().bit(false) };
+            Remap, RemapTx, RemapRx, PB13, PB12  => { |_, w| w.can2_remap().bit(true) };
+        ]
     }
 }
 
-#[cfg(feature = "connectivity")]
-impl<INMODE, OUTMODE> crate::Sealed for (gpio::PB6<Alternate<OUTMODE>>, gpio::PB5<Input<INMODE>>) {}
-#[cfg(feature = "connectivity")]
-impl<INMODE, OUTMODE> Pins for (gpio::PB6<Alternate<OUTMODE>>, gpio::PB5<Input<INMODE>>) {
-    type Instance = pac::CAN2;
+macro_rules! remap {
+    ($name:ident: [
+        $($(#[$attr:meta])* $rname:ident, $txonly:ident, $rxonly:ident, $TX:ident, $RX:ident => { $remapex:expr };)+
+    ]) => {
+        pub enum $name<PULL> {
+            $(
+                $(#[$attr])*
+                $rname { tx: gpio::$TX<Alternate>, rx: gpio::$RX<Input<PULL>> },
+                $(#[$attr])*
+                $txonly { tx: gpio::$TX<Alternate> },
+                $(#[$attr])*
+                $rxonly { rx: gpio::$RX<Input<PULL>> },
+            )+
+        }
 
-    fn remap(mapr: &mut MAPR) {
-        mapr.modify_mapr(|_, w| w.can2_remap().set_bit());
+        $(
+            $(#[$attr])*
+            impl<PULL: InMode> From<(gpio::$TX<Alternate>, gpio::$RX<Input<PULL>>, &mut MAPR)> for $name<PULL> {
+                fn from(p: (gpio::$TX<Alternate>, gpio::$RX<Input<PULL>>, &mut MAPR)) -> Self {
+                    p.2.modify_mapr($remapex);
+                    Self::$rname { tx: p.0, rx: p.1 }
+                }
+            }
+
+            $(#[$attr])*
+            impl<PULL> From<(gpio::$TX, gpio::$RX, &mut MAPR)> for $name<PULL>
+            where
+                Input<PULL>: PinMode,
+                PULL: InMode,
+            {
+                fn from(p: (gpio::$TX, gpio::$RX, &mut MAPR)) -> Self {
+                    let mut cr = Cr;
+                    let tx = p.0.into_mode(&mut cr);
+                    let rx = p.1.into_mode(&mut cr);
+                    p.2.modify_mapr($remapex);
+                    Self::$rname { tx, rx }
+                }
+            }
+
+            $(#[$attr])*
+            impl From<(gpio::$TX, &mut MAPR)> for $name<Floating> {
+                fn from(p: (gpio::$TX, &mut MAPR)) -> Self {
+                    let tx = p.0.into_mode(&mut Cr);
+                    p.1.modify_mapr($remapex);
+                    Self::$txonly { tx }
+                }
+            }
+
+            $(#[$attr])*
+            impl<PULL> From<(gpio::$RX, &mut MAPR)> for $name<PULL>
+            where
+                Input<PULL>: PinMode,
+                PULL: InMode,
+            {
+                fn from(p: (gpio::$RX, &mut MAPR)) -> Self {
+                    let rx = p.0.into_mode(&mut Cr);
+                    p.1.modify_mapr($remapex);
+                    Self::$rxonly { rx }
+                }
+            }
+        )+
     }
+}
+use remap;
+
+pub trait CanExt: Sized + Instance {
+    fn can<PULL>(
+        self,
+        #[cfg(not(feature = "connectivity"))] usb: pac::USB,
+        pins: impl Into<Self::Pins<PULL>>,
+    ) -> Can<Self, PULL>;
+    fn can_loopback<PULL>(
+        self,
+        #[cfg(not(feature = "connectivity"))] usb: pac::USB,
+    ) -> Can<Self, PULL>;
+}
+
+impl<CAN: Instance> CanExt for CAN {
+    fn can<PULL>(
+        self,
+        #[cfg(not(feature = "connectivity"))] usb: pac::USB,
+        pins: impl Into<Self::Pins<PULL>>,
+    ) -> Can<Self, PULL> {
+        Can::new(
+            self,
+            #[cfg(not(feature = "connectivity"))]
+            usb,
+            pins,
+        )
+    }
+    fn can_loopback<PULL>(
+        self,
+        #[cfg(not(feature = "connectivity"))] usb: pac::USB,
+    ) -> Can<Self, PULL> {
+        Can::new_loopback(
+            self,
+            #[cfg(not(feature = "connectivity"))]
+            usb,
+        )
+    }
+}
+
+pub trait Instance: crate::rcc::Enable {
+    type Pins<PULL>;
+}
+impl Instance for pac::CAN1 {
+    type Pins<PULL> = can1::Pins<PULL>;
+}
+#[cfg(feature = "connectivity")]
+impl Instance for pac::CAN2 {
+    type Pins<PULL> = can2::Pins<PULL>;
 }
 
 /// Interface to the CAN peripheral.
-pub struct Can<Instance> {
-    _peripheral: Instance,
+#[allow(unused)]
+pub struct Can<CAN: Instance, PULL = Floating> {
+    can: CAN,
+    pins: Option<CAN::Pins<PULL>>,
 }
 
-impl<Instance> Can<Instance>
-where
-    Instance: crate::rcc::Enable,
-{
-    /// Creates a CAN interaface.
+impl<CAN: Instance, PULL> Can<CAN, PULL> {
+    /// Creates a CAN interface.
     ///
     /// CAN shares SRAM with the USB peripheral. Take ownership of USB to
     /// prevent accidental shared usage.
-    #[cfg(not(feature = "connectivity"))]
-    pub fn new(can: Instance, _usb: pac::USB) -> Can<Instance> {
+    pub fn new(
+        can: CAN,
+        #[cfg(not(feature = "connectivity"))] _usb: pac::USB,
+        pins: impl Into<CAN::Pins<PULL>>,
+    ) -> Can<CAN, PULL> {
         let rcc = unsafe { &(*RCC::ptr()) };
-        Instance::enable(rcc);
+        CAN::enable(rcc);
 
-        Can { _peripheral: can }
+        let pins = Some(pins.into());
+        Can { can, pins }
     }
 
-    /// Creates a CAN interaface.
-    #[cfg(feature = "connectivity")]
-    pub fn new(can: Instance) -> Can<Instance> {
+    /// Creates a CAN interface in loopback mode
+    pub fn new_loopback(
+        can: CAN,
+        #[cfg(not(feature = "connectivity"))] _usb: pac::USB,
+    ) -> Can<CAN, PULL> {
         let rcc = unsafe { &(*RCC::ptr()) };
-        Instance::enable(rcc);
+        CAN::enable(rcc);
 
-        Can { _peripheral: can }
-    }
-
-    /// Routes CAN TX signals and RX signals to pins.
-    pub fn assign_pins<P>(&self, _pins: P, mapr: &mut MAPR)
-    where
-        P: Pins<Instance = Instance>,
-    {
-        P::remap(mapr);
+        Can { can, pins: None }
     }
 }
 
-unsafe impl bxcan::Instance for Can<pac::CAN1> {
+unsafe impl<PULL> bxcan::Instance for Can<pac::CAN1, PULL> {
     const REGISTERS: *mut bxcan::RegisterBlock = pac::CAN1::ptr() as *mut _;
 }
 
 #[cfg(feature = "connectivity")]
-unsafe impl bxcan::Instance for Can<pac::CAN2> {
+unsafe impl<PULL> bxcan::Instance for Can<pac::CAN2, PULL> {
     const REGISTERS: *mut bxcan::RegisterBlock = pac::CAN2::ptr() as *mut _;
 }
 
-unsafe impl bxcan::FilterOwner for Can<pac::CAN1> {
+unsafe impl<PULL> bxcan::FilterOwner for Can<pac::CAN1, PULL> {
     const NUM_FILTER_BANKS: u8 = 28;
 }
 
 #[cfg(feature = "connectivity")]
-unsafe impl bxcan::MasterInstance for Can<pac::CAN1> {}
+unsafe impl<PULL> bxcan::MasterInstance for Can<pac::CAN1, PULL> {}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -138,9 +138,7 @@ pub trait Active {}
 
 /// Input mode (type state)
 #[derive(Default)]
-pub struct Input<MODE = Floating> {
-    _mode: PhantomData<MODE>,
-}
+pub struct Input<PULL = Floating>(PhantomData<PULL>);
 
 impl<MODE> Active for Input<MODE> {}
 
@@ -162,9 +160,7 @@ pub struct PullUp;
 
 /// Output mode (type state)
 #[derive(Default)]
-pub struct Output<MODE = PushPull> {
-    _mode: PhantomData<MODE>,
-}
+pub struct Output<Otype = PushPull>(PhantomData<Otype>);
 
 impl<MODE> Active for Output<MODE> {}
 
@@ -184,9 +180,7 @@ impl Active for Analog {}
 
 /// Alternate function
 #[derive(Default)]
-pub struct Alternate<MODE = PushPull> {
-    _mode: PhantomData<MODE>,
-}
+pub struct Alternate<Otype = PushPull>(PhantomData<Otype>);
 
 impl<MODE> Active for Alternate<MODE> {}
 

--- a/src/i2c/hal_02.rs
+++ b/src/i2c/hal_02.rs
@@ -1,7 +1,7 @@
 use super::*;
 use embedded_hal_02::blocking::i2c::{Operation, Read, Transactional, Write, WriteRead};
 
-impl<I2C: Instance, PINS> Write for BlockingI2c<I2C, PINS> {
+impl<I2C: Instance> Write for BlockingI2c<I2C> {
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
@@ -9,7 +9,7 @@ impl<I2C: Instance, PINS> Write for BlockingI2c<I2C, PINS> {
     }
 }
 
-impl<I2C: Instance, PINS> Read for BlockingI2c<I2C, PINS> {
+impl<I2C: Instance> Read for BlockingI2c<I2C> {
     type Error = Error;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -17,7 +17,7 @@ impl<I2C: Instance, PINS> Read for BlockingI2c<I2C, PINS> {
     }
 }
 
-impl<I2C: Instance, PINS> WriteRead for BlockingI2c<I2C, PINS> {
+impl<I2C: Instance> WriteRead for BlockingI2c<I2C> {
     type Error = Error;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -25,10 +25,7 @@ impl<I2C: Instance, PINS> WriteRead for BlockingI2c<I2C, PINS> {
     }
 }
 
-impl<I2C, PINS> Transactional for BlockingI2c<I2C, PINS>
-where
-    I2C: Instance,
-{
+impl<I2C: Instance> Transactional for BlockingI2c<I2C> {
     type Error = Error;
 
     fn exec(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {

--- a/src/i2c/hal_1.rs
+++ b/src/i2c/hal_1.rs
@@ -12,7 +12,7 @@ impl Error for super::Error {
     }
 }
 
-impl<I2C: super::Instance, PINS> ErrorType for super::BlockingI2c<I2C, PINS> {
+impl<I2C: super::Instance> ErrorType for super::BlockingI2c<I2C> {
     type Error = super::Error;
 }
 
@@ -20,7 +20,7 @@ mod blocking {
     use super::super::{BlockingI2c, Instance};
     use embedded_hal::i2c::Operation;
 
-    impl<I2C: Instance, PINS> embedded_hal::i2c::I2c for BlockingI2c<I2C, PINS> {
+    impl<I2C: Instance> embedded_hal::i2c::I2c for BlockingI2c<I2C> {
         fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
             self.read(addr, buffer)
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 pub use crate::adc::ChannelTimeSequence as _stm32_hal_adc_ChannelTimeSequence;
 pub use crate::afio::AfioExt as _stm32_hal_afio_AfioExt;
+#[cfg(feature = "has-can")]
+pub use crate::can::CanExt as _;
 pub use crate::crc::CrcExt as _stm32_hal_crc_CrcExt;
 pub use crate::dma::CircReadDma as _stm32_hal_dma_CircReadDma;
 pub use crate::dma::DmaExt as _stm32_hal_dma_DmaExt;
@@ -10,7 +12,10 @@ pub use crate::flash::FlashExt as _stm32_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32_hal_gpio_GpioExt;
 pub use crate::hal_02::adc::OneShot as _embedded_hal_adc_OneShot;
 pub use crate::hal_02::prelude::*;
+pub use crate::i2c::I2cExt as _;
 pub use crate::rcc::RccExt as _stm32_hal_rcc_RccExt;
+pub use crate::serial::SerialExt as _;
+pub use crate::spi::SpiExt as _;
 pub use crate::time::U32Ext as _stm32_hal_time_U32Ext;
 #[cfg(feature = "rtic")]
 pub use crate::timer::MonoTimerExt as _stm32f4xx_hal_timer_MonoTimerExt;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -36,7 +36,7 @@
 mod hal_02;
 mod hal_1;
 
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 use crate::pac::{self, RCC};
@@ -46,7 +46,7 @@ use crate::dma::dma1;
 #[cfg(feature = "connectivity")]
 use crate::dma::dma2;
 use crate::dma::{Receive, RxDma, RxTxDma, Transfer, TransferPayload, Transmit, TxDma, R, W};
-use crate::gpio::{self, Alternate, Input};
+use crate::gpio::{self, Alternate, Cr, Floating, Input, PinMode, PullUp, PushPull};
 use crate::rcc::{BusClock, Clocks, Enable, Reset};
 use crate::time::Hertz;
 
@@ -104,50 +104,293 @@ pub enum Error {
 
 use core::marker::PhantomData;
 
-/// Spi in Master mode (type state)
-pub struct Master;
-/// Spi in Slave mode (type state)
-pub struct Slave;
+pub trait InMode {}
+impl InMode for Floating {}
+impl InMode for PullUp {}
 
-mod sealed {
-    pub trait Remap {
-        type Periph;
-        const REMAP: bool;
+pub mod spi1 {
+    use super::*;
+
+    remap! {
+        MasterPins, SlavePins: [
+            All, Nomosi, Nomiso, PA5, PA6, PA7 => MAPR { |_, w| w.spi1_remap().bit(false) };
+            Remap, RemapNomosi, RemapNomiso, PB3, PB4, PB5  => MAPR { |_, w| w.spi1_remap().bit(true) };
+        ]
     }
-    pub trait Sck<REMAP> {}
-    pub trait Miso<REMAP> {}
-    pub trait Mosi<REMAP> {}
-    pub trait Ssck<REMAP> {}
-    pub trait So<REMAP> {}
-    pub trait Si<REMAP> {}
-}
-pub use sealed::Remap;
-use sealed::{Miso, Mosi, Sck, Si, So, Ssck};
-
-pub trait Pins<REMAP, OPERATION = Master> {}
-
-impl<REMAP, SCK, MISO, MOSI> Pins<REMAP, Master> for (SCK, MISO, MOSI)
-where
-    SCK: Sck<REMAP>,
-    MISO: Miso<REMAP>,
-    MOSI: Mosi<REMAP>,
-{
 }
 
-impl<REMAP, SCK, MISO, MOSI> Pins<REMAP, Slave> for (SCK, MISO, MOSI)
-where
-    SCK: Ssck<REMAP>,
-    MISO: So<REMAP>,
-    MOSI: Si<REMAP>,
-{
+pub mod spi2 {
+    use super::*;
+
+    remap! {
+        MasterPins, SlavePins: [
+            All, Nomosi, Nomiso, PB13, PB14, PB15;
+        ]
+    }
+}
+#[cfg(any(feature = "high", feature = "connectivity"))]
+pub mod spi3 {
+    use super::*;
+
+    remap! {
+        MasterPins, SlavePins: [
+            #[cfg(not(feature = "connectivity"))]
+            All, Nomosi, Nomiso, PB3, PB4, PB5;
+            #[cfg(feature = "connectivity")]
+            All, Nomosi, Nomiso, PB3, PB4, PB5 => MAPR { |_, w| w.spi3_remap().bit(false) };
+            #[cfg(feature = "connectivity")]
+            Remap, RemapNomosi, RemapNomiso, PC10, PC11, PC12  => MAPR { |_, w| w.spi3_remap().bit(true) };
+        ]
+    }
 }
 
-pub struct Spi<SPI, REMAP, PINS, FRAMESIZE, OPERATION = Master> {
+macro_rules! remap {
+    ($master:ident, $slave:ident: [
+        $($(#[$attr:meta])* $rname:ident, $nomosi:ident, $nomiso:ident, $SCK:ident, $MISO:ident, $MOSI:ident $( => $MAPR:ident { $remapex:expr })?;)+
+    ]) => {
+        pub enum $master<PULL> {
+            $(
+                $(#[$attr])*
+                $rname { sck: gpio::$SCK<Alternate>, miso: gpio::$MISO<Input<PULL>>, mosi: gpio::$MOSI<Alternate> },
+                $(#[$attr])*
+                $nomosi { sck: gpio::$SCK<Alternate>, miso: gpio::$MISO<Input<PULL>> },
+                $(#[$attr])*
+                $nomiso { sck: gpio::$SCK<Alternate>, mosi: gpio::$MOSI<Alternate> },
+            )+
+        }
+
+        pub enum $slave<Otype, PULL> {
+            $(
+                $(#[$attr])*
+                $rname { sck: gpio::$SCK, miso: gpio::$MISO<Alternate<Otype>>, mosi: gpio::$MOSI<Input<PULL>> },
+                $(#[$attr])*
+                $nomosi { sck: gpio::$SCK, miso: gpio::$MISO<Alternate<Otype>> },
+                $(#[$attr])*
+                $nomiso { sck: gpio::$SCK, mosi: gpio::$MOSI<Input<PULL>> },
+            )+
+        }
+
+        $(
+            // For master mode
+
+            $(#[$attr])*
+            impl<PULL: InMode> From<(gpio::$SCK<Alternate>, gpio::$MISO<Input<PULL>>, gpio::$MOSI<Alternate> $(, &mut $MAPR)?)> for $master<PULL> {
+                fn from(p: (gpio::$SCK<Alternate>, gpio::$MISO<Input<PULL>>, gpio::$MOSI<Alternate> $(, &mut $MAPR)?)) -> Self {
+                    $(p.3.modify_mapr($remapex);)?
+                    Self::$rname { sck: p.0, miso: p.1, mosi: p.2 }
+                }
+            }
+
+            $(#[$attr])*
+            impl<PULL> From<(gpio::$SCK, gpio::$MISO, gpio::$MOSI $(, &mut $MAPR)?)> for $master<PULL>
+            where
+                Input<PULL>: PinMode,
+                PULL: InMode,
+            {
+                fn from(p: (gpio::$SCK, gpio::$MISO, gpio::$MOSI $(, &mut $MAPR)?)) -> Self {
+                    let mut cr = Cr;
+                    let sck = p.0.into_mode(&mut cr);
+                    let miso = p.1.into_mode(&mut cr);
+                    let mosi = p.2.into_mode(&mut cr);
+                    $(p.3.modify_mapr($remapex);)?
+                    Self::$rname { sck, miso, mosi }
+                }
+            }
+
+            $(#[$attr])*
+            impl<PULL: InMode> From<(gpio::$SCK<Alternate>, gpio::$MISO<Input<PULL>> $(, &mut $MAPR)?)> for $master<PULL> {
+                fn from(p: (gpio::$SCK<Alternate>, gpio::$MISO<Input<PULL>> $(, &mut $MAPR)?)) -> Self {
+                    $(p.2.modify_mapr($remapex);)?
+                    Self::$nomosi { sck: p.0, miso: p.1 }
+                }
+            }
+
+            $(#[$attr])*
+            impl<PULL> From<(gpio::$SCK, gpio::$MISO $(, &mut $MAPR)?)> for $master<PULL>
+            where
+                Input<PULL>: PinMode,
+                PULL: InMode,
+            {
+                fn from(p: (gpio::$SCK, gpio::$MISO $(, &mut $MAPR)?)) -> Self {
+                    let mut cr = Cr;
+                    let sck = p.0.into_mode(&mut cr);
+                    let miso = p.1.into_mode(&mut cr);
+                    $(p.2.modify_mapr($remapex);)?
+                    Self::$nomosi { sck, miso }
+                }
+            }
+
+            $(#[$attr])*
+            impl From<(gpio::$SCK, gpio::$MOSI $(, &mut $MAPR)?)> for $master<Floating> {
+                fn from(p: (gpio::$SCK, gpio::$MOSI $(, &mut $MAPR)?)) -> Self {
+                    let mut cr = Cr;
+                    let sck = p.0.into_mode(&mut cr);
+                    let mosi = p.1.into_mode(&mut cr);
+                    $(p.2.modify_mapr($remapex);)?
+                    Self::$nomiso { sck, mosi }
+                }
+            }
+
+            // For slave mode
+
+            $(#[$attr])*
+            impl<Otype, PULL: InMode> From<(gpio::$SCK, gpio::$MISO<Alternate<Otype>>, gpio::$MOSI<Input<PULL>> $(, &mut $MAPR)?)> for $slave<Otype, PULL> {
+                fn from(p: (gpio::$SCK, gpio::$MISO<Alternate<Otype>>, gpio::$MOSI<Input<PULL>> $(, &mut $MAPR)?)) -> Self {
+                    $(p.3.modify_mapr($remapex);)?
+                    Self::$rname { sck: p.0, miso: p.1, mosi: p.2 }
+                }
+            }
+
+            $(#[$attr])*
+            impl<Otype, PULL> From<(gpio::$SCK, gpio::$MISO, gpio::$MOSI $(, &mut $MAPR)?)> for $slave<Otype, PULL>
+            where
+                Alternate<Otype>: PinMode,
+                Input<PULL>: PinMode,
+                PULL: InMode,
+            {
+                fn from(p: (gpio::$SCK, gpio::$MISO, gpio::$MOSI $(, &mut $MAPR)?)) -> Self {
+                    let mut cr = Cr;
+                    let sck = p.0.into_mode(&mut cr);
+                    let miso = p.1.into_mode(&mut cr);
+                    let mosi = p.2.into_mode(&mut cr);
+                    $(p.3.modify_mapr($remapex);)?
+                    Self::$rname { sck, miso, mosi }
+                }
+            }
+
+            $(#[$attr])*
+            impl<Otype> From<(gpio::$SCK, gpio::$MISO $(, &mut $MAPR)?)> for $slave<Otype, Floating>
+            where
+                Alternate<Otype>: PinMode,
+            {
+                fn from(p: (gpio::$SCK, gpio::$MISO $(, &mut $MAPR)?)) -> Self {
+                    let mut cr = Cr;
+                    let sck = p.0.into_mode(&mut cr);
+                    let miso = p.1.into_mode(&mut cr);
+                    $(p.2.modify_mapr($remapex);)?
+                    Self::$nomosi { sck, miso }
+                }
+            }
+
+            $(#[$attr])*
+            impl<PULL> From<(gpio::$SCK, gpio::$MOSI $(, &mut $MAPR)?)> for $slave<PushPull, PULL>
+            where
+                Input<PULL>: PinMode,
+                PULL: InMode,
+            {
+                fn from(p: (gpio::$SCK, gpio::$MOSI $(, &mut $MAPR)?)) -> Self {
+                    let mut cr = Cr;
+                    let sck = p.0.into_mode(&mut cr);
+                    let mosi = p.1.into_mode(&mut cr);
+                    $(p.2.modify_mapr($remapex);)?
+                    Self::$nomiso { sck, mosi }
+                }
+            }
+        )+
+    }
+}
+use remap;
+
+pub trait SpiExt: Sized + Instance {
+    fn spi<PULL>(
+        self,
+        pins: impl Into<Self::MasterPins<PULL>>,
+        mode: Mode,
+        freq: Hertz,
+        clocks: &Clocks,
+    ) -> Spi<Self, u8, PULL>;
+    fn spi_u16<PULL>(
+        self,
+        pins: impl Into<Self::MasterPins<PULL>>,
+        mode: Mode,
+        freq: Hertz,
+        clocks: &Clocks,
+    ) -> Spi<Self, u16, PULL> {
+        Self::spi(self, pins, mode, freq, clocks).frame_size_16bit()
+    }
+    fn spi_slave<Otype, PULL>(
+        self,
+        pins: impl Into<Self::SlavePins<Otype, PULL>>,
+        mode: Mode,
+    ) -> SpiSlave<Self, u8, Otype, PULL>;
+    fn spi_slave_u16<Otype, PULL>(
+        self,
+        pins: impl Into<Self::SlavePins<Otype, PULL>>,
+        mode: Mode,
+    ) -> SpiSlave<Self, u16, Otype, PULL> {
+        Self::spi_slave(self, pins, mode).frame_size_16bit()
+    }
+}
+
+impl<SPI: Instance> SpiExt for SPI {
+    fn spi<PULL>(
+        self,
+        pins: impl Into<Self::MasterPins<PULL>>,
+        mode: Mode,
+        freq: Hertz,
+        clocks: &Clocks,
+    ) -> Spi<Self, u8, PULL> {
+        Spi::new(self, pins, mode, freq, clocks)
+    }
+    fn spi_slave<Otype, PULL>(
+        self,
+        pins: impl Into<Self::SlavePins<Otype, PULL>>,
+        mode: Mode,
+    ) -> SpiSlave<Self, u8, Otype, PULL> {
+        SpiSlave::new(self, pins, mode)
+    }
+}
+
+pub struct SpiInner<SPI, W> {
     spi: SPI,
-    pins: PINS,
-    _remap: PhantomData<REMAP>,
-    _framesize: PhantomData<FRAMESIZE>,
-    _operation: PhantomData<OPERATION>,
+    _framesize: PhantomData<W>,
+}
+
+impl<SPI, W> SpiInner<SPI, W> {
+    fn new(spi: SPI) -> Self {
+        Self {
+            spi,
+            _framesize: PhantomData,
+        }
+    }
+}
+
+/// Spi in Master mode
+pub struct Spi<SPI: Instance, W, PULL = Floating> {
+    inner: SpiInner<SPI, W>,
+    pins: SPI::MasterPins<PULL>,
+}
+
+/// Spi in Slave mode
+pub struct SpiSlave<SPI: Instance, W, Otype = PushPull, PULL = Floating> {
+    inner: SpiInner<SPI, W>,
+    pins: SPI::SlavePins<Otype, PULL>,
+}
+
+impl<SPI: Instance, W, PULL> Deref for Spi<SPI, W, PULL> {
+    type Target = SpiInner<SPI, W>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<SPI: Instance, W, PULL> DerefMut for Spi<SPI, W, PULL> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<SPI: Instance, W, Otype, PULL> Deref for SpiSlave<SPI, W, Otype, PULL> {
+    type Target = SpiInner<SPI, W>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<SPI: Instance, W, Otype, PULL> DerefMut for SpiSlave<SPI, W, Otype, PULL> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
 }
 
 /// The bit format to send the data in
@@ -159,208 +402,150 @@ pub enum SpiBitFormat {
     MsbFirst,
 }
 
-/// A filler type for when the SCK pin is unnecessary
-pub struct NoSck;
-/// A filler type for when the Miso pin is unnecessary
-pub struct NoMiso;
-/// A filler type for when the Mosi pin is unnecessary
-pub struct NoMosi;
-
-impl<REMAP> Sck<REMAP> for NoSck {}
-impl<REMAP> Miso<REMAP> for NoMiso {}
-impl<REMAP> Mosi<REMAP> for NoMosi {}
-impl<REMAP> So<REMAP> for NoMiso {}
-impl<REMAP> Si<REMAP> for NoMosi {}
-
-macro_rules! remap {
-    ($name:ident, $SPIX:ty, $state:literal, $SCK:ident, $MISO:ident, $MOSI:ident) => {
-        pub struct $name;
-        impl Remap for $name {
-            type Periph = $SPIX;
-            const REMAP: bool = $state;
-        }
-        // Master mode pins
-        impl<MODE> Sck<$name> for gpio::$SCK<Alternate<MODE>> {}
-        impl<MODE> Miso<$name> for gpio::$MISO<Input<MODE>> {}
-        impl<MODE> Mosi<$name> for gpio::$MOSI<Alternate<MODE>> {}
-        // Slave mode pins
-        impl<MODE> Ssck<$name> for gpio::$SCK<Input<MODE>> {}
-        impl<MODE> So<$name> for gpio::$MISO<Alternate<MODE>> {}
-        impl<MODE> Si<$name> for gpio::$MOSI<Input<MODE>> {}
-    };
-}
-
-remap!(Spi1NoRemap, pac::SPI1, false, PA5, PA6, PA7);
-remap!(Spi1Remap, pac::SPI1, true, PB3, PB4, PB5);
-remap!(Spi2NoRemap, pac::SPI2, false, PB13, PB14, PB15);
-#[cfg(any(feature = "high", feature = "connectivity"))]
-remap!(Spi3NoRemap, pac::SPI3, false, PB3, PB4, PB5);
-#[cfg(feature = "connectivity")]
-remap!(Spi3Remap, pac::SPI3, true, PC10, PC11, PC12);
-
 pub trait Instance:
     crate::Sealed + Deref<Target = crate::pac::spi1::RegisterBlock> + Enable + Reset + BusClock
 {
+    type MasterPins<PULL>;
+    type SlavePins<Otype, PULL>;
 }
 
-impl Instance for pac::SPI1 {}
-impl Instance for pac::SPI2 {}
+impl Instance for pac::SPI1 {
+    type MasterPins<PULL> = spi1::MasterPins<PULL>;
+    type SlavePins<Otype, PULL> = spi1::SlavePins<Otype, PULL>;
+}
+impl Instance for pac::SPI2 {
+    type MasterPins<PULL> = spi2::MasterPins<PULL>;
+    type SlavePins<Otype, PULL> = spi2::SlavePins<Otype, PULL>;
+}
 #[cfg(any(feature = "high", feature = "connectivity"))]
-impl Instance for pac::SPI3 {}
+impl Instance for pac::SPI3 {
+    type MasterPins<PULL> = spi3::MasterPins<PULL>;
+    type SlavePins<Otype, PULL> = spi3::SlavePins<Otype, PULL>;
+}
 
-impl<REMAP, PINS> Spi<pac::SPI1, REMAP, PINS, u8, Master> {
+impl<SPI: Instance, PULL> Spi<SPI, u8, PULL> {
     /**
       Constructs an SPI instance using SPI1 in 8bit dataframe mode.
 
-      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
+      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Alternate<PushPull>, Input<...>, Alternate<PushPull>)`.
 
       You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
     */
-    pub fn spi1(
-        spi: pac::SPI1,
-        pins: PINS,
-        mapr: &mut MAPR,
-        mode: impl Into<Mode>,
-        freq: Hertz,
-        clocks: &Clocks,
-    ) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI1>,
-        PINS: Pins<REMAP>,
-    {
-        mapr.modify_mapr(|_, w| w.spi1_remap().bit(REMAP::REMAP));
-        Spi::<pac::SPI1, _, _, u8>::configure(spi, pins, mode, freq, clocks)
-    }
-}
-
-impl<REMAP, PINS> Spi<pac::SPI1, REMAP, PINS, u8, Slave> {
-    /**
-      Constructs an SPI instance using SPI1 in 8bit dataframe mode.
-
-      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Input<...>, Alternate<...>, Input<...>)`.
-
-      You can also use `NoMiso` or `NoMosi` if you don't want to use the pins
-    */
-    pub fn spi1_slave(spi: pac::SPI1, pins: PINS, mapr: &mut MAPR, mode: impl Into<Mode>) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI1>,
-        PINS: Pins<REMAP, Slave>,
-    {
-        mapr.modify_mapr(|_, w| w.spi1_remap().bit(REMAP::REMAP));
-        Spi::<pac::SPI1, _, _, u8, Slave>::configure(spi, pins, mode)
-    }
-}
-
-impl<REMAP, PINS> Spi<pac::SPI2, REMAP, PINS, u8, Master> {
-    /**
-      Constructs an SPI instance using SPI2 in 8bit dataframe mode.
-
-      The pin parameter tuple (sck, miso, mosi) should be `(PB13, PB14, PB15)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
-
-      You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
-    */
-    pub fn spi2(spi: pac::SPI2, pins: PINS, mode: Mode, freq: Hertz, clocks: &Clocks) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI2>,
-        PINS: Pins<REMAP>,
-    {
-        Spi::<pac::SPI2, _, _, u8>::configure(spi, pins, mode, freq, clocks)
-    }
-}
-
-impl<REMAP, PINS> Spi<pac::SPI2, REMAP, PINS, u8, Slave> {
-    /**
-      Constructs an SPI instance using SPI2 in 8bit dataframe mode.
-
-      The pin parameter tuple (sck, miso, mosi) should be `(PB13, PB14, PB15)` configured as `(Input<...>, Alternate<...>, Input<...>)`.
-
-      You can also use `NoMiso` or `NoMosi` if you don't want to use the pins
-    */
-    pub fn spi2_slave(spi: pac::SPI2, pins: PINS, mode: Mode) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI2>,
-        PINS: Pins<REMAP, Slave>,
-    {
-        Spi::<pac::SPI2, _, _, u8, Slave>::configure(spi, pins, mode)
-    }
-}
-
-#[cfg(any(feature = "high", feature = "connectivity"))]
-impl<REMAP, PINS> Spi<pac::SPI3, REMAP, PINS, u8, Master> {
-    /**
-      Constructs an SPI instance using SPI3 in 8bit dataframe mode.
-
-      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
-
-      You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
-    */
-    #[cfg(not(feature = "connectivity"))]
-    pub fn spi3(spi: pac::SPI3, pins: PINS, mode: Mode, freq: Hertz, clocks: &Clocks) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI3>,
-        PINS: Pins<REMAP>,
-    {
-        Spi::<pac::SPI3, _, _, u8>::configure(spi, pins, mode, freq, clocks)
-    }
-
-    /**
-      Constructs an SPI instance using SPI3 in 8bit dataframe mode.
-
-      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)` configured as `(Alternate<...>, Input<...>, Alternate<...>)`.
-
-      You can also use `NoSck`, `NoMiso` or `NoMosi` if you don't want to use the pins
-    */
-    #[cfg(feature = "connectivity")]
-    pub fn spi3(
-        spi: pac::SPI3,
-        pins: PINS,
-        mapr: &mut MAPR,
+    pub fn new(
+        spi: SPI,
+        pins: impl Into<SPI::MasterPins<PULL>>,
         mode: Mode,
         freq: Hertz,
         clocks: &Clocks,
-    ) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI3>,
-        PINS: Pins<REMAP>,
-    {
-        mapr.modify_mapr(|_, w| w.spi3_remap().bit(REMAP::REMAP));
-        Spi::<pac::SPI3, _, _, u8>::configure(spi, pins, mode, freq, clocks)
+    ) -> Self {
+        // enable or reset SPI
+        let rcc = unsafe { &(*RCC::ptr()) };
+        SPI::enable(rcc);
+        SPI::reset(rcc);
+
+        // disable SS output
+        spi.cr2.write(|w| w.ssoe().clear_bit());
+
+        let br = match SPI::clock(clocks) / freq {
+            0 => unreachable!(),
+            1..=2 => 0b000,
+            3..=5 => 0b001,
+            6..=11 => 0b010,
+            12..=23 => 0b011,
+            24..=47 => 0b100,
+            48..=95 => 0b101,
+            96..=191 => 0b110,
+            _ => 0b111,
+        };
+
+        let pins = pins.into();
+
+        spi.cr1.write(|w| {
+            // clock phase from config
+            w.cpha().bit(mode.phase == Phase::CaptureOnSecondTransition);
+            // clock polarity from config
+            w.cpol().bit(mode.polarity == Polarity::IdleHigh);
+            // mstr: master configuration
+            w.mstr().set_bit();
+            // baudrate value
+            w.br().bits(br);
+            // lsbfirst: MSB first
+            w.lsbfirst().clear_bit();
+            // ssm: enable software slave management (NSS pin free for other uses)
+            w.ssm().set_bit();
+            // ssi: set nss high = master mode
+            w.ssi().set_bit();
+            // dff: 8 bit frames
+            w.dff().clear_bit();
+            // bidimode: 2-line unidirectional
+            w.bidimode().clear_bit();
+            // both TX and RX are used
+            w.rxonly().clear_bit();
+            // spe: enable the SPI bus
+            w.spe().set_bit()
+        });
+
+        Spi {
+            inner: SpiInner::new(spi),
+            pins,
+        }
+    }
+
+    pub fn release(self) -> (SPI, SPI::MasterPins<PULL>) {
+        (self.inner.spi, self.pins)
     }
 }
 
-#[cfg(any(feature = "high", feature = "connectivity"))]
-impl<REMAP, PINS> Spi<pac::SPI3, REMAP, PINS, u8, Slave> {
+impl<SPI: Instance, Otype, PULL> SpiSlave<SPI, u8, Otype, PULL> {
     /**
-      Constructs an SPI instance using SPI3 in 8bit dataframe mode.
+      Constructs an SPI instance using SPI1 in 8bit dataframe mode.
 
-      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` configured as `(Input<...>, Alternate<...>, Input<...>)`.
+      The pin parameter tuple (sck, miso, mosi) should be `(PA5, PA6, PA7)` or `(PB3, PB4, PB5)` configured as `(Input<Floating>, Alternate<...>, Input<...>)`.
 
       You can also use `NoMiso` or `NoMosi` if you don't want to use the pins
     */
-    #[cfg(not(feature = "connectivity"))]
-    pub fn spi3_slave(spi: pac::SPI3, pins: PINS, mode: Mode) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI3>,
-        PINS: Pins<REMAP>,
-    {
-        Spi::<pac::SPI3, _, _, u8, Slave>::configure(spi, pins, mode)
+    pub fn new(spi: SPI, pins: impl Into<SPI::SlavePins<Otype, PULL>>, mode: Mode) -> Self {
+        // enable or reset SPI
+        let rcc = unsafe { &(*RCC::ptr()) };
+        SPI::enable(rcc);
+        SPI::reset(rcc);
+
+        // disable SS output
+        spi.cr2.write(|w| w.ssoe().clear_bit());
+
+        let pins = pins.into();
+
+        spi.cr1.write(|w| {
+            // clock phase from config
+            w.cpha().bit(mode.phase == Phase::CaptureOnSecondTransition);
+            // clock polarity from config
+            w.cpol().bit(mode.polarity == Polarity::IdleHigh);
+            // mstr: slave configuration
+            w.mstr().clear_bit();
+            // lsbfirst: MSB first
+            w.lsbfirst().clear_bit();
+            // ssm: enable software slave management (NSS pin free for other uses)
+            w.ssm().set_bit();
+            // ssi: set nss low = slave mode
+            w.ssi().clear_bit();
+            // dff: 8 bit frames
+            w.dff().clear_bit();
+            // bidimode: 2-line unidirectional
+            w.bidimode().clear_bit();
+            // both TX and RX are used
+            w.rxonly().clear_bit();
+            // spe: enable the SPI bus
+            w.spe().set_bit()
+        });
+
+        SpiSlave {
+            inner: SpiInner::new(spi),
+            pins,
+        }
     }
 
-    /**
-      Constructs an SPI instance using SPI3 in 8bit dataframe mode.
-
-      The pin parameter tuple (sck, miso, mosi) should be `(PB3, PB4, PB5)` or `(PC10, PC11, PC12)` configured as `(Input<...>, Alternate<...>, Input<...>)`.
-
-      You can also use `NoMiso` or `NoMosi` if you don't want to use the pins
-    */
-    #[cfg(feature = "connectivity")]
-    pub fn spi3_slave(spi: pac::SPI3, pins: PINS, mapr: &mut MAPR, mode: Mode) -> Self
-    where
-        REMAP: Remap<Periph = pac::SPI3>,
-        PINS: Pins<REMAP>,
-    {
-        mapr.modify_mapr(|_, w| w.spi3_remap().bit(REMAP::REMAP));
-        Spi::<pac::SPI3, _, _, u8, Slave>::configure(spi, pins, mode)
+    pub fn release(self) -> (SPI, SPI::SlavePins<Otype, PULL>) {
+        (self.inner.spi, self.pins)
     }
 }
 
@@ -370,28 +555,23 @@ pub trait SpiReadWrite<T> {
     fn spi_write(&mut self, words: &[T]) -> Result<(), Error>;
 }
 
-impl<SPI, REMAP, PINS, FrameSize, OP> SpiReadWrite<FrameSize>
-    for Spi<SPI, REMAP, PINS, FrameSize, OP>
-where
-    SPI: Instance,
-    FrameSize: Copy,
-{
-    fn read_data_reg(&mut self) -> FrameSize {
+impl<SPI: Instance, W: Copy> SpiReadWrite<W> for SpiInner<SPI, W> {
+    fn read_data_reg(&mut self) -> W {
         // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
         // reading a half-word)
-        unsafe { ptr::read_volatile(ptr::addr_of!(self.spi.dr) as *const FrameSize) }
+        unsafe { ptr::read_volatile(ptr::addr_of!(self.spi.dr) as *const W) }
     }
 
-    fn write_data_reg(&mut self, data: FrameSize) {
+    fn write_data_reg(&mut self, data: W) {
         // NOTE(write_volatile) see note above
-        unsafe { ptr::write_volatile(ptr::addr_of!(self.spi.dr) as *mut FrameSize, data) }
+        unsafe { ptr::write_volatile(ptr::addr_of!(self.spi.dr) as *mut W, data) }
     }
 
     // Implement write as per the "Transmit only procedure" page 712
     // of RM0008 Rev 20. This is more than twice as fast as the
     // default Write<> implementation (which reads and drops each
     // received value)
-    fn spi_write(&mut self, words: &[FrameSize]) -> Result<(), Error> {
+    fn spi_write(&mut self, words: &[W]) -> Result<(), Error> {
         // Write each word when the tx buffer is empty
         for word in words {
             loop {
@@ -416,15 +596,7 @@ where
     }
 }
 
-impl<SPI, REMAP, PINS, FrameSize, OP> Spi<SPI, REMAP, PINS, FrameSize, OP>
-where
-    SPI: Instance,
-    FrameSize: Copy,
-{
-    pub fn release(self) -> (SPI, PINS) {
-        (self.spi, self.pins)
-    }
-
+impl<SPI: Instance, W: Copy> SpiInner<SPI, W> {
     /// Select which frame format is used for data transfers
     pub fn bit_format(&mut self, format: SpiBitFormat) {
         match format {
@@ -480,164 +652,64 @@ where
     }
 }
 
-impl<SPI, REMAP, PINS> Spi<SPI, REMAP, PINS, u8, Master>
-where
-    SPI: Instance,
-{
-    fn configure(
-        spi: SPI,
-        pins: PINS,
-        mode: impl Into<Mode>,
-        freq: Hertz,
-        clocks: &Clocks,
-    ) -> Self {
-        let mode = mode.into();
-        // enable or reset SPI
-        let rcc = unsafe { &(*RCC::ptr()) };
-        SPI::enable(rcc);
-        SPI::reset(rcc);
-
-        // disable SS output
-        spi.cr2.write(|w| w.ssoe().clear_bit());
-
-        let br = match SPI::clock(clocks) / freq {
-            0 => unreachable!(),
-            1..=2 => 0b000,
-            3..=5 => 0b001,
-            6..=11 => 0b010,
-            12..=23 => 0b011,
-            24..=47 => 0b100,
-            48..=95 => 0b101,
-            96..=191 => 0b110,
-            _ => 0b111,
-        };
-
-        spi.cr1.write(|w| {
-            // clock phase from config
-            w.cpha().bit(mode.phase == Phase::CaptureOnSecondTransition);
-            // clock polarity from config
-            w.cpol().bit(mode.polarity == Polarity::IdleHigh);
-            // mstr: master configuration
-            w.mstr().set_bit();
-            // baudrate value
-            w.br().bits(br);
-            // lsbfirst: MSB first
-            w.lsbfirst().clear_bit();
-            // ssm: enable software slave management (NSS pin free for other uses)
-            w.ssm().set_bit();
-            // ssi: set nss high = master mode
-            w.ssi().set_bit();
-            // dff: 8 bit frames
-            w.dff().clear_bit();
-            // bidimode: 2-line unidirectional
-            w.bidimode().clear_bit();
-            // both TX and RX are used
-            w.rxonly().clear_bit();
-            // spe: enable the SPI bus
-            w.spe().set_bit()
-        });
-
-        Spi {
-            spi,
-            pins,
-            _remap: PhantomData,
-            _framesize: PhantomData,
-            _operation: PhantomData,
-        }
-    }
-}
-
-impl<SPI, REMAP, PINS> Spi<SPI, REMAP, PINS, u8, Slave>
-where
-    SPI: Instance,
-{
-    fn configure(spi: SPI, pins: PINS, mode: impl Into<Mode>) -> Self {
-        let mode = mode.into();
-        // enable or reset SPI
-        let rcc = unsafe { &(*RCC::ptr()) };
-        SPI::enable(rcc);
-        SPI::reset(rcc);
-
-        // disable SS output
-        spi.cr2.write(|w| w.ssoe().clear_bit());
-
-        spi.cr1.write(|w| {
-            // clock phase from config
-            w.cpha().bit(mode.phase == Phase::CaptureOnSecondTransition);
-            // clock polarity from config
-            w.cpol().bit(mode.polarity == Polarity::IdleHigh);
-            // mstr: slave configuration
-            w.mstr().clear_bit();
-            // lsbfirst: MSB first
-            w.lsbfirst().clear_bit();
-            // ssm: enable software slave management (NSS pin free for other uses)
-            w.ssm().set_bit();
-            // ssi: set nss low = slave mode
-            w.ssi().clear_bit();
-            // dff: 8 bit frames
-            w.dff().clear_bit();
-            // bidimode: 2-line unidirectional
-            w.bidimode().clear_bit();
-            // both TX and RX are used
-            w.rxonly().clear_bit();
-            // spe: enable the SPI bus
-            w.spe().set_bit()
-        });
-
-        Spi {
-            spi,
-            pins,
-            _remap: PhantomData,
-            _framesize: PhantomData,
-            _operation: PhantomData,
-        }
-    }
-}
-
-impl<SPI, REMAP, PINS, OP> Spi<SPI, REMAP, PINS, u8, OP>
-where
-    SPI: Instance,
-{
+impl<SPI: Instance, PULL> Spi<SPI, u8, PULL> {
     /// Converts from 8bit dataframe to 16bit.
-    pub fn frame_size_16bit(self) -> Spi<SPI, REMAP, PINS, u16> {
+    pub fn frame_size_16bit(self) -> Spi<SPI, u16, PULL> {
         self.spi.cr1.modify(|_, w| w.spe().clear_bit());
         self.spi.cr1.modify(|_, w| w.dff().set_bit());
         self.spi.cr1.modify(|_, w| w.spe().set_bit());
         Spi {
-            spi: self.spi,
+            inner: SpiInner::new(self.inner.spi),
             pins: self.pins,
-            _remap: PhantomData,
-            _framesize: PhantomData,
-            _operation: PhantomData,
         }
     }
 }
 
-impl<SPI, REMAP, PINS, OP> Spi<SPI, REMAP, PINS, u16, OP>
-where
-    SPI: Instance,
-{
+impl<SPI: Instance, Otype, PULL> SpiSlave<SPI, u8, Otype, PULL> {
+    /// Converts from 8bit dataframe to 16bit.
+    pub fn frame_size_16bit(self) -> SpiSlave<SPI, u16, Otype, PULL> {
+        self.spi.cr1.modify(|_, w| w.spe().clear_bit());
+        self.spi.cr1.modify(|_, w| w.dff().set_bit());
+        self.spi.cr1.modify(|_, w| w.spe().set_bit());
+        SpiSlave {
+            inner: SpiInner::new(self.inner.spi),
+            pins: self.pins,
+        }
+    }
+}
+
+impl<SPI: Instance, PULL> Spi<SPI, u16, PULL> {
     /// Converts from 16bit dataframe to 8bit.
-    pub fn frame_size_8bit(self) -> Spi<SPI, REMAP, PINS, u8> {
+    pub fn frame_size_8bit(self) -> Spi<SPI, u16, PULL> {
         self.spi.cr1.modify(|_, w| w.spe().clear_bit());
         self.spi.cr1.modify(|_, w| w.dff().clear_bit());
         self.spi.cr1.modify(|_, w| w.spe().set_bit());
         Spi {
-            spi: self.spi,
+            inner: SpiInner::new(self.inner.spi),
             pins: self.pins,
-            _remap: PhantomData,
-            _framesize: PhantomData,
-            _operation: PhantomData,
         }
     }
 }
 
-impl<SPI, REMAP, PINS, FrameSize, OP> Spi<SPI, REMAP, PINS, FrameSize, OP>
+impl<SPI: Instance, Otype, PULL> SpiSlave<SPI, u16, Otype, PULL> {
+    /// Converts from 16bit dataframe to 8bit.
+    pub fn frame_size_8bit(self) -> SpiSlave<SPI, u8, Otype, PULL> {
+        self.spi.cr1.modify(|_, w| w.spe().clear_bit());
+        self.spi.cr1.modify(|_, w| w.dff().clear_bit());
+        self.spi.cr1.modify(|_, w| w.spe().set_bit());
+        SpiSlave {
+            inner: SpiInner::new(self.inner.spi),
+            pins: self.pins,
+        }
+    }
+}
+
+impl<SPI, W> SpiInner<SPI, W>
 where
     SPI: Instance,
-    FrameSize: Copy,
+    W: Copy,
 {
-    pub fn read_nonblocking(&mut self) -> nb::Result<FrameSize, Error> {
+    pub fn read_nonblocking(&mut self) -> nb::Result<W, Error> {
         let sr = self.spi.sr.read();
 
         Err(if sr.ovr().bit_is_set() {
@@ -654,7 +726,7 @@ where
             nb::Error::WouldBlock
         })
     }
-    pub fn write_nonblocking(&mut self, data: FrameSize) -> nb::Result<(), Error> {
+    pub fn write_nonblocking(&mut self, data: W) -> nb::Result<(), Error> {
         let sr = self.spi.sr.read();
 
         // NOTE: Error::Overrun was deleted in #408. Need check
@@ -670,53 +742,60 @@ where
             nb::Error::WouldBlock
         })
     }
-    pub fn write(&mut self, words: &[FrameSize]) -> Result<(), Error> {
+    pub fn write(&mut self, words: &[W]) -> Result<(), Error> {
         self.spi_write(words)
     }
 }
 
 // DMA
 
-pub type SpiTxDma<SPI, REMAP, PINS, OP, CHANNEL> = TxDma<Spi<SPI, REMAP, PINS, u8, OP>, CHANNEL>;
-pub type SpiRxDma<SPI, REMAP, PINS, OP, CHANNEL> = RxDma<Spi<SPI, REMAP, PINS, u8, OP>, CHANNEL>;
-pub type SpiRxTxDma<SPI, REMAP, PINS, OP, RXCHANNEL, TXCHANNEL> =
-    RxTxDma<Spi<SPI, REMAP, PINS, u8, OP>, RXCHANNEL, TXCHANNEL>;
+pub type SpiTxDma<SPI, CHANNEL, PULL = Floating> = TxDma<Spi<SPI, u8, PULL>, CHANNEL>;
+pub type SpiRxDma<SPI, CHANNEL, PULL = Floating> = RxDma<Spi<SPI, u8, PULL>, CHANNEL>;
+pub type SpiRxTxDma<SPI, RXCHANNEL, TXCHANNEL, PULL = Floating> =
+    RxTxDma<Spi<SPI, u8, PULL>, RXCHANNEL, TXCHANNEL>;
+
+pub type SpiSlaveTxDma<SPI, CHANNEL, Otype, PULL = Floating> =
+    TxDma<SpiSlave<SPI, u8, Otype, PULL>, CHANNEL>;
+pub type SpiSlaveRxDma<SPI, CHANNEL, Otype, PULL = Floating> =
+    RxDma<SpiSlave<SPI, u8, Otype, PULL>, CHANNEL>;
+pub type SpiSlaveRxTxDma<SPI, RXCHANNEL, TXCHANNEL, Otype, PULL = Floating> =
+    RxTxDma<SpiSlave<SPI, u8, Otype, PULL>, RXCHANNEL, TXCHANNEL>;
 
 macro_rules! spi_dma {
-    ($SPIi:ty, $RCi:ty, $TCi:ty, $rxdma:ident, $txdma:ident, $rxtxdma:ident) => {
-        pub type $rxdma<REMAP, PINS, OP> = SpiRxDma<$SPIi, REMAP, PINS, OP, $RCi>;
-        pub type $txdma<REMAP, PINS, OP> = SpiTxDma<$SPIi, REMAP, PINS, OP, $TCi>;
-        pub type $rxtxdma<REMAP, PINS, OP> = SpiRxTxDma<$SPIi, REMAP, PINS, OP, $RCi, $TCi>;
+    ($SPIi:ty, $RCi:ty, $TCi:ty, $rxdma:ident, $txdma:ident, $rxtxdma:ident, $slaverxdma:ident, $slavetxdma:ident, $slaverxtxdma:ident) => {
+        pub type $rxdma<PULL = Floating> = SpiRxDma<$SPIi, $RCi, PULL>;
+        pub type $txdma<PULL = Floating> = SpiTxDma<$SPIi, $TCi, PULL>;
+        pub type $rxtxdma<PULL = Floating> = SpiRxTxDma<$SPIi, $RCi, $TCi, PULL>;
 
-        impl<REMAP, PINS, OP> Transmit for SpiTxDma<$SPIi, REMAP, PINS, OP, $TCi> {
+        impl<PULL> Transmit for SpiTxDma<$SPIi, $TCi, PULL> {
             type TxChannel = $TCi;
             type ReceivedWord = u8;
         }
 
-        impl<REMAP, PINS, OP> Receive for SpiRxDma<$SPIi, REMAP, PINS, OP, $RCi> {
+        impl<PULL> Receive for SpiRxDma<$SPIi, $RCi, PULL> {
             type RxChannel = $RCi;
             type TransmittedWord = u8;
         }
 
-        impl<REMAP, PINS, OP> Transmit for SpiRxTxDma<$SPIi, REMAP, PINS, OP, $RCi, $TCi> {
+        impl<PULL> Transmit for SpiRxTxDma<$SPIi, $RCi, $TCi, PULL> {
             type TxChannel = $TCi;
             type ReceivedWord = u8;
         }
 
-        impl<REMAP, PINS, OP> Receive for SpiRxTxDma<$SPIi, REMAP, PINS, OP, $RCi, $TCi> {
+        impl<PULL> Receive for SpiRxTxDma<$SPIi, $RCi, $TCi, PULL> {
             type RxChannel = $RCi;
             type TransmittedWord = u8;
         }
 
-        impl<REMAP, PINS, OP> Spi<$SPIi, REMAP, PINS, u8, OP> {
-            pub fn with_tx_dma(self, channel: $TCi) -> SpiTxDma<$SPIi, REMAP, PINS, OP, $TCi> {
+        impl<PULL> Spi<$SPIi, u8, PULL> {
+            pub fn with_tx_dma(self, channel: $TCi) -> SpiTxDma<$SPIi, $TCi, PULL> {
                 self.spi.cr2.modify(|_, w| w.txdmaen().set_bit());
                 SpiTxDma {
                     payload: self,
                     channel,
                 }
             }
-            pub fn with_rx_dma(self, channel: $RCi) -> SpiRxDma<$SPIi, REMAP, PINS, OP, $RCi> {
+            pub fn with_rx_dma(self, channel: $RCi) -> SpiRxDma<$SPIi, $RCi, PULL> {
                 self.spi.cr2.modify(|_, w| w.rxdmaen().set_bit());
                 SpiRxDma {
                     payload: self,
@@ -727,7 +806,7 @@ macro_rules! spi_dma {
                 self,
                 rxchannel: $RCi,
                 txchannel: $TCi,
-            ) -> SpiRxTxDma<$SPIi, REMAP, PINS, OP, $RCi, $TCi> {
+            ) -> SpiRxTxDma<$SPIi, $RCi, $TCi, PULL> {
                 self.spi
                     .cr2
                     .modify(|_, w| w.rxdmaen().set_bit().txdmaen().set_bit());
@@ -739,24 +818,24 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<REMAP, PINS, OP> SpiTxDma<$SPIi, REMAP, PINS, OP, $TCi> {
-            pub fn release(self) -> (Spi<$SPIi, REMAP, PINS, u8, OP>, $TCi) {
+        impl<PULL> SpiTxDma<$SPIi, $TCi, PULL> {
+            pub fn release(self) -> (Spi<$SPIi, u8, PULL>, $TCi) {
                 let SpiTxDma { payload, channel } = self;
                 payload.spi.cr2.modify(|_, w| w.txdmaen().clear_bit());
                 (payload, channel)
             }
         }
 
-        impl<REMAP, PINS, OP> SpiRxDma<$SPIi, REMAP, PINS, OP, $RCi> {
-            pub fn release(self) -> (Spi<$SPIi, REMAP, PINS, u8, OP>, $RCi) {
+        impl<PULL> SpiRxDma<$SPIi, $RCi, PULL> {
+            pub fn release(self) -> (Spi<$SPIi, u8, PULL>, $RCi) {
                 let SpiRxDma { payload, channel } = self;
                 payload.spi.cr2.modify(|_, w| w.rxdmaen().clear_bit());
                 (payload, channel)
             }
         }
 
-        impl<REMAP, PINS, OP> SpiRxTxDma<$SPIi, REMAP, PINS, OP, $RCi, $TCi> {
-            pub fn release(self) -> (Spi<$SPIi, REMAP, PINS, u8, OP>, $RCi, $TCi) {
+        impl<PULL> SpiRxTxDma<$SPIi, $RCi, $TCi, PULL> {
+            pub fn release(self) -> (Spi<$SPIi, u8, PULL>, $RCi, $TCi) {
                 let SpiRxTxDma {
                     payload,
                     rxchannel,
@@ -770,7 +849,7 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<REMAP, PINS, OP> TransferPayload for SpiTxDma<$SPIi, REMAP, PINS, OP, $TCi> {
+        impl<PULL> TransferPayload for SpiTxDma<$SPIi, $TCi, PULL> {
             fn start(&mut self) {
                 self.channel.start();
             }
@@ -779,7 +858,7 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<REMAP, PINS, OP> TransferPayload for SpiRxDma<$SPIi, REMAP, PINS, OP, $RCi> {
+        impl<PULL> TransferPayload for SpiRxDma<$SPIi, $RCi, PULL> {
             fn start(&mut self) {
                 self.channel.start();
             }
@@ -788,7 +867,7 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<REMAP, PINS, OP> TransferPayload for SpiRxTxDma<$SPIi, REMAP, PINS, OP, $RCi, $TCi> {
+        impl<PULL> TransferPayload for SpiRxTxDma<$SPIi, $RCi, $TCi, PULL> {
             fn start(&mut self) {
                 self.rxchannel.start();
                 self.txchannel.start();
@@ -799,7 +878,7 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<B, REMAP, PIN, OP> crate::dma::ReadDma<B, u8> for SpiRxDma<$SPIi, REMAP, PIN, OP, $RCi>
+        impl<B, PULL> crate::dma::ReadDma<B, u8> for SpiRxDma<$SPIi, $RCi, PULL>
         where
             B: WriteBuffer<Word = u8>,
         {
@@ -833,8 +912,7 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<B, REMAP, PIN, OP> crate::dma::WriteDma<B, u8>
-            for SpiTxDma<$SPIi, REMAP, PIN, OP, $TCi>
+        impl<B, PULL> crate::dma::WriteDma<B, u8> for SpiTxDma<$SPIi, $TCi, PULL>
         where
             B: ReadBuffer<Word = u8>,
         {
@@ -868,8 +946,267 @@ macro_rules! spi_dma {
             }
         }
 
-        impl<RXB, TXB, REMAP, PIN, OP> crate::dma::ReadWriteDma<RXB, TXB, u8>
-            for SpiRxTxDma<$SPIi, REMAP, PIN, OP, $RCi, $TCi>
+        impl<RXB, TXB, PULL> crate::dma::ReadWriteDma<RXB, TXB, u8>
+            for SpiRxTxDma<$SPIi, $RCi, $TCi, PULL>
+        where
+            RXB: WriteBuffer<Word = u8>,
+            TXB: ReadBuffer<Word = u8>,
+        {
+            fn read_write(
+                mut self,
+                mut rxbuffer: RXB,
+                txbuffer: TXB,
+            ) -> Transfer<W, (RXB, TXB), Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (rxptr, rxlen) = unsafe { rxbuffer.write_buffer() };
+                let (txptr, txlen) = unsafe { txbuffer.read_buffer() };
+
+                if rxlen != txlen {
+                    panic!("receive and send buffer lengths do not match!");
+                }
+
+                self.rxchannel.set_peripheral_address(
+                    unsafe { &(*<$SPIi>::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.rxchannel.set_memory_address(rxptr as u32, true);
+                self.rxchannel.set_transfer_length(rxlen);
+
+                self.txchannel.set_peripheral_address(
+                    unsafe { &(*<$SPIi>::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.txchannel.set_memory_address(txptr as u32, true);
+                self.txchannel.set_transfer_length(txlen);
+
+                atomic::compiler_fence(Ordering::Release);
+                self.rxchannel.ch().cr.modify(|_, w| {
+                    // memory to memory mode disabled
+                    w.mem2mem().clear_bit();
+                    // medium channel priority level
+                    w.pl().medium();
+                    // 8-bit memory size
+                    w.msize().bits8();
+                    // 8-bit peripheral size
+                    w.psize().bits8();
+                    // circular mode disabled
+                    w.circ().clear_bit();
+                    // write to memory
+                    w.dir().clear_bit()
+                });
+                self.txchannel.ch().cr.modify(|_, w| {
+                    // memory to memory mode disabled
+                    w.mem2mem().clear_bit();
+                    // medium channel priority level
+                    w.pl().medium();
+                    // 8-bit memory size
+                    w.msize().bits8();
+                    // 8-bit peripheral size
+                    w.psize().bits8();
+                    // circular mode disabled
+                    w.circ().clear_bit();
+                    // read from memory
+                    w.dir().set_bit()
+                });
+                self.start();
+
+                Transfer::w((rxbuffer, txbuffer), self)
+            }
+        }
+
+        pub type $slaverxdma<Otype = PushPull, PULL = Floating> =
+            SpiSlaveRxDma<$SPIi, $RCi, Otype, PULL>;
+        pub type $slavetxdma<Otype = PushPull, PULL = Floating> =
+            SpiSlaveTxDma<$SPIi, $TCi, Otype, PULL>;
+        pub type $slaverxtxdma<Otype = PushPull, PULL = Floating> =
+            SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL>;
+
+        impl<Otype, PULL> Transmit for SpiSlaveTxDma<$SPIi, $TCi, Otype, PULL> {
+            type TxChannel = $TCi;
+            type ReceivedWord = u8;
+        }
+
+        impl<Otype, PULL> Receive for SpiSlaveRxDma<$SPIi, $RCi, Otype, PULL> {
+            type RxChannel = $RCi;
+            type TransmittedWord = u8;
+        }
+
+        impl<Otype, PULL> Transmit for SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL> {
+            type TxChannel = $TCi;
+            type ReceivedWord = u8;
+        }
+
+        impl<Otype, PULL> Receive for SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL> {
+            type RxChannel = $RCi;
+            type TransmittedWord = u8;
+        }
+
+        impl<Otype, PULL> SpiSlave<$SPIi, u8, Otype, PULL> {
+            pub fn with_tx_dma(self, channel: $TCi) -> SpiSlaveTxDma<$SPIi, $TCi, Otype, PULL> {
+                self.spi.cr2.modify(|_, w| w.txdmaen().set_bit());
+                SpiSlaveTxDma {
+                    payload: self,
+                    channel,
+                }
+            }
+            pub fn with_rx_dma(self, channel: $RCi) -> SpiSlaveRxDma<$SPIi, $RCi, Otype, PULL> {
+                self.spi.cr2.modify(|_, w| w.rxdmaen().set_bit());
+                SpiSlaveRxDma {
+                    payload: self,
+                    channel,
+                }
+            }
+            pub fn with_rx_tx_dma(
+                self,
+                rxchannel: $RCi,
+                txchannel: $TCi,
+            ) -> SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL> {
+                self.spi
+                    .cr2
+                    .modify(|_, w| w.rxdmaen().set_bit().txdmaen().set_bit());
+                SpiSlaveRxTxDma {
+                    payload: self,
+                    rxchannel,
+                    txchannel,
+                }
+            }
+        }
+
+        impl<Otype, PULL> SpiSlaveTxDma<$SPIi, $TCi, Otype, PULL> {
+            pub fn release(self) -> (SpiSlave<$SPIi, u8, Otype, PULL>, $TCi) {
+                let SpiSlaveTxDma { payload, channel } = self;
+                payload.spi.cr2.modify(|_, w| w.txdmaen().clear_bit());
+                (payload, channel)
+            }
+        }
+
+        impl<Otype, PULL> SpiSlaveRxDma<$SPIi, $RCi, Otype, PULL> {
+            pub fn release(self) -> (SpiSlave<$SPIi, u8, Otype, PULL>, $RCi) {
+                let SpiSlaveRxDma { payload, channel } = self;
+                payload.spi.cr2.modify(|_, w| w.rxdmaen().clear_bit());
+                (payload, channel)
+            }
+        }
+
+        impl<Otype, PULL> SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL> {
+            pub fn release(self) -> (SpiSlave<$SPIi, u8, Otype, PULL>, $RCi, $TCi) {
+                let SpiSlaveRxTxDma {
+                    payload,
+                    rxchannel,
+                    txchannel,
+                } = self;
+                payload
+                    .spi
+                    .cr2
+                    .modify(|_, w| w.rxdmaen().clear_bit().txdmaen().clear_bit());
+                (payload, rxchannel, txchannel)
+            }
+        }
+
+        impl<Otype, PULL> TransferPayload for SpiSlaveTxDma<$SPIi, $TCi, Otype, PULL> {
+            fn start(&mut self) {
+                self.channel.start();
+            }
+            fn stop(&mut self) {
+                self.channel.stop();
+            }
+        }
+
+        impl<Otype, PULL> TransferPayload for SpiSlaveRxDma<$SPIi, $RCi, Otype, PULL> {
+            fn start(&mut self) {
+                self.channel.start();
+            }
+            fn stop(&mut self) {
+                self.channel.stop();
+            }
+        }
+
+        impl<Otype, PULL> TransferPayload for SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL> {
+            fn start(&mut self) {
+                self.rxchannel.start();
+                self.txchannel.start();
+            }
+            fn stop(&mut self) {
+                self.txchannel.stop();
+                self.rxchannel.stop();
+            }
+        }
+
+        impl<B, Otype, PULL> crate::dma::ReadDma<B, u8> for SpiSlaveRxDma<$SPIi, $RCi, Otype, PULL>
+        where
+            B: WriteBuffer<Word = u8>,
+        {
+            fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (ptr, len) = unsafe { buffer.write_buffer() };
+                self.channel.set_peripheral_address(
+                    unsafe { &(*<$SPIi>::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.channel.set_memory_address(ptr as u32, true);
+                self.channel.set_transfer_length(len);
+
+                atomic::compiler_fence(Ordering::Release);
+                self.channel.ch().cr.modify(|_, w| {
+                    // memory to memory mode disabled
+                    w.mem2mem().clear_bit();
+                    // medium channel priority level
+                    w.pl().medium();
+                    // 8-bit memory size
+                    w.msize().bits8();
+                    // 8-bit peripheral size
+                    w.psize().bits8();
+                    // circular mode disabled
+                    w.circ().clear_bit();
+                    // write to memory
+                    w.dir().clear_bit()
+                });
+                self.start();
+
+                Transfer::w(buffer, self)
+            }
+        }
+
+        impl<B, Otype, PULL> crate::dma::WriteDma<B, u8> for SpiSlaveTxDma<$SPIi, $TCi, Otype, PULL>
+        where
+            B: ReadBuffer<Word = u8>,
+        {
+            fn write(mut self, buffer: B) -> Transfer<R, B, Self> {
+                // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
+                // until the end of the transfer.
+                let (ptr, len) = unsafe { buffer.read_buffer() };
+                self.channel.set_peripheral_address(
+                    unsafe { &(*<$SPIi>::ptr()).dr as *const _ as u32 },
+                    false,
+                );
+                self.channel.set_memory_address(ptr as u32, true);
+                self.channel.set_transfer_length(len);
+
+                atomic::compiler_fence(Ordering::Release);
+                self.channel.ch().cr.modify(|_, w| {
+                    // memory to memory mode disabled
+                    w.mem2mem().clear_bit();
+                    // medium channel priority level
+                    w.pl().medium();
+                    // 8-bit memory size
+                    w.msize().bits8();
+                    // 8-bit peripheral size
+                    w.psize().bits8();
+                    // circular mode disabled
+                    w.circ().clear_bit();
+                    // read from memory
+                    w.dir().set_bit()
+                });
+                self.start();
+
+                Transfer::r(buffer, self)
+            }
+        }
+
+        impl<RXB, TXB, Otype, PULL> crate::dma::ReadWriteDma<RXB, TXB, u8>
+            for SpiSlaveRxTxDma<$SPIi, $RCi, $TCi, Otype, PULL>
         where
             RXB: WriteBuffer<Word = u8>,
             TXB: ReadBuffer<Word = u8>,
@@ -941,7 +1278,10 @@ spi_dma!(
     dma1::C3,
     Spi1RxDma,
     Spi1TxDma,
-    Spi1RxTxDma
+    Spi1RxTxDma,
+    SpiSlave1RxDma,
+    SpiSlave1TxDma,
+    SpiSlave1RxTxDma
 );
 spi_dma!(
     pac::SPI2,
@@ -949,7 +1289,10 @@ spi_dma!(
     dma1::C5,
     Spi2RxDma,
     Spi2TxDma,
-    Spi2RxTxDma
+    Spi2RxTxDma,
+    SpiSlave2RxDma,
+    SpiSlave2TxDma,
+    SpiSlave2RxTxDma
 );
 #[cfg(feature = "connectivity")]
 spi_dma!(
@@ -958,5 +1301,8 @@ spi_dma!(
     dma2::C2,
     Spi3RxDma,
     Spi3TxDma,
-    Spi3RxTxDma
+    Spi3RxTxDma,
+    SpiSlave3RxDma,
+    SpiSlave3TxDma,
+    SpiSlave3RxTxDma
 );

--- a/src/spi/hal_02.rs
+++ b/src/spi/hal_02.rs
@@ -30,7 +30,7 @@ impl From<Mode> for super::Mode {
     }
 }
 
-impl<SPI, REMAP, PINS, W, OP> spi::FullDuplex<W> for Spi<SPI, REMAP, PINS, W, OP>
+impl<SPI, W, PULL> spi::FullDuplex<W> for Spi<SPI, W, PULL>
 where
     SPI: Instance,
     W: Copy,
@@ -46,25 +46,25 @@ where
     }
 }
 
-impl<SPI, REMAP, PINS, W, OP> blocking::transfer::Default<W> for Spi<SPI, REMAP, PINS, W, OP>
+impl<SPI, W, PULL> blocking::transfer::Default<W> for Spi<SPI, W, PULL>
 where
     SPI: Instance,
     W: Copy,
 {
 }
 
-impl<SPI: Instance, REMAP, PINS, OP> blocking::Write<u8> for Spi<SPI, REMAP, PINS, u8, OP> {
+impl<SPI: Instance, PULL> blocking::Write<u8> for Spi<SPI, u8, PULL> {
     type Error = Error;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Error> {
-        self.write(words)
+        self.deref_mut().write(words)
     }
 }
 
-impl<SPI: Instance, REMAP, PINS, OP> blocking::Write<u16> for Spi<SPI, REMAP, PINS, u16, OP> {
+impl<SPI: Instance, PULL> blocking::Write<u16> for Spi<SPI, u16, PULL> {
     type Error = Error;
 
     fn write(&mut self, words: &[u16]) -> Result<(), Error> {
-        self.write(words)
+        self.deref_mut().write(words)
     }
 }

--- a/src/spi/hal_1.rs
+++ b/src/spi/hal_1.rs
@@ -38,7 +38,7 @@ impl embedded_hal::spi::Error for Error {
     }
 }
 
-impl<SPI: Instance, REMAP, PINS, W, OP> ErrorType for Spi<SPI, REMAP, PINS, W, OP> {
+impl<SPI: Instance, W, PULL> ErrorType for Spi<SPI, W, PULL> {
     type Error = Error;
 }
 
@@ -46,7 +46,7 @@ mod nb {
     use super::{Error, Instance, Spi};
     use embedded_hal_nb::spi::FullDuplex;
 
-    impl<SPI, REMAP, PINS, W, OP> FullDuplex<W> for Spi<SPI, REMAP, PINS, W, OP>
+    impl<SPI, W, PULL> FullDuplex<W> for Spi<SPI, W, PULL>
     where
         SPI: Instance,
         W: Copy,
@@ -63,9 +63,10 @@ mod nb {
 
 mod blocking {
     use super::super::{Instance, Spi};
+    use core::ops::DerefMut;
     use embedded_hal::spi::SpiBus;
 
-    impl<SPI: Instance, REMAP, PINS, W, OP> SpiBus<W> for Spi<SPI, REMAP, PINS, W, OP>
+    impl<SPI: Instance, W, PULL> SpiBus<W> for Spi<SPI, W, PULL>
     where
         SPI: Instance,
         W: Copy + 'static,
@@ -83,7 +84,7 @@ mod blocking {
         }
 
         fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
-            self.write(words)
+            self.deref_mut().write(words)
         }
 
         fn flush(&mut self) -> Result<(), Self::Error> {

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -94,11 +94,11 @@ macro_rules! pins_impl {
     ( $( ( $($PINX:ident),+ ), ( $($ENCHX:ident),+ ); )+ ) => {
         $(
             #[allow(unused_parens)]
-            impl<TIM, REMAP, OUTMODE, $($PINX,)+> Pins<REMAP, ($(Ch<$ENCHX>),+)> for ($($PINX),+)
+            impl<TIM, REMAP, Otype, $($PINX,)+> Pins<REMAP, ($(Ch<$ENCHX>),+)> for ($($PINX),+)
             where
                 TIM: Instance + WithPwm,
                 REMAP: Remap<Periph = TIM>,
-                $($PINX: CPin<REMAP, $ENCHX> + gpio::PinExt<Mode=Alternate<OUTMODE>>,)+
+                $($PINX: CPin<REMAP, $ENCHX> + gpio::PinExt<Mode=Alternate<Otype>>,)+
             {
                 $(const $ENCHX: bool = true;)+
                 type Channels = ($(PwmChannel<TIM, $ENCHX>),+);


### PR DESCRIPTION
This is breaking change.
It uses similar idea to https://github.com/stm32-rs/stm32f4xx-hal/pull/594 and family, but different.
Istead of `pins: TupleOfPinEnums` peripheral keeps `pins: EnumOfPinTupleCombinations`. It is less beautiful and flexible, but gives workaround for `AFIO` map issues (which is F1 only).

Needs complex testing. cc @all_who_can_test_and_have_ideas :)