### PR TITLE
Allow restoring currently running rtc (lost time on initialization)

### DIFF
--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -9,6 +9,8 @@ use panic_semihosting as _;
 use cortex_m_semihosting::hprintln;
 
 use cortex_m_rt::entry;
+use fugit::RateExtU32;
+use stm32f1xx_hal::rtc::RestoredOrNewRtc::{New, Restored};
 use stm32f1xx_hal::{pac, prelude::*, rtc::Rtc};
 
 #[entry]
@@ -19,7 +21,24 @@ fn main() -> ! {
     let rcc = p.RCC.constrain();
     let mut backup_domain = rcc.bkp.constrain(p.BKP, &mut pwr);
 
-    let rtc = Rtc::new(p.RTC, &mut backup_domain);
+    // Initializes rtc every startup, use only if you don't have a battery.
+    // let rtc = Rtc::new(p.RTC, &mut backup_domain);
+
+    // Restores Rtc: that happens in case it was already running, a battery is connected,
+    // and it was already initialized before.
+    // If you are going to use ::new with battery, the time will lack behind
+    // due to unnecessary reinitialization of the crystal,
+    // as well as reset of the selected frequency.
+    // Else, the rtc is initialized.
+    let rtc = match Rtc::restore_or_new(p.RTC, &mut backup_domain) {
+        Restored(rtc) => rtc, // The rtc is restored from previous configuration. You may verify the frequency you want if needed.
+        New(mut rtc) => {
+            // The rtc was just initialized, the clock source selected, frequency is 1.Hz()
+            // Initialize rtc with desired parameters
+            rtc.select_frequency(2u32.Hz()); // Set the frequency to 2 Hz. This will stay same after reset
+            rtc
+        }
+    };
 
     loop {
         hprintln!("time: {}", rtc.current_time());


### PR DESCRIPTION
Hi, I came across a problem when using the Rtc.
The problem is that if the microcontroller is reset, some time will be lost due to the reinitialization of the oscillator.

In order to solve this, I added methods restore_or_new, restore_or_new_lsi, restore_or_new_hse.
These methods check whether the rtc is enabled and the source is correct. If this is the case, the initialization is skipped.
After testing this, (for now, only with lse) it worked as intended, no time was lost anymore and the rtc was still counting.

What do you think about this? Are there any other things needed to be done, or should I change the behavior somehow?