### PR TITLE
Fix missing RCC argument in GPIO split docs example

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -4,9 +4,10 @@
 //! `gpioa`, `gpiob`... modules. To get access to the pins, you first need to convert them into a
 //! HAL designed struct from the `pac` struct using the [split](trait.GpioExt.html#tymethod.split) function.
 //! ```rust
-//! // Acquire the GPIOC peripheral
+//! // Acquire the GPIOA peripheral
 //! // NOTE: `dp` is the device peripherals from the `PAC` crate
-//! let mut gpioa = dp.GPIOA.split();
+//! let mut rcc = dp.RCC.constrain();
+//! let mut gpioa = dp.GPIOA.split(&mut rcc);
 //! ```
 //!
 //! This gives you a struct containing two control registers `crl` and `crh`, and all the pins


### PR DESCRIPTION
Fixes #566.
This updates the GPIO example to pass the RCC argument to `split()`, matching the current API.
It also changes the comment from GPIOC to GPIOA, since the example uses `dp.GPIOA`.