### PR TITLE
Add an option to allow overclocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add dac
 - Fix flash error flag clearing
 - Clarify README for windows users
+- Add an option to allow overclocking [#494]
 
 ### Added
 
 - Allow to set HSE bypass bit in `RCC` clock configuration register to use an external clock input on the `OSC_IN` pin
 - support `embedded-hal-1.0`
+  
+[#494]: https://github.com/stm32-rs/stm32f1xx-hal/pull/494
 
 ## [v0.10.0] - 2022-12-12
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -507,6 +507,7 @@ pub struct Config {
     #[cfg(any(feature = "stm32f103", feature = "connectivity"))]
     pub usbpre: UsbPre,
     pub adcpre: AdcPre,
+    pub allow_overclock: bool,
 }
 
 impl Default for Config {
@@ -521,6 +522,7 @@ impl Default for Config {
             #[cfg(any(feature = "stm32f103", feature = "connectivity"))]
             usbpre: UsbPre::Div15,
             adcpre: AdcPre::Div2,
+            allow_overclock: false,
         }
     }
 }
@@ -681,6 +683,7 @@ impl Config {
             #[cfg(any(feature = "stm32f103", feature = "connectivity"))]
             usbpre,
             adcpre: apre_bits,
+            allow_overclock: false,
         }
     }
 
@@ -724,11 +727,12 @@ impl Config {
         );
 
         assert!(
-            sysclk <= 72_000_000
-                && hclk <= 72_000_000
-                && pclk1 <= 36_000_000
-                && pclk2 <= 72_000_000
-                && adcclk <= 14_000_000
+            self.allow_overclock
+                || (sysclk <= 72_000_000
+                    && hclk <= 72_000_000
+                    && pclk1 <= 36_000_000
+                    && pclk2 <= 72_000_000
+                    && adcclk <= 14_000_000)
         );
 
         Clocks {
@@ -763,6 +767,7 @@ fn rcc_config_usb() {
         #[cfg(any(feature = "stm32f103", feature = "connectivity"))]
         usbpre: UsbPre::Div1,
         adcpre: AdcPre::Div8,
+        allow_overclock: false,
     };
     assert_eq!(config, config_expected);
 


### PR DESCRIPTION
Similar to [this PR in stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal/pull/231), I am porting a firmware on existing target that was designed to run faster than the official speed. This PR bypass the assert if allow_overclock is set in Config :

```
    let clocks = rcc.cfgr.freeze_with_config(Config{
        hse: Some(10_000_000),
        hse_bypass: true,
        pllmul: Some(0b1000),
        hpre: HPre::Div1,
        ppre1: PPre::Div4,
        ppre2: PPre::Div1,
        usbpre: UsbPre::Div1,
        adcpre: AdcPre::Div8,
        allow_overclock: true,
    }, &mut flash.acr);
```