### PR TITLE
Reexport Direction from older embedded_hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add tools/check.py python script for local check
 - Add changelog check on PRs
 - Replace UB code by a legitimate pointer access
+- Reexport `Direction` from `qei`
 
 ## [v0.10.0] - 2022-12-12
 

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -8,7 +8,8 @@ use core::u16;
 
 use core::marker::PhantomData;
 
-use crate::hal::{self, Direction};
+use crate::hal;
+pub use crate::hal::Direction;
 #[cfg(any(feature = "stm32f100", feature = "stm32f103", feature = "connectivity",))]
 use crate::pac::TIM1;
 #[cfg(feature = "medium")]
@@ -188,9 +189,9 @@ macro_rules! hal {
 
                 fn direction(&self) -> Direction {
                     if self.tim.cr1.read().dir().bit_is_clear() {
-                        hal::Direction::Upcounting
+                        Direction::Upcounting
                     } else {
-                        hal::Direction::Downcounting
+                        Direction::Downcounting
                     }
                 }
             }


### PR DESCRIPTION
`embedded_hal::Direction` has been removed from recent `embedded_hal` releases. It needs to be reexported from `qei` in order to allow users of `Qei::direction()` to be able to match against the method result if they use a recent `embdded_hal` release.
