### PR TITLE
Support Latest Embedded-io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `rtic2` feature, renamed `rtic` to `rtic1`
 - move pin connecting to timer channels after `Pwm` initialization [#517]
 - `timer.rs` refactoring
+- bumped `embedded-io` dependency to v0.7.0 [#565]
 
 ### Changed
 
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#553]: https://github.com/stm32-rs/stm32f1xx-hal/pull/553
 [#554]: https://github.com/stm32-rs/stm32f1xx-hal/pull/554
 [#557]: https://github.com/stm32-rs/stm32f1xx-hal/pull/557
+[#565]: https://github.com/stm32-rs/stm32f1xx-hal/pull/565
 
 ## [v0.11.0] - 2025-09-09
 
@@ -117,6 +119,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#528]: https://github.com/stm32-rs/stm32f1xx-hal/pull/528
 [#534]: https://github.com/stm32-rs/stm32f1xx-hal/pull/534
 [#536]: https://github.com/stm32-rs/stm32f1xx-hal/pull/536
+
 - Move from bors/manual merge to GH merge queue
 - Add tools/check.py python script for local check
 - Add changelog check on PRs
@@ -312,7 +315,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix SPI2 and 3 using the wrong frequency
 - Fix some problems with I2C reads anad writes
 
-
 ## [v0.5.0] - 2019-12-03
 
 ### Added
@@ -401,7 +403,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - *Breaking change* Add additional configuration options to USART.
-    - Baud rate now has to be set using configuration struct
+  - Baud rate now has to be set using configuration struct
 - Now requires stm32f1 v0.7 (breaking change)
 - enable PWM on stm32f100
 - Fix gpio misconfiguration when using a timer in pwm input mode. Now the gpio has to be configured in floating input mode.
@@ -421,9 +423,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Use correct clock for serial baudrate computation
-
-
-
 
 ## [v0.2.0] - 2019-02-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ version = "1.0"
 version = "1.0"
 
 [dependencies.embedded-io]
-version = "0.6.1"
+version = "0.7"
 
 [dependencies.stm32-usbd]
 version = "0.8.0"

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -227,6 +227,22 @@ pub enum Error {
     Other,
 }
 
+impl core::fmt::Display for Error {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let message = match self {
+            Error::Overrun => "serial receive buffer overrun",
+            Error::FrameFormat => "serial frame format error",
+            Error::Parity => "serial parity error",
+            Error::Noise => "serial noise error",
+            Error::Other => "serial error",
+        };
+
+        formatter.write_str(message)
+    }
+}
+
+impl core::error::Error for Error {}
+
 pub enum WordLength {
     /// When parity is enabled, a word has 7 data bits + 1 parity bit,
     /// otherwise 8 data bits.


### PR DESCRIPTION
Thanks for making this cool HAL, I would like to contribute this small PR to bump the embedded-io dependency so that we can link it with the latest drivers using that trait. For example im building this [Power Monitor driver](https://github.com/ScottGibb/JSY-MK-194-rs) at the moment and would like to test it on an STM32 Blue Pill 