### PR TITLE
Use latest version of `usb-device` and `usbd-serial`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Check "device selected" in `build.rs` [#502]
 - Use gpio field enums internally [#506]
 - Unmacro `dma.rs` [#505]
+- Updated `usb-device` and `usbd-serial` to latest versions [#510]
 - Rework pin remaps, fix CAN1 remap [#511]
+- Rework USART remap, 
 
 ### Added
 
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#505]: https://github.com/stm32-rs/stm32f1xx-hal/pull/505
 [#506]: https://github.com/stm32-rs/stm32f1xx-hal/pull/506
 [#509]: https://github.com/stm32-rs/stm32f1xx-hal/pull/509
+[#510]: https://github.com/stm32-rs/stm32f1xx-hal/pull/510
 [#511]: https://github.com/stm32-rs/stm32f1xx-hal/pull/511
 
 ## [v0.10.0] - 2022-12-12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "1.0"
 version = "0.6.1"
 
 [dependencies.stm32-usbd]
-version = "0.6.0"
+version = "0.7.0"
 optional = true
 
 [dev-dependencies]
@@ -62,8 +62,8 @@ cortex-m-semihosting = "0.5.0"
 heapless = "0.8.0"
 mfrc522 = { version = "0.7.0", features = ["eh02"] }
 mpu9250 = "0.25.0"
-usb-device = "0.2.8"
-usbd-serial = "0.1.1"
+usb-device = "0.3.2"
+usbd-serial = "0.2.2"
 
 [features]
 doc = []
@@ -101,15 +101,15 @@ lto = true
 
 [[example]]
 name = "usb_serial"
-required-features = ["stm32-usbd"]
+required-features = ["stm32f103", "stm32-usbd"]
 
 [[example]]
 name = "usb_serial_interrupt"
-required-features = ["stm32-usbd"]
+required-features = ["stm32f103", "stm32-usbd"]
 
 [[example]]
 name = "usb_serial_rtic"
-required-features = ["stm32-usbd"]
+required-features = ["stm32f103", "stm32-usbd"]
 
 [[example]]
 name = "blinky_timer_irq"

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -59,10 +59,12 @@ fn main() -> ! {
     let mut serial = SerialPort::new(&usb_bus);
 
     let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
-        .manufacturer("Fake company")
-        .product("Serial port")
-        .serial_number("TEST")
         .device_class(USB_CLASS_CDC)
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Fake Company")
+            .product("Serial port")
+            .serial_number("TEST")])
+        .unwrap()
         .build();
 
     loop {

--- a/examples/usb_serial_interrupt.rs
+++ b/examples/usb_serial_interrupt.rs
@@ -61,10 +61,12 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(USB_BUS.as_ref().unwrap()));
 
         let usb_dev = UsbDeviceBuilder::new(USB_BUS.as_ref().unwrap(), UsbVidPid(0x16c0, 0x27dd))
-            .manufacturer("Fake company")
-            .product("Serial port")
-            .serial_number("TEST")
             .device_class(USB_CLASS_CDC)
+            .strings(&[StringDescriptors::default()
+                .manufacturer("Fake Company")
+                .product("Serial port")
+                .serial_number("TEST")])
+            .unwrap()
             .build();
 
         USB_DEVICE = Some(usb_dev);

--- a/examples/usb_serial_rtic.rs
+++ b/examples/usb_serial_rtic.rs
@@ -67,10 +67,12 @@ mod app {
             unsafe { USB_BUS.as_ref().unwrap() },
             UsbVidPid(0x16c0, 0x27dd),
         )
-        .manufacturer("Fake company")
-        .product("Serial port")
-        .serial_number("TEST")
         .device_class(usbd_serial::USB_CLASS_CDC)
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Fake Company")
+            .product("Serial port")
+            .serial_number("TEST")])
+        .unwrap()
         .build();
 
         (Shared { usb_dev, serial }, Local {}, init::Monotonics())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub mod spi;
 pub mod time;
 pub mod timer;
 #[cfg(feature = "stm32-usbd")]
+#[cfg(feature = "stm32f103")]
 pub mod usb;
 pub mod watchdog;
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -28,7 +28,7 @@ def main():
 
     crate_info = cargo_meta["packages"][0]
 
-    features = ["{},rtic,high".format(x)
+    features = ["{},rtic,high,stm32-usbd".format(x)
             for x in crate_info["features"].keys()
             if x.startswith("stm32f1")]
 


### PR DESCRIPTION
Use the latest version to get implementations of `Read` and `Write` from `embedded-io` for `SerialPort`.