### PR TITLE
Fix RTC selection of frequency for LSI and HSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update `bxcan`, `heapless`, `mfrc522`, reenable `mpu9250` example [#513]
 - PWM timer auto reload value is now preloaded/buffered [#453]
 - Move from bors/manual merge to GH merge queue [#467]
+- `Rtc::restore_or_new`: adds restoring mechanism of running Rtc [#468]
+- `Rtc::select_frequency`: fix for LSI and HSE, where correct frequency was not selected [#468]
 - Replace UB code by a legitimate pointer access [#480]
 - Fix flash error flag clearing [#489]
 - Clarify README for windows users [#496]
@@ -59,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#453]: https://github.com/stm32-rs/stm32f1xx-hal/pull/453
 [#462]: https://github.com/stm32-rs/stm32f1xx-hal/pull/462
 [#467]: https://github.com/stm32-rs/stm32f1xx-hal/pull/467
+[#468]: https://github.com/stm32-rs/stm32f1xx-hal/pull/468
 [#479]: https://github.com/stm32-rs/stm32f1xx-hal/pull/479
 [#480]: https://github.com/stm32-rs/stm32f1xx-hal/pull/480
 [#483]: https://github.com/stm32-rs/stm32f1xx-hal/pull/483
@@ -81,6 +84,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#528]: https://github.com/stm32-rs/stm32f1xx-hal/pull/528
 [#534]: https://github.com/stm32-rs/stm32f1xx-hal/pull/534
 [#536]: https://github.com/stm32-rs/stm32f1xx-hal/pull/536
+- Move from bors/manual merge to GH merge queue
+- Add tools/check.py python script for local check
+- Add changelog check on PRs
 
 ## [v0.10.0] - 2022-12-12
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -8,6 +8,7 @@ use crate::time::{Hertz, Hz};
 
 use core::convert::Infallible;
 use core::marker::PhantomData;
+use fugit::RateExtU32;
 
 // The LSE runs at at 32 768 hertz unless an external clock is provided
 const LSE_HERTZ: Hertz = Hz(32_768);
@@ -43,6 +44,7 @@ pub enum RestoredOrNewRtc<CS> {
 */
 pub struct Rtc<CS = RtcClkLse> {
     regs: RTC,
+    frequency: Hertz,
     _clock_source: PhantomData<CS>,
 }
 
@@ -63,22 +65,12 @@ impl Rtc<RtcClkLse> {
       [`restore_or_new`](Rtc::<RtcClkLse>::restore_or_new) instead.
     */
     pub fn new(regs: RTC, bkp: &mut BackupDomain, rcc: &mut RCC) -> Self {
-        let mut result = Rtc {
-            regs,
-            _clock_source: PhantomData,
-        };
+        let mut result = Self::init(regs);
 
         Self::enable_rtc(bkp, rcc);
 
         // Set the prescaler to make it count up once every second.
-        let prl = LSE_HERTZ.raw() - 1;
-        assert!(prl < 1 << 20);
-        result.perform_write(|s| {
-            s.regs.prlh().write(|w| unsafe { w.bits(prl >> 16) });
-            s.regs
-                .prll()
-                .write(|w| unsafe { w.bits(prl as u16 as u32) });
-        });
+        result.select_frequency(1u32.Hz());
 
         result
     }
@@ -105,10 +97,15 @@ impl Rtc<RtcClkLse> {
         if !Self::is_enabled() {
             RestoredOrNewRtc::New(Rtc::new(regs, bkp, rcc))
         } else {
-            RestoredOrNewRtc::Restored(Rtc {
-                regs,
-                _clock_source: PhantomData,
-            })
+            RestoredOrNewRtc::Restored(Self::init(regs))
+        }
+    }
+
+    fn init(regs: RTC) -> Self {
+        Self {
+            regs,
+            frequency: LSE_HERTZ,
+            _clock_source: PhantomData,
         }
     }
 
@@ -149,22 +146,12 @@ impl Rtc<RtcClkLsi> {
       [`restore_or_new_lsi`](Rtc::<RtcClkLsi>::restore_or_new_lsi) instead.
     */
     pub fn new_lsi(regs: RTC, bkp: &mut BackupDomain) -> Self {
-        let mut result = Rtc {
-            regs,
-            _clock_source: PhantomData,
-        };
+        let mut result = Self::init(regs);
 
         Self::enable_rtc(bkp);
 
         // Set the prescaler to make it count up once every second.
-        let prl = LSI_HERTZ.raw() - 1;
-        assert!(prl < 1 << 20);
-        result.perform_write(|s| {
-            s.regs.prlh().write(|w| unsafe { w.bits(prl >> 16) });
-            s.regs
-                .prll()
-                .write(|w| unsafe { w.bits(prl as u16 as u32) });
-        });
+        result.select_frequency(1u32.Hz());
 
         result
     }
@@ -175,10 +162,15 @@ impl Rtc<RtcClkLsi> {
         if !Rtc::<RtcClkLsi>::is_enabled() {
             RestoredOrNewRtc::New(Rtc::new_lsi(regs, bkp))
         } else {
-            RestoredOrNewRtc::Restored(Rtc {
-                regs,
-                _clock_source: PhantomData,
-            })
+            RestoredOrNewRtc::Restored(Self::init(regs))
+        }
+    }
+
+    fn init(regs: RTC) -> Self {
+        Self {
+            regs,
+            frequency: LSI_HERTZ,
+            _clock_source: PhantomData,
         }
     }
 
@@ -224,22 +216,12 @@ impl Rtc<RtcClkHseDiv128> {
       [`restore_or_new_hse`](Rtc::<RtcClkHseDiv128>::restore_or_new_hse) instead.
     */
     pub fn new_hse(regs: RTC, bkp: &mut BackupDomain, hse: Hertz) -> Self {
-        let mut result = Rtc {
-            regs,
-            _clock_source: PhantomData,
-        };
+        let mut result = Self::init(regs, hse);
 
         Self::enable_rtc(bkp);
 
         // Set the prescaler to make it count up once every second.
-        let prl = hse.raw() / 128 - 1;
-        assert!(prl < 1 << 20);
-        result.perform_write(|s| {
-            s.regs.prlh().write(|w| unsafe { w.bits(prl >> 16) });
-            s.regs
-                .prll()
-                .write(|w| unsafe { w.bits(prl as u16 as u32) });
-        });
+        result.select_frequency(1u32.Hz());
 
         result
     }
@@ -254,10 +236,15 @@ impl Rtc<RtcClkHseDiv128> {
         if !Self::is_enabled() {
             RestoredOrNewRtc::New(Rtc::new_hse(regs, bkp, hse))
         } else {
-            RestoredOrNewRtc::Restored(Rtc {
-                regs,
-                _clock_source: PhantomData,
-            })
+            RestoredOrNewRtc::Restored(Self::init(regs, hse))
+        }
+    }
+
+    fn init(regs: RTC, hse: Hertz) -> Self {
+        Self {
+            regs,
+            frequency: hse / 128,
+            _clock_source: PhantomData,
         }
     }
 
@@ -290,9 +277,10 @@ impl<CS> Rtc<CS> {
     pub fn select_frequency(&mut self, frequency: Hertz) {
         // The manual says that the zero value for the prescaler is not recommended, thus the
         // minimum division factor is 2 (prescaler + 1)
-        assert!(frequency <= LSE_HERTZ / 2);
+        assert!(frequency <= self.frequency / 2);
 
-        let prescaler = LSE_HERTZ / frequency - 1;
+        let prescaler = self.frequency / frequency - 1;
+        assert!(prescaler < 1 << 20);
         self.perform_write(|s| {
             s.regs.prlh().write(|w| unsafe { w.bits(prescaler >> 16) });
             s.regs


### PR DESCRIPTION
So far, `Rtc::select_frequency` did not consider frequencies other than LSE_HERTZ, which was valid only for LSE with 32.768 kHz. For LSI, which has 40 kHz, and HSE, which may have an arbitrary frequency in a given range, the frequency was selected based on the wrong RTC frequency.

This PR aims to fix that. I've also refactored the new methods a bit, using the select_frequency instead of repeating the same code.

I've solved this by adding frequency field to the Rtc, there is no other way I could think of, as HSE frequency may be different depending on the crystal selected for specific application. As far as I understand it, LSE does not necessarily have to be 32.768 kHz, so maybe adding the possibility to change the frequency of LSE could prove useful as well? Adding the frequency field unfortunately introduces redundancy for LSI and (maybe) LSE.