### PR TITLE
Update RCC freeze method usage in documents

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //!
 //! // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
 //! // `clocks`
-//! let clocks = rcc.cfgr.freeze(&mut flash.acr);
+//! let clocks = rcc.freeze(rcc::Config::default(), &mut flash.acr);
 //!
 //! // Prepare the alternate function I/O registers
 //! let mut afio = dp.AFIO.constrain(&mut rcc);

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -204,7 +204,7 @@ impl Rcc {
     /// let dp = pac::Peripherals::take().unwrap();
     /// let mut flash = dp.FLASH.constrain();
     /// let mut rcc = dp.RCC.constrain();
-    /// let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    /// let clocks = rcc.freeze(rcc::Config::default(), &mut flash.acr);
     /// ```
     #[inline(always)]
     pub fn freeze(self, cfg: impl Into<RawConfig>, acr: &mut ACR) -> Self {
@@ -343,7 +343,7 @@ impl BkpExt for BKP {
 /// let mut rcc = dp.RCC.constrain();
 /// let mut flash = dp.FLASH.constrain();
 ///
-/// let clocks = rcc.cfgr.freeze(&mut flash.acr);
+/// let clocks = rcc.freeze(rcc::Config::default(), &mut flash.acr);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Clocks {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -54,7 +54,7 @@
 //! let dp = stm32f1xx_hal::Peripherals::take().unwrap();
 //! let mut flash = dp.FLASH.constrain();
 //! let mut rcc = dp.RCC.constrain();
-//! let clocks = rcc.cfgr.freeze(&mut flash.acr);
+//! let clocks = rcc.freeze(rcc::Config::default(), &mut flash.acr);
 //! let mut afio = dp.AFIO.constrain(&mut rcc);
 //! let mut gpioa = dp.GPIOA.split(&mut rcc);
 //!


### PR DESCRIPTION
The interface of the RCC `freeze` method has been updated.
This commit update the documents to reflect the new API.

Old interface:
  - rcc.cfgr.freeze(ACR)

New interface:
  - rcc.freeze(Config, ACR)
