### PR TITLE
Add enable/disable EOC interrupt functions for ADCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add an option to allow overclocking [#494]
 - `new` on gpio mode [#506]
 - Add `Serial` `rx`/`tx` constructors [#509]
+- Add enable/disable EOC interrupt functions for ADCs [#526]
 
 [#416]: https://github.com/stm32-rs/stm32f1xx-hal/pull/416
 [#453]: https://github.com/stm32-rs/stm32f1xx-hal/pull/453
@@ -69,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#514]: https://github.com/stm32-rs/stm32f1xx-hal/pull/514
 [#516]: https://github.com/stm32-rs/stm32f1xx-hal/pull/516
 [#520]: https://github.com/stm32-rs/stm32f1xx-hal/pull/520
+[#526]: https://github.com/stm32-rs/stm32f1xx-hal/pull/526
 
 ## [v0.10.0] - 2022-12-12
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -420,23 +420,23 @@ macro_rules! adc_hal {
                 }
 
                 /// Enable interrupt for EOC (end of convert)
-                pub fn enable_eoc_interrupt() {
-                    self.rb.cr1()..write(|w| w.eocie().set_bit());
+                pub fn enable_eoc_interrupt(&mut self) {
+                    self.rb.cr1().write(|w| w.eocie().set_bit());
                 }
 
                 /// Disable interrupt for EOC (end of convert)
-                pub fn disable_eoc_interrupt() {
-                    self.rb.cr1()..write(|w| w.eocie().clear_bit());
+                pub fn disable_eoc_interrupt(&mut self) {
+                    self.rb.cr1().write(|w| w.eocie().clear_bit());
                 }
 
                 /// Enable interrupt for JEOC (EOC for injected channels)
-                pub fn enable_jeoc_interrupt() {
-                    self.rb.cr1()..write(|w| w.jeocie().set_bit());
+                pub fn enable_jeoc_interrupt(&mut self) {
+                    self.rb.cr1().write(|w| w.jeocie().set_bit());
                 }
 
                 /// Disable interrupt for JEOC (EOC for injected channels)
-                pub fn disable_jeoc_interrupt() {
-                    self.rb.cr1()..write(|w| w.jeocie().clear_bit());
+                pub fn disable_jeoc_interrupt(&mut self) {
+                    self.rb.cr1().write(|w| w.jeocie().clear_bit());
                 }
             }
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -418,6 +418,26 @@ macro_rules! adc_hal {
                     self.disable_clock();
                     self.rb
                 }
+
+                /// Enable interrupt for EOC (end of convert)
+                pub fn enable_eoc_interrupt() {
+                    self.rb.cr1()..write(|w| w.eocie().set_bit());
+                }
+
+                /// Disable interrupt for EOC (end of convert)
+                pub fn disable_eoc_interrupt() {
+                    self.rb.cr1()..write(|w| w.eocie().clear_bit());
+                }
+
+                /// Enable interrupt for JEOC (EOC for injected channels)
+                pub fn enable_jeoc_interrupt() {
+                    self.rb.cr1()..write(|w| w.jeocie().set_bit());
+                }
+
+                /// Disable interrupt for JEOC (EOC for injected channels)
+                pub fn disable_jeoc_interrupt() {
+                    self.rb.cr1()..write(|w| w.jeocie().clear_bit());
+                }
             }
 
             impl ChannelTimeSequence for Adc<$ADC> {


### PR DESCRIPTION
This patch allow user enable End of Convert interrupt for ADCs by calling `adc1.enable_eoc_interrupt()`.

Tested on STM32F103CBT6, after enabling the `eocie` register. The interrupt `ADC1_2` is triggered every time ADC convert is finished. This allows more efficient waiting for ADC result.
