### PR TITLE
Fix flash error flag clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace UB code by a legitimate pointer access
 - Reexport `Direction` from `qei`
 - Add dac
+- Fix flash error flag clearing
 
 ## [v0.10.0] - 2022-12-12
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -166,7 +166,8 @@ impl<'a> FlashWriter<'a> {
         self.lock()?;
 
         if sr.wrprterr().bit_is_set() {
-            self.flash.sr.sr().modify(|_, w| w.wrprterr().clear_bit());
+            // reset by writing 1
+            self.flash.sr.sr().modify(|_, w| w.wrprterr().bit(true));
             Err(Error::EraseError)
         } else {
             if self.verify {
@@ -257,12 +258,14 @@ impl<'a> FlashWriter<'a> {
 
             // Check for errors
             if self.flash.sr.sr().read().pgerr().bit_is_set() {
-                self.flash.sr.sr().modify(|_, w| w.pgerr().clear_bit());
+                // reset by writing 1
+                self.flash.sr.sr().modify(|_, w| w.pgerr().bit(true));
 
                 self.lock()?;
                 return Err(Error::ProgrammingError);
             } else if self.flash.sr.sr().read().wrprterr().bit_is_set() {
-                self.flash.sr.sr().modify(|_, w| w.wrprterr().clear_bit());
+                // reset by writing 1
+                self.flash.sr.sr().modify(|_, w| w.wrprterr().bit(true));
 
                 self.lock()?;
                 return Err(Error::WriteError);


### PR DESCRIPTION
According to the STM32F10xxx Flash programming manual [(PM0068, p22)](https://www.st.com/resource/en/programming_manual/pm0068-stm32f10xxx-xldensity-flash-programming-stmicroelectronics.pdf), WRPRTERR and PGERR flags are cleared by writing 1. The original code incorrectly attempted to clear these flags by writing 0, causing them to remain set after an error occurred. This prevented further flash operations until reset.

This commit corrects the flag clearing operation, allowing flash operations to continue after recoverable errors.