### PR TITLE
Replace UB code by a legitimate pointer access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Move from bors/manual merge to GH merge queue
 - Add tools/check.py python script for local check
 - Add changelog check on PRs
+- Replace UB code by a legitimate pointer access
 
 ## [v0.10.0] - 2022-12-12
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -355,7 +355,7 @@ where
 
     fn write_data_reg(&mut self, data: FrameSize) {
         // NOTE(write_volatile) see note above
-        unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut FrameSize, data) }
+        unsafe { ptr::write_volatile(ptr::addr_of!(self.spi.dr) as *mut FrameSize, data) }
     }
 
     // Implement write as per the "Transmit only procedure" page 712


### PR DESCRIPTION
This removes a compilation error due to the `invalid-reference-casting` check.